### PR TITLE
Eleganse-dark: Border for switcher selected item

### DIFF
--- a/Eleganse-dark/files/Eleganse-dark/cinnamon/cinnamon.css
+++ b/Eleganse-dark/files/Eleganse-dark/cinnamon/cinnamon.css
@@ -1031,7 +1031,7 @@ StScrollBar StButton#vhandle:hover {
     color: #fff;
     background: rgba(0,0,0,0.72);
     border: 1px solid rgba(0,0,0,0.21);
-    border-radius: 3px;
+    border-radius: 2px;
     padding: 20px;
     font-size: 9pt;
 }
@@ -1062,7 +1062,7 @@ StScrollBar StButton#vhandle:hover {
 
 .switcher-list .item-box {
     padding: 8px;
-    border-radius: 8px;
+    border-radius: 2px;
 }
 
 .switcher-list .item-box:outlined {
@@ -1072,6 +1072,7 @@ StScrollBar StButton#vhandle:hover {
 
 .switcher-list .item-box:selected {
     background-color: rgba(0,0,0,0.72);
+    border: 1px solid rgba(255,255,255,0.50);
 }
 
 .switcher-list .thumbnail-box {


### PR DESCRIPTION
According to theme comments, switcher has visibility issues on dark backgrounds. Adding light border for selected switcher item box for better visibility.