### PR TITLE
Jet-Gray: Correct menu theming in 3.2

### DIFF
--- a/Jet-Gray/files/Jet-Gray/cinnamon/cinnamon.css
+++ b/Jet-Gray/files/Jet-Gray/cinnamon/cinnamon.css
@@ -183,6 +183,25 @@ StScrollBar StButton#vhandle:hover {
         border-right: 2px;
 	border-bottom: 2px;
 }
+.menu {
+    color: #fff;
+    font-size: 9.5pt;
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    min-width: 100px;
+    min-height: 80px;
+    border:rgba(10,10,10,0.9);
+    border-radius: 0px 0px 0px 0px;
+    box-shadow: none;
+    background-color: rgba(10,10,10,0.9);
+    border-top: 2px;
+    border-left: 2px;
+    border-right: 2px;
+    border-bottom: 2px;
+    border-image: url("images/panel-bg.png") 6 6 6 6 stretch
+}
 
 .popup-submenu-menu-item:open {
     background-color: rgba(0, 0, 0, 0.0);
@@ -283,6 +302,8 @@ StScrollBar StButton#vhandle:hover {
 
 .popup-separator-menu-item {
     background-color: rgba(0, 0, 0, 0.4);
+    -gradient-start: rgba(0, 0, 0, 0.4);
+    -gradient-end: rgba(0, 0, 0, 0.4);
     border: 1px solid rgba(120, 120, 120, 0.3);
     border-top: 0px;
     height: 0.1em;
@@ -360,13 +381,19 @@ StScrollBar StButton#vhandle:hover {
 #panelRight:dnd {
     background-color: rgba(0, 0, 255, 0.1);
 }
-
+#panelLeft.vertical {
+    padding: 0px;
+    spacing: 0px;
+}
 #panelLeft:ltr {
     padding-right: 4px;
 }
-
 #panelLeft:rtl {
     padding-left: 4px;
+}
+#panelRight.vertical {
+    padding: 0px;
+    spacing: 0px;
 }
 
 #panelRight:ltr {
@@ -2116,6 +2143,12 @@ StScrollBar StButton#vhandle:hover {
     padding-top: 1px;
     font-weight: bold;
 }
+.applet-box.vertical {
+    padding-left: 0px;
+    padding-right: 0px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
 
 .applet-box:hover {
     border-image: url("images/applet-hover.png") 6 6 6 6 stretch;
@@ -2881,4 +2914,34 @@ StScrollBar StButton#vhandle:hover {
     padding: 8px 8px 8px 8px;
     color: #EEEEEE;
     text-align: center;
+}
+/* Media keys OSD popup */
+.osd-window {
+    background: rgba(51,51,51,0.8);
+    border: 1px rgba(179, 0,0, 0.8);
+    padding: 20px;
+    color: white;
+    spacing: 1em;
+    border-image: url("images/panel-bg.png") 6 6 6 6 stretch
+}
+
+.osd-window .level {
+    height: 0.7em;
+    border-radius: 0.3em;
+    background-color: rgba(190,190,190,0.2);
+}
+.info-osd {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(27,27,27,.98);
+    background-gradient-end: rgba(51,51,51,.95);
+    border-width: 1px;
+    box-shadow: 2px 2px 2px 2px rgba(0,0,0,0.45);
+    color: #ffffff;
+    font-size: 14pt;
+    padding-right: 10px;
+    padding-left: 10px;
+    padding-bottom: 10px;
+    padding-top: 10px;
+    text-align: center;
+    border-image: url("images/panel-bg.png") 6 6 6 6 stretch
 }


### PR DESCRIPTION
Add suitable vertical alignment/spacing in a vertical panel
Suppress warning messages from popup-separator-menu-item
Add additional themed OSD