### PR TITLE
Remove separate panel shadow for top/bottom side

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -459,7 +459,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel {
     background: rgb(38, 50, 56);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+    box-shadow: 0 6px 6px rgba(0, 0, 0, 0.23);
 
     font-weight: bold;
     /* sets the height of horizontal panels */


### PR DESCRIPTION
Remove separate panel shadow for top/bottom side to fix  linuxmint/cinnamon-spices-themes#189.
.