### PR TITLE
thunderbolt - .popup-menu-item:active glitch

### DIFF
--- a/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
+++ b/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
@@ -352,8 +352,8 @@ StScrollBar StButton#vhandle:hover
     border-radius: 3px;
     box-shadow: inset  0px 1px 1px rgba(255,255,255,0.1);
     color: #fff;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     padding-left: 22px;
     padding-right: 22px;
 }


### PR DESCRIPTION
Theme: Thunderbolt
An active (hovered) item in the popmenu cause a slight resizing of the menu. 

![thunderbolt_flip01](https://user-images.githubusercontent.com/3920264/35296883-b535504e-007d-11e8-8245-b7fd53beecf0.png)
![thunderbolt_flip02](https://user-images.githubusercontent.com/3920264/35296884-b5558cc4-007d-11e8-9461-34efc2816b25.png)