### PR TITLE
Photocopy: fix doubled up menu text bug

### DIFF
--- a/Photocopy/files/Photocopy/cinnamon/cinnamon.css
+++ b/Photocopy/files/Photocopy/cinnamon/cinnamon.css
@@ -133,7 +133,7 @@ StScrollBar StButton#vhandle:hover {
 /*    border-image: url("checkbox-off-focus.svg") 3; */
     color: #ffffff;
     font-size: 10.5pt;
-    text-shadow: 1px 1px 1px #000000;
+/*    text-shadow: 1px 1px 1px #000000; do not use, creates weird doubled up category effect */
     min-width: 100px;
     background-image: url('pcopymenu.jpg');
     background-size: cover;
@@ -344,13 +344,13 @@ text-shadow: 1px 1px 1px #000000;
     border-image: url('pcopyvert.jpg');
 }
 .panel-status-button {
+    border: 0px solid #8b8b8b;
     -natural-hpadding: 0px;
     -minimum-hpadding: 0px;
     font-weight: bold;
     color: white;
-    height: 29px;
+    height: 27px;
     icon-size: 1em;
-    border: 0px solid #8b8b8b;
 }
 .panel-status-button:hover {
     border-image: url("window-active1.svg") 2 2 0 0;
@@ -1207,7 +1207,7 @@ border-image: url("button-focus.svg") 3;
     box-shadow: inset 0px 0px 1px 1px rgba(255,255,255,0.06);
     border-radius: 4px;
     border-image: url("checkbox-off-focus.svg") 3;
-    text-shadow: 0px 1px 1px #000000;
+/*    text-shadow: 0px 1px 1px #000000;  do not use it, it causes weird overlapping of different category applications */
 }
 .menu-category-button-label:ltr {
     padding-left: 5px;


### PR DESCRIPTION
using text shadow in either of two places seems to use the previous category text as well