### PR TITLE
Carta: Center clock in side panels

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1878,7 +1878,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .applet-box.vertical StLabel {
     padding-top: 0;
-    width: 34px;
+    min-width: 0px;
+    max-width: 34px;
 }
 
 .applet-box:hover, .applet-box:checked {


### PR DESCRIPTION
Bug:
- The default clock is not centered horizontally when the panel is vertical (i.e. when the panel is docked to the left or right sides of the screen).

Changes:
- Removed applet label's fixed width (originally fixed to be as wide as the panel itself) so that the clock text can be centered.
- Added min and max widths so that the clock text will not expand beyond the panel width.
