### PR TITLE
popmenu cause a slight resizing if an active item is selected

### DIFF
--- a/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
+++ b/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
@@ -352,8 +352,8 @@ StScrollBar StButton#vhandle:hover
     border-radius: 3px;
     box-shadow: inset  0px 1px 1px rgba(255,255,255,0.1);
     color: #fff;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     padding-left: 22px;
     padding-right: 22px;
 }

--- a/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
+++ b/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
@@ -352,8 +352,8 @@ StScrollBar StButton#vhandle:hover
     border-radius: 3px;
     box-shadow: inset  0px 1px 1px rgba(255,255,255,0.1);
     color: #fff;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: 6px;
+    padding-bottom: 6px;
     padding-left: 22px;
     padding-right: 22px;
 }


### PR DESCRIPTION
Theme: Thunderbolt
An active (hovered) item in the popmenu cause a slight resizing of the menu.

![thunderbolt_flip01](https://user-images.githubusercontent.com/3920264/35297449-3d8678dc-007f-11e8-9c29-b7e02f49dfd7.png)
![thunderbolt_flip02](https://user-images.githubusercontent.com/3920264/35297450-3da33742-007f-11e8-9c47-42ad10cde0d2.png)
