### PR TITLE
Fix spacing for applet-box (top/bottom panel)

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1860,10 +1860,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
     color: rgb(207, 216, 220);
     text-shadow: none;
     transition-duration: 100ms;
-}
-
-.panel-top .applet-box,
-.panel-bottom .applet-box {
     spacing: 3px;
 }
 

--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1862,6 +1862,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
     transition-duration: 100ms;
 }
 
+.panel-top .applet-box,
+.panel-bottom .applet-box {
+    spacing: 3px;
+}
+
 .applet-box StLabel {
     padding-top: 2px;
 }


### PR DESCRIPTION
Fix for linuxmint/cinnamon-spices-themes#192: spacing for applet-box of top/bottom panel.
See also: ac43b6fbed41dd0df427d0a4a48a49627334bfc0