### PR TITLE
ChromeOS:  Ensure context menu shows with a background

### DIFF
--- a/ChromeOS/files/Chrome OS/cinnamon/cinnamon.css
+++ b/ChromeOS/files/Chrome OS/cinnamon/cinnamon.css
@@ -28,6 +28,7 @@
 }
 
 .popup-menu,
+.menu,
 .window-caption, /* Open windows aka "exposé" */
 .window-caption#selected,
 .desklet-with-borders,
@@ -1534,6 +1535,7 @@ StScrollBar StButton#hhandle {
     color: black;
     font-weight: normal;
     font-size: 26pt;
+    box-shadow: 0 0 12px 1px rgba(0,0,0,0.6);
 }
 .expo-workspaces-name-entry {
     padding: 6px;
@@ -1671,11 +1673,13 @@ StScrollBar StButton#hhandle {
     padding-bottom: 20px;
     padding-top: 20px;
     text-align: center;
+    box-shadow: 0 0 12px 1px rgba(0,0,0,0.6);
 }
 .osd-window { /* Media key */
     color: black;
     padding: 20px;
     spacing: 5px;
+    box-shadow: 0 0 12px 1px rgba(0,0,0,0.6);
 }
 .osd-window .level {
     height: 0.7em;


### PR DESCRIPTION
Put some shadow on (white) OSD popups so they look sensible against a white background