### PR TITLE
Discreet-Flat: added empty description

### DIFF
--- a/Discreet-Flat/info.json
+++ b/Discreet-Flat/info.json
@@ -1,4 +1,5 @@
 {
-	"author": "getkey",
-	"name": "Discreet Flat"
+    "author": "getkey",
+    "name": "Discreet Flat",
+    "description": ""
 }


### PR DESCRIPTION
@getkey

The non existent description is forcing the website to say "Invalid Description".
This just adds a blank key to prevent that.