### PR TITLE
Windows-10: Add vertical styling for applet-box

### DIFF
--- a/Windows-10/files/Windows 10/cinnamon/cinnamon.css
+++ b/Windows-10/files/Windows 10/cinnamon/cinnamon.css
@@ -285,6 +285,8 @@ spacing: 1em;
 }
 .popup-separator-menu-item {
     background-color: rgba(50,50,50,1);
+    -gradient-start: rgba(50,50,50,1);
+    -gradient-end: rgba(50,50,50,1);
     box-shadow: 0px 1px 1px 0px rgba(220,220,220,0.06);
     border-radius: 5px; 
     -margin-horizontal: 14px;
@@ -1906,6 +1908,13 @@ background: #111;
     color: #fff;
     padding-left: 6px;
     padding-right: 6px;
+}
+
+.applet-box.vertical {
+    padding-left: 0px;
+    padding-right: 0px;
+    padding-top: 3px;
+    padding-bottom: 3px;
 }
 
 .applet-box:hover,


### PR DESCRIPTION
Ensures sensible spacing and central alignment in a vertical panel

Windows-10: suppress warning messages from popup-separator-menu-item