### PR TITLE
ChromeOS: Ensure applet spacing is sensible in a vertical panel

### DIFF
--- a/ChromeOS/files/Chrome OS/cinnamon/cinnamon.css
+++ b/ChromeOS/files/Chrome OS/cinnamon/cinnamon.css
@@ -1503,6 +1503,12 @@ StScrollBar StButton#hhandle {
     color: white;
     transition-duration: 50;
 }
+.applet-box.vertical {
+    padding-left: 0px;
+    padding-right: 0px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
 .applet-box:hover {
     border-image: url('hover-box.png') 4 4 4 4;
 }


### PR DESCRIPTION
More work is needed to make this look right in a vertical panel, and popup menus are coming up transparent as well, regardless of panel orientation.  There are some design choices that may need to be made to look right in a vertical panel, so corrections beyond this modest one here should be referred back to the original author, if contactable, IMO