### PR TITLE
Numix-Cinnamon-Transparent: Add panel highlight

### DIFF
--- a/Numix-Cinnamon-Transparent/files/Numix-Cinnamon-Transparent/cinnamon/cinnamon.css
+++ b/Numix-Cinnamon-Transparent/files/Numix-Cinnamon-Transparent/cinnamon/cinnamon.css
@@ -3153,3 +3153,7 @@ StBoxLayout.applet-box.desktop-capture StBin {
   width: 24px;
   height: 24px;
 }
+
+#panel:highlight {
+background-color: #aa5555;
+}


### PR DESCRIPTION
This permits the panel settings to highlight the panel the user is on successfully.
@edoz90 I made the change direct to the .css as I could not work out your build mechanism.  You might
like to add some build instructions to your github site.  If you are happy with this as it is I will merge, and assume you will adjust your own source code to avoid it getting over-written with your next change.