### PR TITLE
Mint-XP: add panel highlight

### DIFF
--- a/Mint-XP/files/Mint-XP/cinnamon/cinnamon.css
+++ b/Mint-XP/files/Mint-XP/cinnamon/cinnamon.css
@@ -340,7 +340,10 @@ StScrollBar StButton#vhandle:hover
 	background-gradient-end: #4993e6;
 	background-gradient-direction: horizontal;
 }
-
+#panel:highlight {
+background-color: #aa5555;
+border-image: none;
+}
 #panelLeft, #panelCenter {
     spacing: 1px;
 }


### PR DESCRIPTION
Permits the panel to be highlighted correctly in the panel settings
@fmcgorenc - trust OK as per our earlier communications.  I'll be suggesting the same change to your other themes too