### PR TITLE
Cinnamox themes - 20180304 update

### DIFF
--- a/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Aubergine
 
-Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Aubergine
 
-Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Aubergine */
 /* Transparency: None */
-/* Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #f2d9f0;
+    color: #e92041;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #e9dd00;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #e92041;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Aubergine. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Aubergine
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/gtkrc
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#5E2750\nbg_color:#77216F\ntooltip_bg_color:#77216F\nselected_bg_color:#E95420\ntext_color:#f2d9f0\nfg_color:#f2d9f0\ntooltip_fg_color:#f2d9f0\nselected_fg_color:#000000\nmenubar_bg_color:#2C001E\nmenubar_fg_color:#f2d9f0\ntoolbar_bg_color:#77216F\ntoolbar_fg_color:#f2d9f0\nmenu_bg_color:#2C001E\nmenu_fg_color:#f2d9f0\npanel_bg_color:#77216F\npanel_fg_color:#f2d9f0\nlink_color:#E95420\nbtn_bg_color:#5E2750\nbtn_fg_color:#f2d9f0\ntitlebar_bg_color:#2C001E\ntitlebar_fg_color:#f2d9f0\nprimary_caret_color:#f2d9f0\nsecondary_caret_color:#f2d9f0\n"
+"base_color:#5E2750\nbg_color:#77216F\ntooltip_bg_color:#77216F\nselected_bg_color:#E95420\ntext_color:#f2d9f0\nfg_color:#f2d9f0\ntooltip_fg_color:#f2d9f0\nselected_fg_color:#000000\nmenubar_bg_color:#2C001E\nmenubar_fg_color:#f2d9f0\ntoolbar_bg_color:#77216F\ntoolbar_fg_color:#f2d9f0\nmenu_bg_color:#2C001E\nmenu_fg_color:#f2d9f0\npanel_bg_color:#77216F\npanel_fg_color:#f2d9f0\nlink_color:#f2a9ec\nbtn_bg_color:#5E2750\nbtn_fg_color:#f2d9f0\ntitlebar_bg_color:#2C001E\ntitlebar_fg_color:#f2d9f0\nprimary_caret_color:#f2d9f0\nsecondary_caret_color:#f2d9f0\naccent_bg_color:#E95420\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#5E2750\nbg_color:#77216F\ntooltip_bg_color:#77216F\nselected_bg_color:#E95420\ntext_color:#f2d9f0\nfg_color:#f2d9f0\ntooltip_fg_color:#f2d9f0\nselected_fg_color:#000000\nmenubar_bg_color:#2C001E\nmenubar_fg_color:#f2d9f0\ntoolbar_bg_color:#77216F\ntoolbar_fg_color:#f2d9f0\nmenu_bg_color:#2C001E\nmenu_fg_color:#f2d9f0\npanel_bg_color:#77216F\npanel_fg_color:#f2d9f0\nlink_color:#E95420\nbtn_bg_color:#5E2750\nbtn_fg_color:#f2d9f0\ntitlebar_bg_color:#2C001E\ntitlebar_fg_color:#f2d9f0\n"
+"base_color:#5E2750\nbg_color:#77216F\ntooltip_bg_color:#77216F\nselected_bg_color:#E95420\ntext_color:#f2d9f0\nfg_color:#f2d9f0\ntooltip_fg_color:#f2d9f0\nselected_fg_color:#000000\nmenubar_bg_color:#2C001E\nmenubar_fg_color:#f2d9f0\ntoolbar_bg_color:#77216F\ntoolbar_fg_color:#f2d9f0\nmenu_bg_color:#2C001E\nmenu_fg_color:#f2d9f0\npanel_bg_color:#77216F\npanel_fg_color:#f2d9f0\nlink_color:#f2a9ec\nbtn_bg_color:#5E2750\nbtn_fg_color:#f2d9f0\ntitlebar_bg_color:#2C001E\ntitlebar_fg_color:#f2d9f0\nprimary_caret_color:#f2d9f0\nsecondary_caret_color:#f2d9f0\naccent_bg_color:#E95420\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.0/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #441741;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #E95420;
+@define-color info_bg_color #54548b;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #e9dd00;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #E95420;
+@define-color question_bg_color #54548b;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#E95420,#f2d9f0,0.6);
-@define-color success_color #E95420;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #e92041;
+@define-color link_color #f2a9ec;
+@define-color success_color #abd200;
+@define-color warning_color #e9dd00;
+@define-color error_color #e92041;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#E95420,#f2d9f0,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#E95420,#f2d9f0,0.6);
-  -GtkWidget-link-color: mix(#E95420,#f2d9f0,0.6);
-  -GtkWidget-visited-link-color: mix(#E95420,#f2d9f0,0.6); }
+  -GtkHTML-link-color: #f2a9ec;
+  -GtkIMHtml-hyperlink-color: #f2a9ec;
+  -GtkWidget-link-color: #f2a9ec;
+  -GtkWidget-visited-link-color: #f2a9ec; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#E95420,#f2d9f0,0.6); }
+    color: #f2a9ec; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#E95420,#f2d9f0,0.6); }
+    color: #f2a9ec; }
 
 .background {
   background-color: #77216F;
@@ -898,45 +898,45 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #E95420;
-  background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-  border-color: rgba(0, 0, 0, 0.12);
+  background-color: #abd200;
+  background-image: linear-gradient(to bottom, #d1ff08, #809e00);
+  border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover {
-    border-color: rgba(0, 0, 0, 0.12); }
+    border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:active:hover, .suggested-action.button:active:focus, .suggested-action.button:active:hover:focus, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button:checked:hover, .suggested-action.button:checked:focus, .suggested-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.12); }
+    border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button:insensitive, .selection-mode.header-bar .button.suggested-action:insensitive, .selection-mode.toolbar .button.suggested-action:insensitive {
-    border-color: rgba(0, 0, 0, 0.12); }
+    border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.12); }
+    border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
-    border-color: rgba(0, 0, 0, 0.1);
-    background-color: rgba(233, 84, 32, 0);
+    border-color: rgba(0, 0, 0, 0.2);
+    background-color: rgba(171, 210, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.1); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button.flat:active, .suggested-action.button.flat:active:hover, .suggested-action.button.flat:active:focus, .suggested-action.button.flat:active:hover:focus, .suggested-action.button.flat:checked, .suggested-action.button.flat:checked:hover, .suggested-action.button.flat:checked:focus, .suggested-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.1); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.1); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.1); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #ee7950;
-    background-image: linear-gradient(to bottom, #f5b099, #d94815);
-    border-color: rgba(0, 0, 0, 0.2);
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+    background-color: #cdfc00;
+    background-image: linear-gradient(to bottom, #dbff3c, #9abd00);
+    border-color: rgba(0, 0, 0, 0.3);
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.3); }
     .suggested-action.button:focus:active, .suggested-action.button:focus:active:hover, .suggested-action.button:focus:active:focus, .suggested-action.button:focus:active:hover:focus, .suggested-action.button:focus:checked, .suggested-action.button:focus:checked:hover, .suggested-action.button:focus:checked:focus, .suggested-action.button:focus:checked:hover:focus, .suggested-action.button:hover:active, .suggested-action.button:hover:active:hover, .suggested-action.button:hover:active:focus, .suggested-action.button:hover:active:hover:focus, .suggested-action.button:hover:checked, .suggested-action.button:hover:checked:hover, .suggested-action.button:hover:checked:focus, .suggested-action.button:hover:checked:hover:focus, .suggested-action.button.flat:focus:active, .suggested-action.button.flat:focus:active:hover, .suggested-action.button.flat:focus:active:focus, .suggested-action.button.flat:focus:active:hover:focus, .suggested-action.button.flat:focus:checked, .suggested-action.button.flat:focus:checked:hover, .suggested-action.button.flat:focus:checked:focus, .suggested-action.button.flat:focus:checked:hover:focus, .suggested-action.button.flat:hover:active, .suggested-action.button.flat:hover:active:hover, .suggested-action.button.flat:hover:active:focus, .suggested-action.button.flat:hover:active:hover:focus, .suggested-action.button.flat:hover:checked, .suggested-action.button.flat:hover:checked:hover, .suggested-action.button.flat:hover:checked:focus, .suggested-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.3); }
     .suggested-action.button:focus:insensitive, .suggested-action.button:hover:insensitive, .suggested-action.button.flat:focus:insensitive, .suggested-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.3); }
     .suggested-action.button:focus:active:insensitive, .suggested-action.button:focus:checked:insensitive, .suggested-action.button:hover:active:insensitive, .suggested-action.button:hover:checked:insensitive, .suggested-action.button.flat:focus:active:insensitive, .suggested-action.button.flat:focus:checked:insensitive, .suggested-action.button.flat:hover:active:insensitive, .suggested-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.3); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button.flat:active, .suggested-action.button.flat:checked {
     background-color: #d94815;
     background-image: linear-gradient(to top, #ec6b3e, #a33610);
@@ -949,69 +949,69 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #000000; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #d94815;
-    background-image: linear-gradient(to bottom, #ec6b3e, #a33610);
+    background-color: #9abd00;
+    background-image: linear-gradient(to bottom, #c0ec00, #738e00);
     color: #000000;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: #e54c17;
-    background-image: linear-gradient(to bottom, #ed774d, #ac3911);
-    color: mix(#E95420,#000000,0.5);
+    background-color: rgba(171, 210, 0, 0.3);
+    background-image: linear-gradient(to bottom, rgba(209, 255, 8, 0.3), rgba(128, 158, 0, 0.3));
+    color: mix(#abd200,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #000000; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#E95420,#000000,0.5);
+    color: mix(#abd200,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #d94815; }
+    color: #9abd00; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #cd4414; }
+      color: #91b300; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #e92041;
+  background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
   .destructive-action.button:focus, .destructive-action.button:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active, .destructive-action.button:active:hover, .destructive-action.button:active:focus, .destructive-action.button:active:hover:focus, .destructive-action.button:checked, .destructive-action.button:checked:hover, .destructive-action.button:checked:focus, .destructive-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button.flat {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(233, 32, 65, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active, .destructive-action.button.flat:active:hover, .destructive-action.button.flat:active:focus, .destructive-action.button.flat:active:hover:focus, .destructive-action.button.flat:checked, .destructive-action.button.flat:checked:hover, .destructive-action.button.flat:checked:focus, .destructive-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
+    background-color: #ee506a;
+    background-image: linear-gradient(to bottom, #f599a8, #d91536);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active, .destructive-action.button:focus:active:hover, .destructive-action.button:focus:active:focus, .destructive-action.button:focus:active:hover:focus, .destructive-action.button:focus:checked, .destructive-action.button:focus:checked:hover, .destructive-action.button:focus:checked:focus, .destructive-action.button:focus:checked:hover:focus, .destructive-action.button:hover:active, .destructive-action.button:hover:active:hover, .destructive-action.button:hover:active:focus, .destructive-action.button:hover:active:hover:focus, .destructive-action.button:hover:checked, .destructive-action.button:hover:checked:hover, .destructive-action.button:hover:checked:focus, .destructive-action.button:hover:checked:hover:focus, .destructive-action.button.flat:focus:active, .destructive-action.button.flat:focus:active:hover, .destructive-action.button.flat:focus:active:focus, .destructive-action.button.flat:focus:active:hover:focus, .destructive-action.button.flat:focus:checked, .destructive-action.button.flat:focus:checked:hover, .destructive-action.button.flat:focus:checked:focus, .destructive-action.button.flat:focus:checked:hover:focus, .destructive-action.button.flat:hover:active, .destructive-action.button.flat:hover:active:hover, .destructive-action.button.flat:hover:active:focus, .destructive-action.button.flat:hover:active:hover:focus, .destructive-action.button.flat:hover:checked, .destructive-action.button.flat:hover:checked:hover, .destructive-action.button.flat:hover:checked:focus, .destructive-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:insensitive, .destructive-action.button:hover:insensitive, .destructive-action.button.flat:focus:insensitive, .destructive-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active:insensitive, .destructive-action.button:focus:checked:insensitive, .destructive-action.button:hover:active:insensitive, .destructive-action.button:hover:checked:insensitive, .destructive-action.button.flat:focus:active:insensitive, .destructive-action.button.flat:focus:checked:insensitive, .destructive-action.button.flat:hover:active:insensitive, .destructive-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:active, .destructive-action.button:checked, .destructive-action.button.flat:active, .destructive-action.button.flat:checked {
     background-color: #d94815;
     background-image: linear-gradient(to top, #ec6b3e, #a33610);
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #d91536;
+    background-image: linear-gradient(to bottom, #ec3e5b, #a31028);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#000000,0.5);
+    background-color: #e51739;
+    background-image: linear-gradient(to bottom, #ed4d68, #ac112a);
+    color: mix(#e92041,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#000000,0.5);
+    color: mix(#e92041,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #d91536; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #cd1433; }
 
 /******************
 * selection mode *
@@ -1424,51 +1424,51 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #E95420;
-  background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-  border: 1px solid #c14013;
+  background-color: #54548b;
+  background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+  border: 1px solid #43436f;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-    border-color: rgba(0, 0, 0, 0.12);
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+    border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .info .button:focus, .info .button:hover {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .info .button:active, .info .button:active:hover, .info .button:active:focus, .info .button:active:hover:focus, .info .button:checked, .info .button:checked:hover, .info .button:checked:focus, .info .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .info .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .info .button:active:insensitive, .info .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .info .button.flat {
-      border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(233, 84, 32, 0);
+      border-color: rgba(0, 0, 0, 0.2);
+      background-color: rgba(84, 84, 139, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button.flat:active, .info .button.flat:active:hover, .info .button.flat:active:focus, .info .button.flat:active:hover:focus, .info .button.flat:checked, .info .button.flat:checked:hover, .info .button.flat:checked:focus, .info .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #ee7950;
-      background-image: linear-gradient(to bottom, #f5b099, #d94815);
-      border-color: rgba(0, 0, 0, 0.2);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+      background-color: #6868a4;
+      background-image: linear-gradient(to bottom, #9292bd, #4c4c7d);
+      border-color: rgba(0, 0, 0, 0.3);
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .info .button:focus:active, .info .button:focus:active:hover, .info .button:focus:active:focus, .info .button:focus:active:hover:focus, .info .button:focus:checked, .info .button:focus:checked:hover, .info .button:focus:checked:focus, .info .button:focus:checked:hover:focus, .info .button:hover:active, .info .button:hover:active:hover, .info .button:hover:active:focus, .info .button:hover:active:hover:focus, .info .button:hover:checked, .info .button:hover:checked:hover, .info .button:hover:checked:focus, .info .button:hover:checked:hover:focus, .info .button.flat:focus:active, .info .button.flat:focus:active:hover, .info .button.flat:focus:active:focus, .info .button.flat:focus:active:hover:focus, .info .button.flat:focus:checked, .info .button.flat:focus:checked:hover, .info .button.flat:focus:checked:focus, .info .button.flat:focus:checked:hover:focus, .info .button.flat:hover:active, .info .button.flat:hover:active:hover, .info .button.flat:hover:active:focus, .info .button.flat:hover:active:hover:focus, .info .button.flat:hover:checked, .info .button.flat:hover:checked:hover, .info .button.flat:hover:checked:focus, .info .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .info .button:focus:insensitive, .info .button:hover:insensitive, .info .button.flat:focus:insensitive, .info .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .info .button:focus:active:insensitive, .info .button:focus:checked:insensitive, .info .button:hover:active:insensitive, .info .button:hover:checked:insensitive, .info .button.flat:focus:active:insensitive, .info .button.flat:focus:checked:insensitive, .info .button.flat:hover:active:insensitive, .info .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
     .info .button:active, .info .button:checked, .info .button.flat:active, .info .button.flat:checked {
       background-color: #d94815;
       background-image: linear-gradient(to top, #ec6b3e, #a33610);
@@ -1481,37 +1481,37 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #d94815;
-      background-image: linear-gradient(to bottom, #ec6b3e, #a33610);
+      background-color: #4c4c7d;
+      background-image: linear-gradient(to bottom, #5f5f9c, #39395e);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: #e54c17;
-      background-image: linear-gradient(to bottom, #ed774d, #ac3911);
-      color: mix(#E95420,#000000,0.5);
+      background-color: rgba(84, 84, 139, 0.3);
+      background-image: linear-gradient(to bottom, rgba(111, 111, 168, 0.3), rgba(63, 63, 104, 0.3));
+      color: mix(#54548b,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#E95420,#000000,0.5);
+      color: mix(#54548b,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #d94815; }
+      color: #4c4c7d; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #cd4414; }
+        color: #474776; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #e9dd00;
+  background-image: linear-gradient(to bottom, #fff424, #afa600);
+  border: 1px solid #bab100;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e9dd00;
+    background-image: linear-gradient(to bottom, #fff424, #afa600);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -1525,7 +1525,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .warning .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(233, 221, 0, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
@@ -1537,8 +1537,8 @@ GtkInfoBar {
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #fff319;
+      background-image: linear-gradient(to bottom, #fff75f, #d2c700);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
@@ -1561,74 +1561,74 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #d2c700;
+      background-image: linear-gradient(to bottom, #fff207, #9d9500);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(233, 221, 0, 0.3);
+      background-image: linear-gradient(to bottom, rgba(255, 244, 36, 0.3), rgba(175, 166, 0, 0.3));
+      color: mix(#e9dd00,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#e9dd00,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #d2c700; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #c6bc00; }
 
 .question {
-  background-color: #E95420;
-  background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-  border: 1px solid #c14013;
+  background-color: #54548b;
+  background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+  border: 1px solid #43436f;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-    border-color: rgba(0, 0, 0, 0.12);
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+    border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .question .button:focus, .question .button:hover {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .question .button:active, .question .button:active:hover, .question .button:active:focus, .question .button:active:hover:focus, .question .button:checked, .question .button:checked:hover, .question .button:checked:focus, .question .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .question .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .question .button:active:insensitive, .question .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.12); }
+      border-color: rgba(0, 0, 0, 0.22); }
     .question .button.flat {
-      border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(233, 84, 32, 0);
+      border-color: rgba(0, 0, 0, 0.2);
+      background-color: rgba(84, 84, 139, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button.flat:active, .question .button.flat:active:hover, .question .button.flat:active:focus, .question .button.flat:active:hover:focus, .question .button.flat:checked, .question .button.flat:checked:hover, .question .button.flat:checked:focus, .question .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.1); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #ee7950;
-      background-image: linear-gradient(to bottom, #f5b099, #d94815);
-      border-color: rgba(0, 0, 0, 0.2);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+      background-color: #6868a4;
+      background-image: linear-gradient(to bottom, #9292bd, #4c4c7d);
+      border-color: rgba(0, 0, 0, 0.3);
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .question .button:focus:active, .question .button:focus:active:hover, .question .button:focus:active:focus, .question .button:focus:active:hover:focus, .question .button:focus:checked, .question .button:focus:checked:hover, .question .button:focus:checked:focus, .question .button:focus:checked:hover:focus, .question .button:hover:active, .question .button:hover:active:hover, .question .button:hover:active:focus, .question .button:hover:active:hover:focus, .question .button:hover:checked, .question .button:hover:checked:hover, .question .button:hover:checked:focus, .question .button:hover:checked:hover:focus, .question .button.flat:focus:active, .question .button.flat:focus:active:hover, .question .button.flat:focus:active:focus, .question .button.flat:focus:active:hover:focus, .question .button.flat:focus:checked, .question .button.flat:focus:checked:hover, .question .button.flat:focus:checked:focus, .question .button.flat:focus:checked:hover:focus, .question .button.flat:hover:active, .question .button.flat:hover:active:hover, .question .button.flat:hover:active:focus, .question .button.flat:hover:active:hover:focus, .question .button.flat:hover:checked, .question .button.flat:hover:checked:hover, .question .button.flat:hover:checked:focus, .question .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .question .button:focus:insensitive, .question .button:hover:insensitive, .question .button.flat:focus:insensitive, .question .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
       .question .button:focus:active:insensitive, .question .button:focus:checked:insensitive, .question .button:hover:active:insensitive, .question .button:hover:checked:insensitive, .question .button.flat:focus:active:insensitive, .question .button.flat:focus:checked:insensitive, .question .button.flat:hover:active:insensitive, .question .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.3); }
     .question .button:active, .question .button:checked, .question .button.flat:active, .question .button.flat:checked {
       background-color: #d94815;
       background-image: linear-gradient(to top, #ec6b3e, #a33610);
@@ -1641,74 +1641,74 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #d94815;
-      background-image: linear-gradient(to bottom, #ec6b3e, #a33610);
+      background-color: #4c4c7d;
+      background-image: linear-gradient(to bottom, #5f5f9c, #39395e);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: #e54c17;
-      background-image: linear-gradient(to bottom, #ed774d, #ac3911);
-      color: mix(#E95420,#000000,0.5);
+      background-color: rgba(84, 84, 139, 0.3);
+      background-image: linear-gradient(to bottom, rgba(111, 111, 168, 0.3), rgba(63, 63, 104, 0.3));
+      color: mix(#54548b,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#E95420,#000000,0.5);
+      color: mix(#54548b,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #d94815; }
+      color: #4c4c7d; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #cd4414; }
+        color: #474776; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #e92041;
+  background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
+  border: 1px solid #c11330;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #e92041;
+    background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
     .error .button:focus, .error .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active, .error .button:active:hover, .error .button:active:focus, .error .button:active:hover:focus, .error .button:checked, .error .button:checked:hover, .error .button:checked:focus, .error .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active:insensitive, .error .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(233, 32, 65, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active, .error .button.flat:active:hover, .error .button.flat:active:focus, .error .button.flat:active:hover:focus, .error .button.flat:checked, .error .button.flat:checked:hover, .error .button.flat:checked:focus, .error .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
+      background-color: #ee506a;
+      background-image: linear-gradient(to bottom, #f599a8, #d91536);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active, .error .button:focus:active:hover, .error .button:focus:active:focus, .error .button:focus:active:hover:focus, .error .button:focus:checked, .error .button:focus:checked:hover, .error .button:focus:checked:focus, .error .button:focus:checked:hover:focus, .error .button:hover:active, .error .button:hover:active:hover, .error .button:hover:active:focus, .error .button:hover:active:hover:focus, .error .button:hover:checked, .error .button:hover:checked:hover, .error .button:hover:checked:focus, .error .button:hover:checked:hover:focus, .error .button.flat:focus:active, .error .button.flat:focus:active:hover, .error .button.flat:focus:active:focus, .error .button.flat:focus:active:hover:focus, .error .button.flat:focus:checked, .error .button.flat:focus:checked:hover, .error .button.flat:focus:checked:focus, .error .button.flat:focus:checked:hover:focus, .error .button.flat:hover:active, .error .button.flat:hover:active:hover, .error .button.flat:hover:active:focus, .error .button.flat:hover:active:hover:focus, .error .button.flat:hover:checked, .error .button.flat:hover:checked:hover, .error .button.flat:hover:checked:focus, .error .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:insensitive, .error .button:hover:insensitive, .error .button.flat:focus:insensitive, .error .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active:insensitive, .error .button:focus:checked:insensitive, .error .button:hover:active:insensitive, .error .button:hover:checked:insensitive, .error .button.flat:focus:active:insensitive, .error .button.flat:focus:checked:insensitive, .error .button.flat:hover:active:insensitive, .error .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .error .button:active, .error .button:checked, .error .button.flat:active, .error .button.flat:checked {
       background-color: #d94815;
       background-image: linear-gradient(to top, #ec6b3e, #a33610);
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #d91536;
+      background-image: linear-gradient(to bottom, #ec3e5b, #a31028);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: #e51739;
+      background-image: linear-gradient(to bottom, #ed4d68, #ac112a);
+      color: mix(#e92041,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#e92041,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #d91536; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #cd1433; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #E95420;
+    background-color: #abd200;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #e9dd00;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #e92041; }
 
 .view, GtkHTML {
   color: #f2d9f0;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #4b1f40;
   background-color: #5E2750; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #e92041;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #c11330;
+  background-color: #eb3351;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a9112a;
+    background-color: #e92041; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #bab100;
+  background-color: #fcef00;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a39b00;
+    background-color: #e9dd00; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #441741;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #E95420;
+@define-color info_bg_color #54548b;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #e9dd00;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #E95420;
+@define-color question_bg_color #54548b;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#E95420,#f2d9f0,0.6);
-@define-color success_color #E95420;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #e92041;
+@define-color link_color #f2a9ec;
+@define-color success_color #abd200;
+@define-color warning_color #e9dd00;
+@define-color error_color #e92041;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#E95420,#f2d9f0,0.6); }
+  -GtkIMHtml-hyperlink-color: #f2a9ec; }
   *:disabled, *:disabled:disabled {
-    color: mix(#E95420,#f2d9f0,0.6); }
+    color: #f2a9ec; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#E95420,#f2d9f0,0.6); }
+    color: #f2a9ec; }
 
 .background {
   background-color: #77216F;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #bab100;
+    background-color: mix(#5E2750,#e9dd00,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e9dd00,0.3);
+      background-color: #e9dd00;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e9dd00; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #c11330;
+    background-color: mix(#5E2750,#e92041,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e92041,0.3);
+      background-color: #e92041;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e92041; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #c11330;
+    background-color: mix(#5E2750,#e92041,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e92041,0.3);
+      background-color: #e92041;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e92041; }
 
 entry {
   background-color: #5E2750;
@@ -1727,11 +1727,11 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #E95420;
-  background-image: linear-gradient(to bottom, #ef825c, #b53c12);
+  background-color: #abd200;
+  background-image: linear-gradient(to bottom, #d1ff08, #809e00);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover {
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(233, 84, 32, 0);
+    background-color: rgba(171, 210, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,11 +1870,11 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #ea5d2c;
-    background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+    background-color: #b4dd00;
+    background-image: linear-gradient(to bottom, #d3ff15, #87a500);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
     .suggested-action:hover:focus,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:focus, .suggested-action:hover:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:hover, .suggested-action.flat:hover:focus, .suggested-action.flat:hover:hover {
@@ -1891,21 +1891,21 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #ea5d2c;
-    background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+    background-color: #b4dd00;
+    background-image: linear-gradient(to bottom, #d3ff15, #87a500);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(233, 84, 32, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #eb6638;
-      background-image: linear-gradient(to bottom, #f2997a, #c74214);
+      background-color: #bce700;
+      background-image: linear-gradient(to bottom, #d6ff22, #8dad00);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       .suggested-action:focus:hover:active, .suggested-action:focus:hover:active:hover, .suggested-action:focus:hover:active:focus, .suggested-action:focus:hover:active:hover:focus, .suggested-action:focus:hover:checked, .suggested-action:focus:hover:checked:hover, .suggested-action:focus:hover:checked:focus, .suggested-action:focus:hover:checked:hover:focus, .suggested-action.flat:focus:hover:active, .suggested-action.flat:focus:hover:active:hover, .suggested-action.flat:focus:hover:active:focus, .suggested-action.flat:focus:hover:active:hover:focus, .suggested-action.flat:focus:hover:checked, .suggested-action.flat:focus:hover:checked:hover, .suggested-action.flat:focus:hover:checked:focus, .suggested-action.flat:focus:hover:checked:hover:focus {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #000000; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#E95420,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#E95420,#000000,0.2),0.4),1.25), shade(alpha(mix(#E95420,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#abd200,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#abd200,#000000,0.2),0.4),1.25), shade(alpha(mix(#abd200,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#E95420,#000000,0.6);
+    color: mix(#abd200,#000000,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#E95420,#000000,0.6); }
+      color: mix(#abd200,#000000,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,18 +1981,18 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(233, 84, 32, 0.9); }
+    color: rgba(171, 210, 0, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(233, 84, 32, 0.85); }
+      color: rgba(171, 210, 0, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e92041;
+  background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
   .destructive-action:focus, .destructive-action:hover {
     border-color: mix(#E95420,rgba(0, 0, 0, 0.32),0.3); }
   .destructive-action:active, .destructive-action:active:hover, .destructive-action:active:focus, .destructive-action:active:hover:focus, .destructive-action:checked, .destructive-action:checked:hover, .destructive-action:checked:focus, .destructive-action:checked:hover:focus {
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(233, 32, 65, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,11 +2056,11 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #ea2c4b;
+    background-image: linear-gradient(to bottom, #f06b81, #be132f);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .destructive-action:hover:focus, .destructive-action:hover:hover, .destructive-action.flat:hover:focus, .destructive-action.flat:hover:hover {
       border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
     .destructive-action:hover:active, .destructive-action:hover:active:hover, .destructive-action:hover:active:focus, .destructive-action:hover:active:hover:focus, .destructive-action:hover:checked, .destructive-action:hover:checked:hover, .destructive-action:hover:checked:focus, .destructive-action:hover:checked:hover:focus, .destructive-action.flat:hover:active, .destructive-action.flat:hover:active:hover, .destructive-action.flat:hover:active:focus, .destructive-action.flat:hover:active:hover:focus, .destructive-action.flat:hover:checked, .destructive-action.flat:hover:checked:hover, .destructive-action.flat:hover:checked:focus, .destructive-action.flat:hover:checked:hover:focus {
@@ -2070,20 +2070,20 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #ea2c4b;
+    background-image: linear-gradient(to bottom, #f06b81, #be132f);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(233, 84, 32, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #eb3856;
+      background-image: linear-gradient(to bottom, #f27a8e, #c71431);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       .destructive-action:focus:hover:active, .destructive-action:focus:hover:active:hover, .destructive-action:focus:hover:active:focus, .destructive-action:focus:hover:active:hover:focus, .destructive-action:focus:hover:checked, .destructive-action:focus:hover:checked:hover, .destructive-action:focus:hover:checked:focus, .destructive-action:focus:hover:checked:hover:focus, .destructive-action.flat:focus:hover:active, .destructive-action.flat:focus:hover:active:hover, .destructive-action.flat:focus:hover:active:focus, .destructive-action.flat:focus:hover:active:hover:focus, .destructive-action.flat:focus:hover:checked, .destructive-action.flat:focus:hover:checked:hover, .destructive-action.flat:focus:hover:checked:focus, .destructive-action.flat:focus:hover:checked:hover:focus {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e92041,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e92041,#000000,0.2),0.4),1.25), shade(alpha(mix(#e92041,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e92041,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e92041,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(233, 84, 32, 0.6);
     background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(233, 32, 65, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(233, 32, 65, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,18 +3202,18 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-    border: 1px solid #c14013;
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+    border: 1px solid #43436f;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     infobar.info button:focus, infobar.info button:hover {
       border-color: mix(#E95420,rgba(0, 0, 0, 0.32),0.3); }
     infobar.info button:active, infobar.info button:active:hover, infobar.info button:active:focus, infobar.info button:active:hover:focus, infobar.info button:checked, infobar.info button:checked:hover, infobar.info button:checked:focus, infobar.info button:checked:hover:focus {
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(233, 84, 32, 0);
+      background-color: rgba(84, 84, 139, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,11 +3277,11 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #ea5d2c;
-      background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+      background-color: #585892;
+      background-image: linear-gradient(to bottom, #7878ad, #42426d);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
       infobar.info button:hover:focus, infobar.info button:hover:hover, infobar.info button.flat:hover:focus, infobar.info button.flat:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       infobar.info button:hover:active, infobar.info button:hover:active:hover, infobar.info button:hover:active:focus, infobar.info button:hover:active:hover:focus, infobar.info button:hover:checked, infobar.info button:hover:checked:hover, infobar.info button:hover:checked:focus, infobar.info button:hover:checked:hover:focus, infobar.info button.flat:hover:active, infobar.info button.flat:hover:active:hover, infobar.info button.flat:hover:active:focus, infobar.info button.flat:hover:active:hover:focus, infobar.info button.flat:hover:checked, infobar.info button.flat:hover:checked:hover, infobar.info button.flat:hover:checked:focus, infobar.info button.flat:hover:checked:hover:focus {
@@ -3291,20 +3291,20 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #ea5d2c;
-      background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+      background-color: #585892;
+      background-image: linear-gradient(to bottom, #7878ad, #42426d);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(233, 84, 32, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #eb6638;
-        background-image: linear-gradient(to bottom, #f2997a, #c74214);
+        background-color: #5c5c99;
+        background-image: linear-gradient(to bottom, #8080b2, #454573);
         border-color: rgba(0, 0, 0, 0.4);
-        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
+        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
           border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
         infobar.info button:focus:hover:active, infobar.info button:focus:hover:active:hover, infobar.info button:focus:hover:active:focus, infobar.info button:focus:hover:active:hover:focus, infobar.info button:focus:hover:checked, infobar.info button:focus:hover:checked:hover, infobar.info button:focus:hover:checked:focus, infobar.info button:focus:hover:checked:hover:focus, infobar.info button.flat:focus:hover:active, infobar.info button.flat:focus:hover:active:hover, infobar.info button.flat:focus:hover:active:focus, infobar.info button.flat:focus:hover:active:hover:focus, infobar.info button.flat:focus:hover:checked, infobar.info button.flat:focus:hover:checked:hover, infobar.info button.flat:focus:hover:checked:focus, infobar.info button.flat:focus:hover:checked:hover:focus {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#E95420,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#E95420,#000000,0.2),0.4),1.25), shade(alpha(mix(#E95420,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#54548b,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#54548b,#000000,0.2),0.4),1.25), shade(alpha(mix(#54548b,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#E95420,#000000,0.6);
+      color: mix(#54548b,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#E95420,#000000,0.6); }
+        color: mix(#54548b,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -3353,19 +3353,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(233, 84, 32, 0.9); }
+      color: rgba(84, 84, 139, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(233, 84, 32, 0.85); }
+        color: rgba(84, 84, 139, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #e9dd00;
+    background-image: linear-gradient(to bottom, #fff424, #afa600);
+    border: 1px solid #bab100;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e9dd00;
+    background-image: linear-gradient(to bottom, #fff424, #afa600);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(233, 221, 0, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,8 +3432,8 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f5e800;
+      background-image: linear-gradient(to bottom, #fff433, #b7ae00);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -3446,8 +3446,8 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f5e800;
+      background-image: linear-gradient(to bottom, #fff433, #b7ae00);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(233, 84, 32, 0.5);
       outline-width: 1px;
@@ -3456,8 +3456,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #fff201;
+        background-image: linear-gradient(to bottom, #fff541, #c0b600);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#e9dd00,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#e9dd00,#000000,0.2),0.4),1.25), shade(alpha(mix(#e9dd00,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#e9dd00,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#e9dd00,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -3508,22 +3508,22 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(233, 221, 0, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(233, 221, 0, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
-    border: 1px solid #c14013;
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
+    border: 1px solid #43436f;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #E95420;
-    background-image: linear-gradient(to bottom, #ef825c, #b53c12);
+    background-color: #54548b;
+    background-image: linear-gradient(to bottom, #6f6fa8, #3f3f68);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     infobar.question button:focus, infobar.question button:hover {
       border-color: mix(#E95420,rgba(0, 0, 0, 0.32),0.3); }
     infobar.question button:active, infobar.question button:active:hover, infobar.question button:active:focus, infobar.question button:active:hover:focus, infobar.question button:checked, infobar.question button:checked:hover, infobar.question button:checked:focus, infobar.question button:checked:hover:focus {
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(233, 84, 32, 0);
+      background-color: rgba(84, 84, 139, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,11 +3587,11 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #ea5d2c;
-      background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+      background-color: #585892;
+      background-image: linear-gradient(to bottom, #7878ad, #42426d);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
       infobar.question button:hover:focus, infobar.question button:hover:hover, infobar.question button.flat:hover:focus, infobar.question button.flat:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       infobar.question button:hover:active, infobar.question button:hover:active:hover, infobar.question button:hover:active:focus, infobar.question button:hover:active:hover:focus, infobar.question button:hover:checked, infobar.question button:hover:checked:hover, infobar.question button:hover:checked:focus, infobar.question button:hover:checked:hover:focus, infobar.question button.flat:hover:active, infobar.question button.flat:hover:active:hover, infobar.question button.flat:hover:active:focus, infobar.question button.flat:hover:active:hover:focus, infobar.question button.flat:hover:checked, infobar.question button.flat:hover:checked:hover, infobar.question button.flat:hover:checked:focus, infobar.question button.flat:hover:checked:hover:focus {
@@ -3601,20 +3601,20 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #ea5d2c;
-      background-image: linear-gradient(to bottom, #f08e6b, #be3f13);
+      background-color: #585892;
+      background-image: linear-gradient(to bottom, #7878ad, #42426d);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(233, 84, 32, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #eb6638;
-        background-image: linear-gradient(to bottom, #f2997a, #c74214);
+        background-color: #5c5c99;
+        background-image: linear-gradient(to bottom, #8080b2, #454573);
         border-color: rgba(0, 0, 0, 0.4);
-        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
+        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
           border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
         infobar.question button:focus:hover:active, infobar.question button:focus:hover:active:hover, infobar.question button:focus:hover:active:focus, infobar.question button:focus:hover:active:hover:focus, infobar.question button:focus:hover:checked, infobar.question button:focus:hover:checked:hover, infobar.question button:focus:hover:checked:focus, infobar.question button:focus:hover:checked:hover:focus, infobar.question button.flat:focus:hover:active, infobar.question button.flat:focus:hover:active:hover, infobar.question button.flat:focus:hover:active:focus, infobar.question button.flat:focus:hover:active:hover:focus, infobar.question button.flat:focus:hover:checked, infobar.question button.flat:focus:hover:checked:hover, infobar.question button.flat:focus:hover:checked:focus, infobar.question button.flat:focus:hover:checked:hover:focus {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#E95420,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#E95420,#000000,0.2),0.4),1.25), shade(alpha(mix(#E95420,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#54548b,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#54548b,#000000,0.2),0.4),1.25), shade(alpha(mix(#54548b,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#E95420,#000000,0.6);
+      color: mix(#54548b,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#E95420,#000000,0.6); }
+        color: mix(#54548b,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -3663,22 +3663,22 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(233, 84, 32, 0.9); }
+      color: rgba(84, 84, 139, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(233, 84, 32, 0.85); }
+        color: rgba(84, 84, 139, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #e92041;
+    background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
+    border: 1px solid #c11330;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e92041;
+    background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
     infobar.error button:focus, infobar.error button:hover {
       border-color: mix(#E95420,rgba(0, 0, 0, 0.32),0.3); }
     infobar.error button:active, infobar.error button:active:hover, infobar.error button:active:focus, infobar.error button:active:hover:focus, infobar.error button:checked, infobar.error button:checked:hover, infobar.error button:checked:focus, infobar.error button:checked:hover:focus {
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(233, 32, 65, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,11 +3742,11 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #ea2c4b;
+      background-image: linear-gradient(to bottom, #f06b81, #be132f);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
       infobar.error button:hover:focus, infobar.error button:hover:hover, infobar.error button.flat:hover:focus, infobar.error button.flat:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       infobar.error button:hover:active, infobar.error button:hover:active:hover, infobar.error button:hover:active:focus, infobar.error button:hover:active:hover:focus, infobar.error button:hover:checked, infobar.error button:hover:checked:hover, infobar.error button:hover:checked:focus, infobar.error button:hover:checked:hover:focus, infobar.error button.flat:hover:active, infobar.error button.flat:hover:active:hover, infobar.error button.flat:hover:active:focus, infobar.error button.flat:hover:active:hover:focus, infobar.error button.flat:hover:checked, infobar.error button.flat:hover:checked:hover, infobar.error button.flat:hover:checked:focus, infobar.error button.flat:hover:checked:hover:focus {
@@ -3756,20 +3756,20 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #ea2c4b;
+      background-image: linear-gradient(to bottom, #f06b81, #be132f);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(233, 84, 32, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #eb3856;
+        background-image: linear-gradient(to bottom, #f27a8e, #c71431);
         border-color: rgba(0, 0, 0, 0.4);
-        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
           border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
         infobar.error button:focus:hover:active, infobar.error button:focus:hover:active:hover, infobar.error button:focus:hover:active:focus, infobar.error button:focus:hover:active:hover:focus, infobar.error button:focus:hover:checked, infobar.error button:focus:hover:checked:hover, infobar.error button:focus:hover:checked:focus, infobar.error button:focus:hover:checked:hover:focus, infobar.error button.flat:focus:hover:active, infobar.error button.flat:focus:hover:active:hover, infobar.error button.flat:focus:hover:active:focus, infobar.error button.flat:focus:hover:active:hover:focus, infobar.error button.flat:focus:hover:checked, infobar.error button.flat:focus:hover:checked:hover, infobar.error button.flat:focus:hover:checked:focus, infobar.error button.flat:focus:hover:checked:hover:focus {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#e92041,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#e92041,#000000,0.2),0.4),1.25), shade(alpha(mix(#e92041,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#e92041,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#e92041,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(233, 32, 65, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(233, 32, 65, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #bab100;
+    background-color: mix(#5E2750,#e9dd00,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e9dd00,0.3);
+      background-color: #e9dd00;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e9dd00; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #c11330;
+    background-color: mix(#5E2750,#e92041,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e92041,0.3);
+      background-color: #e92041;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e92041; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#5E2750,#ff0000,0.6); }
+    border-color: #c11330;
+    background-color: mix(#5E2750,#e92041,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#E95420,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#E95420,#e92041,0.3);
+      background-color: #e92041;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e92041; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#77216F,#f2d9f0,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #f0667c; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #E95420; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #e9dd00;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #E95420;
+    background-color: #abd200;
     border-color: transparent; }
   levelbar block.full {
     background-color: #c14013;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #4b1f40;
   background-color: #5E2750; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #e92041;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #ff0000; }
+  background-color: #e92041; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #eb3856; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,11 +8947,11 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e92041;
+  background-image: linear-gradient(to bottom, #ef5c74, #b5122d);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.12); }
   #shutdown_button button:focus, #shutdown_button button:hover {
     border-color: mix(#E95420,rgba(0, 0, 0, 0.32),0.3); }
   #shutdown_button button:active, #shutdown_button button:active:hover, #shutdown_button button:active:focus, #shutdown_button button:active:hover:focus, #shutdown_button button:checked, #shutdown_button button:checked:hover, #shutdown_button button:checked:focus, #shutdown_button button:checked:hover:focus {
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(233, 32, 65, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,11 +9015,11 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #ea2c4b;
+    background-image: linear-gradient(to bottom, #f06b81, #be132f);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     #shutdown_button button:hover:focus, #shutdown_button button:hover:hover, #shutdown_button button.flat:hover:focus, #shutdown_button button.flat:hover:hover {
       border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
     #shutdown_button button:hover:active, #shutdown_button button:hover:active:hover, #shutdown_button button:hover:active:focus, #shutdown_button button:hover:active:hover:focus, #shutdown_button button:hover:checked, #shutdown_button button:hover:checked:hover, #shutdown_button button:hover:checked:focus, #shutdown_button button:hover:checked:hover:focus, #shutdown_button button.flat:hover:active, #shutdown_button button.flat:hover:active:hover, #shutdown_button button.flat:hover:active:focus, #shutdown_button button.flat:hover:active:hover:focus, #shutdown_button button.flat:hover:checked, #shutdown_button button.flat:hover:checked:hover, #shutdown_button button.flat:hover:checked:focus, #shutdown_button button.flat:hover:checked:hover:focus {
@@ -9029,20 +9029,20 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #ea2c4b;
+    background-image: linear-gradient(to bottom, #f06b81, #be132f);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(233, 84, 32, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #eb3856;
+      background-image: linear-gradient(to bottom, #f27a8e, #c71431);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.38); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
         border-color: mix(#E95420,rgba(0, 0, 0, 0.4),0.3); }
       #shutdown_button button:focus:hover:active, #shutdown_button button:focus:hover:active:hover, #shutdown_button button:focus:hover:active:focus, #shutdown_button button:focus:hover:active:hover:focus, #shutdown_button button:focus:hover:checked, #shutdown_button button:focus:hover:checked:hover, #shutdown_button button:focus:hover:checked:focus, #shutdown_button button:focus:hover:checked:hover:focus, #shutdown_button button.flat:focus:hover:active, #shutdown_button button.flat:focus:hover:active:hover, #shutdown_button button.flat:focus:hover:active:focus, #shutdown_button button.flat:focus:hover:active:hover:focus, #shutdown_button button.flat:focus:hover:checked, #shutdown_button button.flat:focus:hover:checked:hover, #shutdown_button button.flat:focus:hover:checked:focus, #shutdown_button button.flat:focus:hover:checked:hover:focus {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e92041,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e92041,#000000,0.2),0.4),1.25), shade(alpha(mix(#e92041,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e92041,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e92041,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(233, 84, 32, 0.6);
     background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -9091,14 +9091,14 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(233, 32, 65, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(233, 32, 65, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e9dd00;
+  background-image: linear-gradient(to bottom, #fff424, #afa600);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(233, 221, 0, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,8 +9165,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f5e800;
+    background-image: linear-gradient(to bottom, #fff433, #b7ae00);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -9179,8 +9179,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f5e800;
+    background-image: linear-gradient(to bottom, #fff433, #b7ae00);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(233, 84, 32, 0.5);
     outline-width: 1px;
@@ -9189,8 +9189,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #fff201;
+      background-image: linear-gradient(to bottom, #fff541, #c0b600);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e9dd00,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e9dd00,#000000,0.2),0.4),1.25), shade(alpha(mix(#e9dd00,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e9dd00,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e9dd00,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(233, 84, 32, 0.6);
     background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(233, 221, 0, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(233, 221, 0, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/info.json
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Aubergine", 
-	"description": "Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/qt5ct/Cinnamox-Aubergine.conf
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/qt5ct/Cinnamox-Aubergine.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#f2d9f0,          #77216F, #77216F, #77216F, #2C001E, #2C001E, #f2d9f0,           #f2d9f0,           #f2d9f0,           #5E2750, #77216F, #2C001E, #E95420, #000000, #E95420, #f2d9f0,            #77216F, #f2d9f0,           2C001E,  #f2d9f0
+disabled_colors=#d3abcf, #77216F, #77216F, #77216F, #2C001E, #2C001E, #cdacc8,  #cdacc8,  #d3abcf,  #5E2750, #77216F, #2C001E, #E95420, #000000, #E95420, #d3abcf,   #77216F, #d3abcf,  #2C001E, #c0a2bb
+inactive_colors=#f2d9f0,          #77216F, #77216F, #77216F, #2C001E, #2C001E, #f2d9f0,           #f2d9f0,           #f2d9f0,           #5E2750, #77216F, #2C001E, #E95420, #000000, #E95420, #f2d9f0,            #77216F, #f2d9f0,           #2C001E, #f2d9f0
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#f2d9f0,          #5E2750, #77216F, #cbc7c4, #9f9d9a, #b8b5b2, #f2d9f0,           #ff0000, #f2d9f0, #5E2750, #77216F, #767472, #E95420, #000000, #E95420, #f2d9f0,            #77216F, #f2d9f0,           2C001E, #f2d9f0
+#disabled_colors=#d3abcf, #5E2750, #77216F, #cbc7c4, #9f9d9a, #b8b5b2, #cdacc8,  #ffec17, #f2d9f0, #5E2750, #77216F, #767472, #E95420, #000000, #E95420, #d3abcf,   #77216F, #d3abcf,  #2C001E, #c0a2bb
+#inactive_colors=#f2d9f0,          #5E2750, #77216F, #cbc7c4, #9f9d9a, #b8b5b2, #f2d9f0,           #ff9040, #f2d9f0, #5E2750, #77216F, #767472, #E95420, #000000, #E95420, #f2d9f0,            #77216F, #f2d9f0,           #2C001E, #f2d9f0

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Aubergine.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Aubergine;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Aubergine/info.json
+++ b/Cinnamox-Aubergine/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Aubergine", 
-	"description": "Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Gold-Spice
 
-Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Gold-Spice
 
-Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Gold-Spice */
 /* Transparency: None */
-/* Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #f2e2da;
+    color: #e50026;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #e5e500;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #e50026;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Gold-Spice. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Gold-Spice
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/gtkrc
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#663d2b\nbg_color:#99461e\ntooltip_bg_color:#99461e\nselected_bg_color:#e54c00\ntext_color:#f2e2da\nfg_color:#f2e2da\ntooltip_fg_color:#f2e2da\nselected_fg_color:#000000\nmenubar_bg_color:#382218\nmenubar_fg_color:#f2e2da\ntoolbar_bg_color:#99461e\ntoolbar_fg_color:#f2e2da\nmenu_bg_color:#382218\nmenu_fg_color:#f2e2da\npanel_bg_color:#99461e\npanel_fg_color:#f2e2da\nlink_color:#e54c00\nbtn_bg_color:#663d2b\nbtn_fg_color:#f2e2da\ntitlebar_bg_color:#382218\ntitlebar_fg_color:#f2e2da\nprimary_caret_color:#f2e2da\nsecondary_caret_color:#f2e2da\n"
+"base_color:#663d2b\nbg_color:#99461e\ntooltip_bg_color:#99461e\nselected_bg_color:#e54c00\ntext_color:#f2e2da\nfg_color:#f2e2da\ntooltip_fg_color:#f2e2da\nselected_fg_color:#000000\nmenubar_bg_color:#382218\nmenubar_fg_color:#f2e2da\ntoolbar_bg_color:#99461e\ntoolbar_fg_color:#f2e2da\nmenu_bg_color:#382218\nmenu_fg_color:#f2e2da\npanel_bg_color:#99461e\npanel_fg_color:#f2e2da\nlink_color:#f2c1a9\nbtn_bg_color:#663d2b\nbtn_fg_color:#f2e2da\ntitlebar_bg_color:#382218\ntitlebar_fg_color:#f2e2da\nprimary_caret_color:#f2e2da\nsecondary_caret_color:#f2e2da\naccent_bg_color:#e54c00\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#663d2b\nbg_color:#99461e\ntooltip_bg_color:#99461e\nselected_bg_color:#e54c00\ntext_color:#f2e2da\nfg_color:#f2e2da\ntooltip_fg_color:#f2e2da\nselected_fg_color:#000000\nmenubar_bg_color:#382218\nmenubar_fg_color:#f2e2da\ntoolbar_bg_color:#99461e\ntoolbar_fg_color:#f2e2da\nmenu_bg_color:#382218\nmenu_fg_color:#f2e2da\npanel_bg_color:#99461e\npanel_fg_color:#f2e2da\nlink_color:#e54c00\nbtn_bg_color:#663d2b\nbtn_fg_color:#f2e2da\ntitlebar_bg_color:#382218\ntitlebar_fg_color:#f2e2da\n"
+"base_color:#663d2b\nbg_color:#99461e\ntooltip_bg_color:#99461e\nselected_bg_color:#e54c00\ntext_color:#f2e2da\nfg_color:#f2e2da\ntooltip_fg_color:#f2e2da\nselected_fg_color:#000000\nmenubar_bg_color:#382218\nmenubar_fg_color:#f2e2da\ntoolbar_bg_color:#99461e\ntoolbar_fg_color:#f2e2da\nmenu_bg_color:#382218\nmenu_fg_color:#f2e2da\npanel_bg_color:#99461e\npanel_fg_color:#f2e2da\nlink_color:#f2c1a9\nbtn_bg_color:#663d2b\nbtn_fg_color:#f2e2da\ntitlebar_bg_color:#382218\ntitlebar_fg_color:#f2e2da\nprimary_caret_color:#f2e2da\nsecondary_caret_color:#f2e2da\naccent_bg_color:#e54c00\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.0/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #442718;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #e54c00;
+@define-color info_bg_color #4b4b87;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #e5e500;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #e54c00;
+@define-color question_bg_color #4b4b87;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#e54c00,#f2e2da,0.6);
-@define-color success_color #e54c00;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #e50026;
+@define-color link_color #f2c1a9;
+@define-color success_color #a7ca00;
+@define-color warning_color #e5e500;
+@define-color error_color #e50026;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#e54c00,#f2e2da,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#e54c00,#f2e2da,0.6);
-  -GtkWidget-link-color: mix(#e54c00,#f2e2da,0.6);
-  -GtkWidget-visited-link-color: mix(#e54c00,#f2e2da,0.6); }
+  -GtkHTML-link-color: #f2c1a9;
+  -GtkIMHtml-hyperlink-color: #f2c1a9;
+  -GtkWidget-link-color: #f2c1a9;
+  -GtkWidget-visited-link-color: #f2c1a9; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#e54c00,#f2e2da,0.6); }
+    color: #f2c1a9; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#e54c00,#f2e2da,0.6); }
+    color: #f2c1a9; }
 
 .background {
   background-color: #99461e;
@@ -898,8 +898,8 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #e54c00;
-  background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+  background-color: #a7ca00;
+  background-image: linear-gradient(to bottom, #d1fd00, #7d9800);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -913,7 +913,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(229, 76, 0, 0);
+    background-color: rgba(167, 202, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
@@ -925,8 +925,8 @@ GtkComboBox .separator {
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #ff6214;
-    background-image: linear-gradient(to bottom, #ff9059, #ce4400);
+    background-color: #c8f200;
+    background-image: linear-gradient(to bottom, #dbff30, #96b600);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
@@ -949,32 +949,32 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #000000; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #ce4400;
-    background-image: linear-gradient(to bottom, #ff5603, #9b3300);
+    background-color: #96b600;
+    background-image: linear-gradient(to bottom, #bce300, #718800);
     color: #000000;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: rgba(229, 76, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.3), rgba(172, 57, 0, 0.3));
-    color: mix(#e54c00,#000000,0.5);
+    background-color: rgba(167, 202, 0, 0.3);
+    background-image: linear-gradient(to bottom, rgba(209, 253, 0, 0.3), rgba(125, 152, 0, 0.3));
+    color: mix(#a7ca00,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #000000; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#e54c00,#000000,0.5);
+    color: mix(#a7ca00,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #ce4400; }
+    color: #96b600; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #c34100; }
+      color: #8eac00; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e50026;
+  background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -988,7 +988,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .destructive-action.button.flat {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(229, 0, 38, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
@@ -1000,8 +1000,8 @@ GtkComboBox .separator {
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
+    background-color: #ff143b;
+    background-image: linear-gradient(to bottom, #ff5974, #ce0022);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #ce0022;
+    background-image: linear-gradient(to bottom, #ff032d, #9b001a);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#000000,0.5);
+    background-color: rgba(229, 0, 38, 0.3);
+    background-image: linear-gradient(to bottom, rgba(255, 31, 68, 0.3), rgba(172, 0, 29, 0.3));
+    color: mix(#e50026,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#000000,0.5);
+    color: mix(#e50026,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #ce0022; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #c30020; }
 
 /******************
 * selection mode *
@@ -1424,14 +1424,14 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #e54c00;
-  background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
-  border: 1px solid #b73d00;
+  background-color: #4b4b87;
+  background-image: linear-gradient(to bottom, #6060a7, #383865);
+  border: 1px solid #3c3c6c;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1445,7 +1445,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .info .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(229, 76, 0, 0);
+      background-color: rgba(75, 75, 135, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
@@ -1457,8 +1457,8 @@ GtkInfoBar {
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #ff6214;
-      background-image: linear-gradient(to bottom, #ff9059, #ce4400);
+      background-color: #5a5aa2;
+      background-image: linear-gradient(to bottom, #8282b9, #44447a);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
@@ -1481,37 +1481,37 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #ce4400;
-      background-image: linear-gradient(to bottom, #ff5603, #9b3300);
+      background-color: #44447a;
+      background-image: linear-gradient(to bottom, #545498, #33335b);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: rgba(229, 76, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.3), rgba(172, 57, 0, 0.3));
-      color: mix(#e54c00,#000000,0.5);
+      background-color: rgba(75, 75, 135, 0.3);
+      background-image: linear-gradient(to bottom, rgba(96, 96, 167, 0.3), rgba(56, 56, 101, 0.3));
+      color: mix(#4b4b87,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#e54c00,#000000,0.5);
+      color: mix(#4b4b87,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #ce4400; }
+      color: #44447a; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #c34100; }
+        color: #404073; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #e5e500;
+  background-image: linear-gradient(to bottom, #ffff1f, #acac00);
+  border: 1px solid #b7b700;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e5e500;
+    background-image: linear-gradient(to bottom, #ffff1f, #acac00);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1525,7 +1525,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .warning .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(229, 229, 0, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
@@ -1537,8 +1537,8 @@ GtkInfoBar {
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #ffff14;
+      background-image: linear-gradient(to bottom, #ffff59, #cece00);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
@@ -1561,37 +1561,37 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #cece00;
+      background-image: linear-gradient(to bottom, #ffff03, #9b9b00);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(229, 229, 0, 0.3);
+      background-image: linear-gradient(to bottom, rgba(255, 255, 31, 0.3), rgba(172, 172, 0, 0.3));
+      color: mix(#e5e500,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#e5e500,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #cece00; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #c3c300; }
 
 .question {
-  background-color: #e54c00;
-  background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
-  border: 1px solid #b73d00;
+  background-color: #4b4b87;
+  background-image: linear-gradient(to bottom, #6060a7, #383865);
+  border: 1px solid #3c3c6c;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1605,7 +1605,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .question .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(229, 76, 0, 0);
+      background-color: rgba(75, 75, 135, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
@@ -1617,8 +1617,8 @@ GtkInfoBar {
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #ff6214;
-      background-image: linear-gradient(to bottom, #ff9059, #ce4400);
+      background-color: #5a5aa2;
+      background-image: linear-gradient(to bottom, #8282b9, #44447a);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
@@ -1641,37 +1641,37 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #ce4400;
-      background-image: linear-gradient(to bottom, #ff5603, #9b3300);
+      background-color: #44447a;
+      background-image: linear-gradient(to bottom, #545498, #33335b);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: rgba(229, 76, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.3), rgba(172, 57, 0, 0.3));
-      color: mix(#e54c00,#000000,0.5);
+      background-color: rgba(75, 75, 135, 0.3);
+      background-image: linear-gradient(to bottom, rgba(96, 96, 167, 0.3), rgba(56, 56, 101, 0.3));
+      color: mix(#4b4b87,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#e54c00,#000000,0.5);
+      color: mix(#4b4b87,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #ce4400; }
+      color: #44447a; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #c34100; }
+        color: #404073; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #e50026;
+  background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
+  border: 1px solid #b7001e;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e50026;
+    background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1685,7 +1685,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .error .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(229, 0, 38, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
@@ -1697,8 +1697,8 @@ GtkInfoBar {
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #ff143b;
+      background-image: linear-gradient(to bottom, #ff5974, #ce0022);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #ce0022;
+      background-image: linear-gradient(to bottom, #ff032d, #9b001a);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(229, 0, 38, 0.3);
+      background-image: linear-gradient(to bottom, rgba(255, 31, 68, 0.3), rgba(172, 0, 29, 0.3));
+      color: mix(#e50026,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#e50026,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #ce0022; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #c30020; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #e54c00;
+    background-color: #a7ca00;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #e5e500;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #e50026; }
 
 .view, GtkHTML {
   color: #f2e2da;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #523122;
   background-color: #663d2b; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #e50026;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #b7001e;
+  background-color: #f70029;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a0001b;
+    background-color: #e50026; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #b7b700;
+  background-color: #f7f700;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a0a000;
+    background-color: #e5e500; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #442718;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #e54c00;
+@define-color info_bg_color #4b4b87;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #e5e500;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #e54c00;
+@define-color question_bg_color #4b4b87;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#e54c00,#f2e2da,0.6);
-@define-color success_color #e54c00;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #e50026;
+@define-color link_color #f2c1a9;
+@define-color success_color #a7ca00;
+@define-color warning_color #e5e500;
+@define-color error_color #e50026;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#e54c00,#f2e2da,0.6); }
+  -GtkIMHtml-hyperlink-color: #f2c1a9; }
   *:disabled, *:disabled:disabled {
-    color: mix(#e54c00,#f2e2da,0.6); }
+    color: #f2c1a9; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#e54c00,#f2e2da,0.6); }
+    color: #f2c1a9; }
 
 .background {
   background-color: #99461e;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7b700;
+    background-color: mix(#663d2b,#e5e500,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e5e500,0.3);
+      background-color: #e5e500;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e5e500; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7001e;
+    background-color: mix(#663d2b,#e50026,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e50026,0.3);
+      background-color: #e50026;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e50026; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7001e;
+    background-color: mix(#663d2b,#e50026,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e50026,0.3);
+      background-color: #e50026;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e50026; }
 
 entry {
   background-color: #663d2b;
@@ -1727,8 +1727,8 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #e54c00;
-  background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+  background-color: #a7ca00;
+  background-image: linear-gradient(to bottom, #d1fd00, #7d9800);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(229, 76, 0, 0);
+    background-color: rgba(167, 202, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,8 +1870,8 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #f05000;
-    background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+    background-color: #afd400;
+    background-image: linear-gradient(to bottom, #d5ff0a, #849f00);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -1891,8 +1891,8 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #f05000;
-    background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+    background-color: #afd400;
+    background-image: linear-gradient(to bottom, #d5ff0a, #849f00);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(229, 76, 0, 0.5);
     outline-width: 1px;
@@ -1902,8 +1902,8 @@ searchbar,
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #fc5400;
-      background-image: linear-gradient(to bottom, #ff7d3c, #bd3f00);
+      background-color: #b8de00;
+      background-image: linear-gradient(to bottom, #d7ff17, #8aa700);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #000000; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#e54c00,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#e54c00,#000000,0.2),0.4),1.25), shade(alpha(mix(#e54c00,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a7ca00,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a7ca00,#000000,0.2),0.4),1.25), shade(alpha(mix(#a7ca00,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#e54c00,#000000,0.6);
+    color: mix(#a7ca00,#000000,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#e54c00,#000000,0.6); }
+      color: mix(#a7ca00,#000000,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,15 +1981,15 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(229, 76, 0, 0.9); }
+    color: rgba(167, 202, 0, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(229, 76, 0, 0.85); }
+      color: rgba(167, 202, 0, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e50026;
+  background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(229, 0, 38, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,8 +2056,8 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f00028;
+    background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -2070,8 +2070,8 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f00028;
+    background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(229, 76, 0, 0.5);
     outline-width: 1px;
@@ -2080,8 +2080,8 @@ searchbar,
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #fc002a;
+      background-image: linear-gradient(to bottom, #ff3c5c, #bd001f);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e50026,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e50026,#000000,0.2),0.4),1.25), shade(alpha(mix(#e50026,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e50026,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e50026,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(229, 76, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(229, 0, 38, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(229, 0, 38, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,15 +3202,15 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
-    border: 1px solid #b73d00;
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
+    border: 1px solid #3c3c6c;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(229, 76, 0, 0);
+      background-color: rgba(75, 75, 135, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,8 +3277,8 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #f05000;
-      background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+      background-color: #4f4f8e;
+      background-image: linear-gradient(to bottom, #6868ab, #3b3b6a);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -3291,8 +3291,8 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #f05000;
-      background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+      background-color: #4f4f8e;
+      background-image: linear-gradient(to bottom, #6868ab, #3b3b6a);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(229, 76, 0, 0.5);
       outline-width: 1px;
@@ -3301,8 +3301,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #fc5400;
-        background-image: linear-gradient(to bottom, #ff7d3c, #bd3f00);
+        background-color: #535395;
+        background-image: linear-gradient(to bottom, #7171b0, #3e3e6f);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#e54c00,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#e54c00,#000000,0.2),0.4),1.25), shade(alpha(mix(#e54c00,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4b4b87,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4b4b87,#000000,0.2),0.4),1.25), shade(alpha(mix(#4b4b87,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#e54c00,#000000,0.6);
+      color: mix(#4b4b87,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#e54c00,#000000,0.6); }
+        color: mix(#4b4b87,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -3353,19 +3353,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(229, 76, 0, 0.9); }
+      color: rgba(75, 75, 135, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(229, 76, 0, 0.85); }
+        color: rgba(75, 75, 135, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #e5e500;
+    background-image: linear-gradient(to bottom, #ffff1f, #acac00);
+    border: 1px solid #b7b700;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e5e500;
+    background-image: linear-gradient(to bottom, #ffff1f, #acac00);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(229, 229, 0, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,8 +3432,8 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f0f000;
+      background-image: linear-gradient(to bottom, #ffff2e, #b4b400);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -3446,8 +3446,8 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f0f000;
+      background-image: linear-gradient(to bottom, #ffff2e, #b4b400);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(229, 76, 0, 0.5);
       outline-width: 1px;
@@ -3456,8 +3456,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #fcfc00;
+        background-image: linear-gradient(to bottom, #ffff3c, #bdbd00);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#e5e500,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#e5e500,#000000,0.2),0.4),1.25), shade(alpha(mix(#e5e500,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#e5e500,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#e5e500,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -3508,19 +3508,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(229, 229, 0, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(229, 229, 0, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
-    border: 1px solid #b73d00;
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
+    border: 1px solid #3c3c6c;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #e54c00;
-    background-image: linear-gradient(to bottom, #ff6a1f, #ac3900);
+    background-color: #4b4b87;
+    background-image: linear-gradient(to bottom, #6060a7, #383865);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(229, 76, 0, 0);
+      background-color: rgba(75, 75, 135, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,8 +3587,8 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #f05000;
-      background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+      background-color: #4f4f8e;
+      background-image: linear-gradient(to bottom, #6868ab, #3b3b6a);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -3601,8 +3601,8 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #f05000;
-      background-image: linear-gradient(to bottom, #ff732e, #b43c00);
+      background-color: #4f4f8e;
+      background-image: linear-gradient(to bottom, #6868ab, #3b3b6a);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(229, 76, 0, 0.5);
       outline-width: 1px;
@@ -3611,8 +3611,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #fc5400;
-        background-image: linear-gradient(to bottom, #ff7d3c, #bd3f00);
+        background-color: #535395;
+        background-image: linear-gradient(to bottom, #7171b0, #3e3e6f);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#e54c00,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#e54c00,#000000,0.2),0.4),1.25), shade(alpha(mix(#e54c00,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4b4b87,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4b4b87,#000000,0.2),0.4),1.25), shade(alpha(mix(#4b4b87,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#e54c00,#000000,0.6);
+      color: mix(#4b4b87,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#e54c00,#000000,0.6); }
+        color: mix(#4b4b87,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -3663,19 +3663,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(229, 76, 0, 0.9); }
+      color: rgba(75, 75, 135, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(229, 76, 0, 0.85); }
+        color: rgba(75, 75, 135, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #e50026;
+    background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
+    border: 1px solid #b7001e;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #e50026;
+    background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(229, 0, 38, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,8 +3742,8 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f00028;
+      background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -3756,8 +3756,8 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #f00028;
+      background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(229, 76, 0, 0.5);
       outline-width: 1px;
@@ -3766,8 +3766,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #fc002a;
+        background-image: linear-gradient(to bottom, #ff3c5c, #bd001f);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#e50026,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#e50026,#000000,0.2),0.4),1.25), shade(alpha(mix(#e50026,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#e50026,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#e50026,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(229, 0, 38, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(229, 0, 38, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7b700;
+    background-color: mix(#663d2b,#e5e500,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e5e500,0.3);
+      background-color: #e5e500;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e5e500; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7001e;
+    background-color: mix(#663d2b,#e50026,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e50026,0.3);
+      background-color: #e50026;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e50026; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#663d2b,#ff0000,0.6); }
+    border-color: #b7001e;
+    background-color: mix(#663d2b,#e50026,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#e54c00,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#e54c00,#e50026,0.3);
+      background-color: #e50026;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #e50026; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#99461e,#f2e2da,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #ff3354; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #e54c00; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #e5e500;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #e54c00;
+    background-color: #a7ca00;
     border-color: transparent; }
   levelbar block.full {
     background-color: #b73d00;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #523122;
   background-color: #663d2b; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #e50026;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #ff0000; }
+  background-color: #e50026; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #fc002a; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,8 +8947,8 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e50026;
+  background-image: linear-gradient(to bottom, #ff1f44, #ac001d);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(229, 0, 38, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,8 +9015,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f00028;
+    background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -9029,8 +9029,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f00028;
+    background-image: linear-gradient(to bottom, #ff2e50, #b4001e);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(229, 76, 0, 0.5);
     outline-width: 1px;
@@ -9039,8 +9039,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #fc002a;
+      background-image: linear-gradient(to bottom, #ff3c5c, #bd001f);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e50026,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e50026,#000000,0.2),0.4),1.25), shade(alpha(mix(#e50026,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e50026,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e50026,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(229, 76, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -9091,14 +9091,14 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(229, 0, 38, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(229, 0, 38, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #e5e500;
+  background-image: linear-gradient(to bottom, #ffff1f, #acac00);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(229, 229, 0, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,8 +9165,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f0f000;
+    background-image: linear-gradient(to bottom, #ffff2e, #b4b400);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -9179,8 +9179,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #f0f000;
+    background-image: linear-gradient(to bottom, #ffff2e, #b4b400);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(229, 76, 0, 0.5);
     outline-width: 1px;
@@ -9189,8 +9189,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #fcfc00;
+      background-image: linear-gradient(to bottom, #ffff3c, #bdbd00);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#e5e500,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#e5e500,#000000,0.2),0.4),1.25), shade(alpha(mix(#e5e500,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#e5e500,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#e5e500,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(229, 76, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(229, 229, 0, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(229, 229, 0, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/info.json
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Gold-Spice", 
-	"description": "Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/qt5ct/Cinnamox-Gold-Spice.conf
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/qt5ct/Cinnamox-Gold-Spice.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#f2e2da,          #99461e, #99461e, #99461e, #382218, #382218, #f2e2da,           #f2e2da,           #f2e2da,           #663d2b, #99461e, #382218, #e54c00, #000000, #e54c00, #f2e2da,            #99461e, #f2e2da,           382218,  #f2e2da
+disabled_colors=#dbbbab, #99461e, #99461e, #99461e, #382218, #382218, #cfb8ae,  #cfb8ae,  #dbbbab,  #663d2b, #99461e, #382218, #e54c00, #000000, #e54c00, #dbbbab,   #99461e, #dbbbab,  #382218, #c3b2a9
+inactive_colors=#f2e2da,          #99461e, #99461e, #99461e, #382218, #382218, #f2e2da,           #f2e2da,           #f2e2da,           #663d2b, #99461e, #382218, #e54c00, #000000, #e54c00, #f2e2da,            #99461e, #f2e2da,           #382218, #f2e2da
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#f2e2da,          #663d2b, #99461e, #cbc7c4, #9f9d9a, #b8b5b2, #f2e2da,           #ff0000, #f2e2da, #663d2b, #99461e, #767472, #e54c00, #000000, #e54c00, #f2e2da,            #99461e, #f2e2da,           382218, #f2e2da
+#disabled_colors=#dbbbab, #663d2b, #99461e, #cbc7c4, #9f9d9a, #b8b5b2, #cfb8ae,  #ffec17, #f2e2da, #663d2b, #99461e, #767472, #e54c00, #000000, #e54c00, #dbbbab,   #99461e, #dbbbab,  #382218, #c3b2a9
+#inactive_colors=#f2e2da,          #663d2b, #99461e, #cbc7c4, #9f9d9a, #b8b5b2, #f2e2da,           #ff9040, #f2e2da, #663d2b, #99461e, #767472, #e54c00, #000000, #e54c00, #f2e2da,            #99461e, #f2e2da,           #382218, #f2e2da

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Gold-Spice.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Gold-Spice;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Gold-Spice/info.json
+++ b/Cinnamox-Gold-Spice/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Gold-Spice", 
-	"description": "Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Gold-Spice features a golden orange colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Heather
 
-Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Heather
 
-Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Heather */
 /* Transparency: None */
-/* Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #0c1419;
+    color: #ce7575;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #cecd93;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #ce7575;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Heather. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Heather
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/gtkrc
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#99b0bf\nbg_color:#b7c4cc\ntooltip_bg_color:#b7c4cc\nselected_bg_color:#386b8c\ntext_color:#0c1419\nfg_color:#0c1419\ntooltip_fg_color:#0c1419\nselected_fg_color:#ffffff\nmenubar_bg_color:#72a0bf\nmenubar_fg_color:#0c1419\ntoolbar_bg_color:#b7c4cc\ntoolbar_fg_color:#0c1419\nmenu_bg_color:#72a0bf\nmenu_fg_color:#0c1419\npanel_bg_color:#b7c4cc\npanel_fg_color:#0c1419\nlink_color:#386b8c\nbtn_bg_color:#99b0bf\nbtn_fg_color:#0c1419\ntitlebar_bg_color:#72a0bf\ntitlebar_fg_color:#0c1419\nprimary_caret_color:#0c1419\nsecondary_caret_color:#0c1419\n"
+"base_color:#99b0bf\nbg_color:#b7c4cc\ntooltip_bg_color:#b7c4cc\nselected_bg_color:#386b8c\ntext_color:#0c1419\nfg_color:#0c1419\ntooltip_fg_color:#0c1419\nselected_fg_color:#ffffff\nmenubar_bg_color:#72a0bf\nmenubar_fg_color:#0c1419\ntoolbar_bg_color:#b7c4cc\ntoolbar_fg_color:#0c1419\nmenu_bg_color:#72a0bf\nmenu_fg_color:#0c1419\npanel_bg_color:#b7c4cc\npanel_fg_color:#0c1419\nlink_color:#243d4c\nbtn_bg_color:#99b0bf\nbtn_fg_color:#0c1419\ntitlebar_bg_color:#72a0bf\ntitlebar_fg_color:#0c1419\nprimary_caret_color:#0c1419\nsecondary_caret_color:#0c1419\naccent_bg_color:#386b8c\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#99b0bf\nbg_color:#b7c4cc\ntooltip_bg_color:#b7c4cc\nselected_bg_color:#386b8c\ntext_color:#0c1419\nfg_color:#0c1419\ntooltip_fg_color:#0c1419\nselected_fg_color:#ffffff\nmenubar_bg_color:#72a0bf\nmenubar_fg_color:#0c1419\ntoolbar_bg_color:#b7c4cc\ntoolbar_fg_color:#0c1419\nmenu_bg_color:#72a0bf\nmenu_fg_color:#0c1419\npanel_bg_color:#b7c4cc\npanel_fg_color:#0c1419\nlink_color:#386b8c\nbtn_bg_color:#99b0bf\nbtn_fg_color:#0c1419\ntitlebar_bg_color:#72a0bf\ntitlebar_fg_color:#0c1419\n"
+"base_color:#99b0bf\nbg_color:#b7c4cc\ntooltip_bg_color:#b7c4cc\nselected_bg_color:#386b8c\ntext_color:#0c1419\nfg_color:#0c1419\ntooltip_fg_color:#0c1419\nselected_fg_color:#ffffff\nmenubar_bg_color:#72a0bf\nmenubar_fg_color:#0c1419\ntoolbar_bg_color:#b7c4cc\ntoolbar_fg_color:#0c1419\nmenu_bg_color:#72a0bf\nmenu_fg_color:#0c1419\npanel_bg_color:#b7c4cc\npanel_fg_color:#0c1419\nlink_color:#243d4c\nbtn_bg_color:#99b0bf\nbtn_fg_color:#0c1419\ntitlebar_bg_color:#72a0bf\ntitlebar_fg_color:#0c1419\nprimary_caret_color:#0c1419\nsecondary_caret_color:#0c1419\naccent_bg_color:#386b8c\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.0/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #020405;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #ffffff;
-@define-color info_bg_color #386b8c;
+@define-color info_bg_color #70bcff;
 @define-color warning_fg_color #ffffff;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #cecd93;
 @define-color question_fg_color #ffffff;
-@define-color question_bg_color #386b8c;
+@define-color question_bg_color #70bcff;
 @define-color error_fg_color #ffffff;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#386b8c,#0c1419,0.6);
-@define-color success_color #386b8c;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #ce7575;
+@define-color link_color #243d4c;
+@define-color success_color #90f395;
+@define-color warning_color #cecd93;
+@define-color error_color #ce7575;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#386b8c,#0c1419,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#386b8c,#0c1419,0.6);
-  -GtkWidget-link-color: mix(#386b8c,#0c1419,0.6);
-  -GtkWidget-visited-link-color: mix(#386b8c,#0c1419,0.6); }
+  -GtkHTML-link-color: #243d4c;
+  -GtkIMHtml-hyperlink-color: #243d4c;
+  -GtkWidget-link-color: #243d4c;
+  -GtkWidget-visited-link-color: #243d4c; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#386b8c,#0c1419,0.6); }
+    color: #243d4c; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#386b8c,#0c1419,0.6); }
+    color: #243d4c; }
 
 .background {
   background-color: #b7c4cc;
@@ -898,45 +898,45 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #386b8c;
-  background-image: linear-gradient(to bottom, #4686af, #2a5069);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #90f395;
+  background-image: linear-gradient(to bottom, #e7fce8, #39ea42);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:active:hover, .suggested-action.button:active:focus, .suggested-action.button:active:hover:focus, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button:checked:hover, .suggested-action.button:checked:focus, .suggested-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:insensitive, .selection-mode.header-bar .button.suggested-action:insensitive, .selection-mode.toolbar .button.suggested-action:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(56, 107, 140, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(144, 243, 149, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:active, .suggested-action.button.flat:active:hover, .suggested-action.button.flat:active:focus, .suggested-action.button.flat:active:hover:focus, .suggested-action.button.flat:checked, .suggested-action.button.flat:checked:hover, .suggested-action.button.flat:checked:focus, .suggested-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #4380a8;
-    background-image: linear-gradient(to bottom, #659dc1, #32607e);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    background-color: #d6fbd8;
+    background-image: linear-gradient(to bottom, white, #6def74);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:active, .suggested-action.button:focus:active:hover, .suggested-action.button:focus:active:focus, .suggested-action.button:focus:active:hover:focus, .suggested-action.button:focus:checked, .suggested-action.button:focus:checked:hover, .suggested-action.button:focus:checked:focus, .suggested-action.button:focus:checked:hover:focus, .suggested-action.button:hover:active, .suggested-action.button:hover:active:hover, .suggested-action.button:hover:active:focus, .suggested-action.button:hover:active:hover:focus, .suggested-action.button:hover:checked, .suggested-action.button:hover:checked:hover, .suggested-action.button:hover:checked:focus, .suggested-action.button:hover:checked:hover:focus, .suggested-action.button.flat:focus:active, .suggested-action.button.flat:focus:active:hover, .suggested-action.button.flat:focus:active:focus, .suggested-action.button.flat:focus:active:hover:focus, .suggested-action.button.flat:focus:checked, .suggested-action.button.flat:focus:checked:hover, .suggested-action.button.flat:focus:checked:focus, .suggested-action.button.flat:focus:checked:hover:focus, .suggested-action.button.flat:hover:active, .suggested-action.button.flat:hover:active:hover, .suggested-action.button.flat:hover:active:focus, .suggested-action.button.flat:hover:active:hover:focus, .suggested-action.button.flat:hover:checked, .suggested-action.button.flat:hover:checked:hover, .suggested-action.button.flat:hover:checked:focus, .suggested-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:insensitive, .suggested-action.button:hover:insensitive, .suggested-action.button.flat:focus:insensitive, .suggested-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:active:insensitive, .suggested-action.button:focus:checked:insensitive, .suggested-action.button:hover:active:insensitive, .suggested-action.button:hover:checked:insensitive, .suggested-action.button.flat:focus:active:insensitive, .suggested-action.button.flat:focus:checked:insensitive, .suggested-action.button.flat:hover:active:insensitive, .suggested-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button.flat:active, .suggested-action.button.flat:checked {
     background-color: #32607e;
     background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -949,69 +949,69 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #ffffff; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #32607e;
-    background-image: linear-gradient(to bottom, #3f789e, #26485f);
+    background-color: #6def74;
+    background-image: linear-gradient(to bottom, #bcf8bf, #1ee729);
     color: #ffffff;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: rgba(56, 107, 140, 0.3);
-    background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.3), rgba(42, 80, 105, 0.3));
-    color: mix(#386b8c,#ffffff,0.5);
+    background-color: #7ff184;
+    background-image: linear-gradient(to bottom, #d1fad4, #2ce835);
+    color: mix(#90f395,#ffffff,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #ffffff; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#386b8c,#ffffff,0.5);
+    color: mix(#90f395,#ffffff,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #32607e; }
+    color: #6def74; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #305b77; }
+      color: #5ced63; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #ce7575;
+  background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   .destructive-action.button:focus, .destructive-action.button:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active, .destructive-action.button:active:hover, .destructive-action.button:active:focus, .destructive-action.button:active:hover:focus, .destructive-action.button:checked, .destructive-action.button:checked:hover, .destructive-action.button:checked:focus, .destructive-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button.flat {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(206, 117, 117, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active, .destructive-action.button.flat:active:hover, .destructive-action.button.flat:active:focus, .destructive-action.button.flat:active:hover:focus, .destructive-action.button.flat:checked, .destructive-action.button.flat:checked:hover, .destructive-action.button.flat:checked:focus, .destructive-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    background-color: #dfa5a5;
+    background-image: linear-gradient(to bottom, #f8ecec, #c65d5d);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active, .destructive-action.button:focus:active:hover, .destructive-action.button:focus:active:focus, .destructive-action.button:focus:active:hover:focus, .destructive-action.button:focus:checked, .destructive-action.button:focus:checked:hover, .destructive-action.button:focus:checked:focus, .destructive-action.button:focus:checked:hover:focus, .destructive-action.button:hover:active, .destructive-action.button:hover:active:hover, .destructive-action.button:hover:active:focus, .destructive-action.button:hover:active:hover:focus, .destructive-action.button:hover:checked, .destructive-action.button:hover:checked:hover, .destructive-action.button:hover:checked:focus, .destructive-action.button:hover:checked:hover:focus, .destructive-action.button.flat:focus:active, .destructive-action.button.flat:focus:active:hover, .destructive-action.button.flat:focus:active:focus, .destructive-action.button.flat:focus:active:hover:focus, .destructive-action.button.flat:focus:checked, .destructive-action.button.flat:focus:checked:hover, .destructive-action.button.flat:focus:checked:focus, .destructive-action.button.flat:focus:checked:hover:focus, .destructive-action.button.flat:hover:active, .destructive-action.button.flat:hover:active:hover, .destructive-action.button.flat:hover:active:focus, .destructive-action.button.flat:hover:active:hover:focus, .destructive-action.button.flat:hover:checked, .destructive-action.button.flat:hover:checked:hover, .destructive-action.button.flat:hover:checked:focus, .destructive-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:insensitive, .destructive-action.button:hover:insensitive, .destructive-action.button.flat:focus:insensitive, .destructive-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active:insensitive, .destructive-action.button:focus:checked:insensitive, .destructive-action.button:hover:active:insensitive, .destructive-action.button:hover:checked:insensitive, .destructive-action.button.flat:focus:active:insensitive, .destructive-action.button.flat:focus:checked:insensitive, .destructive-action.button.flat:hover:active:insensitive, .destructive-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:active, .destructive-action.button:checked, .destructive-action.button.flat:active, .destructive-action.button.flat:checked {
     background-color: #32607e;
     background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #ffffff; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #c65d5d;
+    background-image: linear-gradient(to bottom, #d99393, #a13939);
     color: #ffffff;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#ffffff,0.5);
+    background-color: #ca6969;
+    background-image: linear-gradient(to bottom, #dea2a2, #aa3c3c);
+    color: mix(#ce7575,#ffffff,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #ffffff; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#ffffff,0.5);
+    color: mix(#ce7575,#ffffff,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #c65d5d; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #c15151; }
 
 /******************
 * selection mode *
@@ -1424,51 +1424,51 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #386b8c;
-  background-image: linear-gradient(to bottom, #4686af, #2a5069);
-  border: 1px solid #2d5670;
+  background-color: #70bcff;
+  background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+  border: 1px solid #279aff;
   color: #ffffff; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .info .button:focus, .info .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:active, .info .button:active:hover, .info .button:active:focus, .info .button:active:hover:focus, .info .button:checked, .info .button:checked:hover, .info .button:checked:focus, .info .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:active:insensitive, .info .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(56, 107, 140, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(112, 188, 255, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:active, .info .button.flat:active:hover, .info .button.flat:active:focus, .info .button.flat:active:hover:focus, .info .button.flat:checked, .info .button.flat:checked:hover, .info .button.flat:checked:focus, .info .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #4380a8;
-      background-image: linear-gradient(to bottom, #659dc1, #32607e);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      background-color: #b9deff;
+      background-image: linear-gradient(to bottom, white, #4babff);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:active, .info .button:focus:active:hover, .info .button:focus:active:focus, .info .button:focus:active:hover:focus, .info .button:focus:checked, .info .button:focus:checked:hover, .info .button:focus:checked:focus, .info .button:focus:checked:hover:focus, .info .button:hover:active, .info .button:hover:active:hover, .info .button:hover:active:focus, .info .button:hover:active:hover:focus, .info .button:hover:checked, .info .button:hover:checked:hover, .info .button:hover:checked:focus, .info .button:hover:checked:hover:focus, .info .button.flat:focus:active, .info .button.flat:focus:active:hover, .info .button.flat:focus:active:focus, .info .button.flat:focus:active:hover:focus, .info .button.flat:focus:checked, .info .button.flat:focus:checked:hover, .info .button.flat:focus:checked:focus, .info .button.flat:focus:checked:hover:focus, .info .button.flat:hover:active, .info .button.flat:hover:active:hover, .info .button.flat:hover:active:focus, .info .button.flat:hover:active:hover:focus, .info .button.flat:hover:checked, .info .button.flat:hover:checked:hover, .info .button.flat:hover:checked:focus, .info .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:insensitive, .info .button:hover:insensitive, .info .button.flat:focus:insensitive, .info .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:active:insensitive, .info .button:focus:checked:insensitive, .info .button:hover:active:insensitive, .info .button:hover:checked:insensitive, .info .button.flat:focus:active:insensitive, .info .button.flat:focus:checked:insensitive, .info .button.flat:hover:active:insensitive, .info .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .info .button:active, .info .button:checked, .info .button.flat:active, .info .button.flat:checked {
       background-color: #32607e;
       background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -1481,74 +1481,74 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #ffffff; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #32607e;
-      background-image: linear-gradient(to bottom, #3f789e, #26485f);
+      background-color: #4babff;
+      background-image: linear-gradient(to bottom, #9ed1ff, #0084f8);
       color: #ffffff;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: rgba(56, 107, 140, 0.3);
-      background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.3), rgba(42, 80, 105, 0.3));
-      color: mix(#386b8c,#ffffff,0.5);
+      background-color: #5eb3ff;
+      background-image: linear-gradient(to bottom, #b5dcff, #068bff);
+      color: mix(#70bcff,#ffffff,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #ffffff; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#386b8c,#ffffff,0.5);
+      color: mix(#70bcff,#ffffff,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #32607e; }
+      color: #4babff; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #305b77; }
+        color: #39a2ff; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #cecd93;
+  background-image: linear-gradient(to bottom, #eae9d0, #b2b156);
+  border: 1px solid #b8b762;
   color: #ffffff; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #cecd93;
+    background-image: linear-gradient(to bottom, #eae9d0, #b2b156);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .warning .button:focus, .warning .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active, .warning .button:active:hover, .warning .button:active:focus, .warning .button:active:hover:focus, .warning .button:checked, .warning .button:checked:hover, .warning .button:checked:focus, .warning .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active:insensitive, .warning .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(206, 205, 147, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active, .warning .button.flat:active:hover, .warning .button.flat:active:focus, .warning .button.flat:active:hover:focus, .warning .button.flat:checked, .warning .button.flat:checked:hover, .warning .button.flat:checked:focus, .warning .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      background-color: #e4e3c4;
+      background-image: linear-gradient(to bottom, white, #c3c27b);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active, .warning .button:focus:active:hover, .warning .button:focus:active:focus, .warning .button:focus:active:hover:focus, .warning .button:focus:checked, .warning .button:focus:checked:hover, .warning .button:focus:checked:focus, .warning .button:focus:checked:hover:focus, .warning .button:hover:active, .warning .button:hover:active:hover, .warning .button:hover:active:focus, .warning .button:hover:active:hover:focus, .warning .button:hover:checked, .warning .button:hover:checked:hover, .warning .button:hover:checked:focus, .warning .button:hover:checked:hover:focus, .warning .button.flat:focus:active, .warning .button.flat:focus:active:hover, .warning .button.flat:focus:active:focus, .warning .button.flat:focus:active:hover:focus, .warning .button.flat:focus:checked, .warning .button.flat:focus:checked:hover, .warning .button.flat:focus:checked:focus, .warning .button.flat:focus:checked:hover:focus, .warning .button.flat:hover:active, .warning .button.flat:hover:active:hover, .warning .button.flat:hover:active:focus, .warning .button.flat:hover:active:hover:focus, .warning .button.flat:hover:checked, .warning .button.flat:hover:checked:hover, .warning .button.flat:hover:checked:focus, .warning .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:insensitive, .warning .button:hover:insensitive, .warning .button.flat:focus:insensitive, .warning .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active:insensitive, .warning .button:focus:checked:insensitive, .warning .button:hover:active:insensitive, .warning .button:hover:checked:insensitive, .warning .button.flat:focus:active:insensitive, .warning .button.flat:focus:checked:insensitive, .warning .button.flat:hover:active:insensitive, .warning .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:active, .warning .button:checked, .warning .button.flat:active, .warning .button.flat:checked {
       background-color: #32607e;
       background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -1561,74 +1561,74 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #ffffff; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #c3c27b;
+      background-image: linear-gradient(to bottom, #dcdbb1, #a4a24a);
       color: #ffffff;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#ffffff,0.5);
+      background-color: #c8c787;
+      background-image: linear-gradient(to bottom, #e3e2c1, #adab4e);
+      color: mix(#cecd93,#ffffff,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #ffffff; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#ffffff,0.5);
+      color: mix(#cecd93,#ffffff,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #c3c27b; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #bdbc6f; }
 
 .question {
-  background-color: #386b8c;
-  background-image: linear-gradient(to bottom, #4686af, #2a5069);
-  border: 1px solid #2d5670;
+  background-color: #70bcff;
+  background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+  border: 1px solid #279aff;
   color: #ffffff; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .question .button:focus, .question .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:active, .question .button:active:hover, .question .button:active:focus, .question .button:active:hover:focus, .question .button:checked, .question .button:checked:hover, .question .button:checked:focus, .question .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:active:insensitive, .question .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(56, 107, 140, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(112, 188, 255, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:active, .question .button.flat:active:hover, .question .button.flat:active:focus, .question .button.flat:active:hover:focus, .question .button.flat:checked, .question .button.flat:checked:hover, .question .button.flat:checked:focus, .question .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #4380a8;
-      background-image: linear-gradient(to bottom, #659dc1, #32607e);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      background-color: #b9deff;
+      background-image: linear-gradient(to bottom, white, #4babff);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:active, .question .button:focus:active:hover, .question .button:focus:active:focus, .question .button:focus:active:hover:focus, .question .button:focus:checked, .question .button:focus:checked:hover, .question .button:focus:checked:focus, .question .button:focus:checked:hover:focus, .question .button:hover:active, .question .button:hover:active:hover, .question .button:hover:active:focus, .question .button:hover:active:hover:focus, .question .button:hover:checked, .question .button:hover:checked:hover, .question .button:hover:checked:focus, .question .button:hover:checked:hover:focus, .question .button.flat:focus:active, .question .button.flat:focus:active:hover, .question .button.flat:focus:active:focus, .question .button.flat:focus:active:hover:focus, .question .button.flat:focus:checked, .question .button.flat:focus:checked:hover, .question .button.flat:focus:checked:focus, .question .button.flat:focus:checked:hover:focus, .question .button.flat:hover:active, .question .button.flat:hover:active:hover, .question .button.flat:hover:active:focus, .question .button.flat:hover:active:hover:focus, .question .button.flat:hover:checked, .question .button.flat:hover:checked:hover, .question .button.flat:hover:checked:focus, .question .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:insensitive, .question .button:hover:insensitive, .question .button.flat:focus:insensitive, .question .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:active:insensitive, .question .button:focus:checked:insensitive, .question .button:hover:active:insensitive, .question .button:hover:checked:insensitive, .question .button.flat:focus:active:insensitive, .question .button.flat:focus:checked:insensitive, .question .button.flat:hover:active:insensitive, .question .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .question .button:active, .question .button:checked, .question .button.flat:active, .question .button.flat:checked {
       background-color: #32607e;
       background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -1641,74 +1641,74 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #ffffff; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #32607e;
-      background-image: linear-gradient(to bottom, #3f789e, #26485f);
+      background-color: #4babff;
+      background-image: linear-gradient(to bottom, #9ed1ff, #0084f8);
       color: #ffffff;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: rgba(56, 107, 140, 0.3);
-      background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.3), rgba(42, 80, 105, 0.3));
-      color: mix(#386b8c,#ffffff,0.5);
+      background-color: #5eb3ff;
+      background-image: linear-gradient(to bottom, #b5dcff, #068bff);
+      color: mix(#70bcff,#ffffff,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #ffffff; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#386b8c,#ffffff,0.5);
+      color: mix(#70bcff,#ffffff,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #32607e; }
+      color: #4babff; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #305b77; }
+        color: #39a2ff; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #ce7575;
+  background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
+  border: 1px solid #bd4545;
   color: #ffffff; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #ce7575;
+    background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .error .button:focus, .error .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active, .error .button:active:hover, .error .button:active:focus, .error .button:active:hover:focus, .error .button:checked, .error .button:checked:hover, .error .button:checked:focus, .error .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active:insensitive, .error .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(206, 117, 117, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active, .error .button.flat:active:hover, .error .button.flat:active:focus, .error .button.flat:active:hover:focus, .error .button.flat:checked, .error .button.flat:checked:hover, .error .button.flat:checked:focus, .error .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      background-color: #dfa5a5;
+      background-image: linear-gradient(to bottom, #f8ecec, #c65d5d);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active, .error .button:focus:active:hover, .error .button:focus:active:focus, .error .button:focus:active:hover:focus, .error .button:focus:checked, .error .button:focus:checked:hover, .error .button:focus:checked:focus, .error .button:focus:checked:hover:focus, .error .button:hover:active, .error .button:hover:active:hover, .error .button:hover:active:focus, .error .button:hover:active:hover:focus, .error .button:hover:checked, .error .button:hover:checked:hover, .error .button:hover:checked:focus, .error .button:hover:checked:hover:focus, .error .button.flat:focus:active, .error .button.flat:focus:active:hover, .error .button.flat:focus:active:focus, .error .button.flat:focus:active:hover:focus, .error .button.flat:focus:checked, .error .button.flat:focus:checked:hover, .error .button.flat:focus:checked:focus, .error .button.flat:focus:checked:hover:focus, .error .button.flat:hover:active, .error .button.flat:hover:active:hover, .error .button.flat:hover:active:focus, .error .button.flat:hover:active:hover:focus, .error .button.flat:hover:checked, .error .button.flat:hover:checked:hover, .error .button.flat:hover:checked:focus, .error .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:insensitive, .error .button:hover:insensitive, .error .button.flat:focus:insensitive, .error .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active:insensitive, .error .button:focus:checked:insensitive, .error .button:hover:active:insensitive, .error .button:hover:checked:insensitive, .error .button.flat:focus:active:insensitive, .error .button.flat:focus:checked:insensitive, .error .button.flat:hover:active:insensitive, .error .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .error .button:active, .error .button:checked, .error .button.flat:active, .error .button.flat:checked {
       background-color: #32607e;
       background-image: linear-gradient(to top, #3f789e, #26485f);
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #ffffff; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #c65d5d;
+      background-image: linear-gradient(to bottom, #d99393, #a13939);
       color: #ffffff;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#ffffff,0.5);
+      background-color: #ca6969;
+      background-image: linear-gradient(to bottom, #dea2a2, #aa3c3c);
+      color: mix(#ce7575,#ffffff,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #ffffff; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#ffffff,0.5);
+      color: mix(#ce7575,#ffffff,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #c65d5d; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #c15151; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #386b8c;
+    background-color: #90f395;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #cecd93;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #ce7575; }
 
 .view, GtkHTML {
   color: #0c1419;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #6f8fa4;
   background-color: #99b0bf; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #ce7575;
     background-image: none;
     color: #ffffff; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #bd4545;
+  background-color: #d58888;
   background-image: none;
   color: #ffffff; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a73b3b;
+    background-color: #ce7575; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #b8b762;
+  background-color: #d7d6a6;
   background-image: none;
   color: #ffffff; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #aaa84d;
+    background-color: #cecd93; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #020405;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #ffffff;
-@define-color info_bg_color #386b8c;
+@define-color info_bg_color #70bcff;
 @define-color warning_fg_color #ffffff;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #cecd93;
 @define-color question_fg_color #ffffff;
-@define-color question_bg_color #386b8c;
+@define-color question_bg_color #70bcff;
 @define-color error_fg_color #ffffff;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#386b8c,#0c1419,0.6);
-@define-color success_color #386b8c;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #ce7575;
+@define-color link_color #243d4c;
+@define-color success_color #90f395;
+@define-color warning_color #cecd93;
+@define-color error_color #ce7575;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#386b8c,#0c1419,0.6); }
+  -GtkIMHtml-hyperlink-color: #243d4c; }
   *:disabled, *:disabled:disabled {
-    color: mix(#386b8c,#0c1419,0.6); }
+    color: #243d4c; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#386b8c,#0c1419,0.6); }
+    color: #243d4c; }
 
 .background {
   background-color: #b7c4cc;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #b8b762;
+    background-color: mix(#99b0bf,#cecd93,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #ffffff; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#cecd93,0.3);
+      background-color: #cecd93;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #cecd93; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #bd4545;
+    background-color: mix(#99b0bf,#ce7575,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #ffffff; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#ce7575,0.3);
+      background-color: #ce7575;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce7575; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #bd4545;
+    background-color: mix(#99b0bf,#ce7575,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #ffffff; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#ce7575,0.3);
+      background-color: #ce7575;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce7575; }
 
 entry {
   background-color: #99b0bf;
@@ -1727,11 +1727,11 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #386b8c;
-  background-image: linear-gradient(to bottom, #4686af, #2a5069);
+  background-color: #90f395;
+  background-image: linear-gradient(to bottom, #e7fce8, #39ea42);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover {
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(56, 107, 140, 0);
+    background-color: rgba(144, 243, 149, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,11 +1870,11 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #3b7093;
-    background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+    background-color: #a1f5a6;
+    background-image: linear-gradient(to bottom, #fdfffd, #46eb4e);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
     .suggested-action:hover:focus,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:focus, .suggested-action:hover:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:hover, .suggested-action.flat:hover:focus, .suggested-action.flat:hover:hover {
@@ -1891,21 +1891,21 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #3b7093;
-    background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+    background-color: #a1f5a6;
+    background-image: linear-gradient(to bottom, #fdfffd, #46eb4e);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 107, 140, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #3e769a;
-      background-image: linear-gradient(to bottom, #5392ba, #2e5874);
+      background-color: #b3f7b6;
+      background-image: linear-gradient(to bottom, white, #53ec5b);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       .suggested-action:focus:hover:active, .suggested-action:focus:hover:active:hover, .suggested-action:focus:hover:active:focus, .suggested-action:focus:hover:active:hover:focus, .suggested-action:focus:hover:checked, .suggested-action:focus:hover:checked:hover, .suggested-action:focus:hover:checked:focus, .suggested-action:focus:hover:checked:hover:focus, .suggested-action.flat:focus:hover:active, .suggested-action.flat:focus:hover:active:hover, .suggested-action.flat:focus:hover:active:focus, .suggested-action.flat:focus:hover:active:hover:focus, .suggested-action.flat:focus:hover:checked, .suggested-action.flat:focus:hover:checked:hover, .suggested-action.flat:focus:hover:checked:focus, .suggested-action.flat:focus:hover:checked:hover:focus {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #ffffff; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#386b8c,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#90f395,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#90f395,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#90f395,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#386b8c,#ffffff,0.6);
+    color: mix(#90f395,#ffffff,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#386b8c,#ffffff,0.6); }
+      color: mix(#90f395,#ffffff,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,18 +1981,18 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(56, 107, 140, 0.9); }
+    color: rgba(144, 243, 149, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(56, 107, 140, 0.85); }
+      color: rgba(144, 243, 149, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #ce7575;
+  background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   .destructive-action:focus, .destructive-action:hover {
     border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
   .destructive-action:active, .destructive-action:active:hover, .destructive-action:active:focus, .destructive-action:active:hover:focus, .destructive-action:checked, .destructive-action:checked:hover, .destructive-action:checked:focus, .destructive-action:checked:hover:focus {
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(206, 117, 117, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,11 +2056,11 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d28181;
+    background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
     .destructive-action:hover:focus, .destructive-action:hover:hover, .destructive-action.flat:hover:focus, .destructive-action.flat:hover:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
     .destructive-action:hover:active, .destructive-action:hover:active:hover, .destructive-action:hover:active:focus, .destructive-action:hover:active:hover:focus, .destructive-action:hover:checked, .destructive-action:hover:checked:hover, .destructive-action:hover:checked:focus, .destructive-action:hover:checked:hover:focus, .destructive-action.flat:hover:active, .destructive-action.flat:hover:active:hover, .destructive-action.flat:hover:active:focus, .destructive-action.flat:hover:active:hover:focus, .destructive-action.flat:hover:checked, .destructive-action.flat:hover:checked:hover, .destructive-action.flat:hover:checked:focus, .destructive-action.flat:hover:checked:hover:focus {
@@ -2070,20 +2070,20 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d28181;
+    background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 107, 140, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #d68d8d;
+      background-image: linear-gradient(to bottom, #eecece, #bf4b4b);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       .destructive-action:focus:hover:active, .destructive-action:focus:hover:active:hover, .destructive-action:focus:hover:active:focus, .destructive-action:focus:hover:active:hover:focus, .destructive-action:focus:hover:checked, .destructive-action:focus:hover:checked:hover, .destructive-action:focus:hover:checked:focus, .destructive-action:focus:hover:checked:hover:focus, .destructive-action.flat:focus:hover:active, .destructive-action.flat:focus:hover:active:hover, .destructive-action.flat:focus:hover:active:focus, .destructive-action.flat:focus:hover:active:hover:focus, .destructive-action.flat:focus:hover:checked, .destructive-action.flat:focus:hover:checked:hover, .destructive-action.flat:focus:hover:checked:focus, .destructive-action.flat:focus:hover:checked:hover:focus {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #ffffff; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#ce7575,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#ce7575,#ffffff,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#ce7575,#ffffff,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(56, 107, 140, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(255, 255, 255, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(206, 117, 117, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(206, 117, 117, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,18 +3202,18 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
-    border: 1px solid #2d5670;
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+    border: 1px solid #279aff;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #ffffff; }
   infobar.info button {
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     infobar.info button:focus, infobar.info button:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
     infobar.info button:active, infobar.info button:active:hover, infobar.info button:active:focus, infobar.info button:active:hover:focus, infobar.info button:checked, infobar.info button:checked:hover, infobar.info button:checked:focus, infobar.info button:checked:hover:focus {
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(56, 107, 140, 0);
+      background-color: rgba(112, 188, 255, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,11 +3277,11 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #3b7093;
-      background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+      background-color: #82c5ff;
+      background-image: linear-gradient(to bottom, #e3f2ff, #2297ff);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
       infobar.info button:hover:focus, infobar.info button:hover:hover, infobar.info button.flat:hover:focus, infobar.info button.flat:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       infobar.info button:hover:active, infobar.info button:hover:active:hover, infobar.info button:hover:active:focus, infobar.info button:hover:active:hover:focus, infobar.info button:hover:checked, infobar.info button:hover:checked:hover, infobar.info button:hover:checked:focus, infobar.info button:hover:checked:hover:focus, infobar.info button.flat:hover:active, infobar.info button.flat:hover:active:hover, infobar.info button.flat:hover:active:focus, infobar.info button.flat:hover:active:hover:focus, infobar.info button.flat:hover:checked, infobar.info button.flat:hover:checked:hover, infobar.info button.flat:hover:checked:focus, infobar.info button.flat:hover:checked:hover:focus {
@@ -3291,20 +3291,20 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #3b7093;
-      background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+      background-color: #82c5ff;
+      background-image: linear-gradient(to bottom, #e3f2ff, #2297ff);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 107, 140, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #3e769a;
-        background-image: linear-gradient(to bottom, #5392ba, #2e5874);
+        background-color: #95cdff;
+        background-image: linear-gradient(to bottom, #fafcff, #309eff);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
           border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
         infobar.info button:focus:hover:active, infobar.info button:focus:hover:active:hover, infobar.info button:focus:hover:active:focus, infobar.info button:focus:hover:active:hover:focus, infobar.info button:focus:hover:checked, infobar.info button:focus:hover:checked:hover, infobar.info button:focus:hover:checked:focus, infobar.info button:focus:hover:checked:hover:focus, infobar.info button.flat:focus:hover:active, infobar.info button.flat:focus:hover:active:hover, infobar.info button.flat:focus:hover:active:focus, infobar.info button.flat:focus:hover:active:hover:focus, infobar.info button.flat:focus:hover:checked, infobar.info button.flat:focus:hover:checked:hover, infobar.info button.flat:focus:hover:checked:focus, infobar.info button.flat:focus:hover:checked:hover:focus {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #ffffff; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#386b8c,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#70bcff,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#70bcff,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#70bcff,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#386b8c,#ffffff,0.6);
+      color: mix(#70bcff,#ffffff,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#386b8c,#ffffff,0.6); }
+        color: mix(#70bcff,#ffffff,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -3353,22 +3353,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(56, 107, 140, 0.9); }
+      color: rgba(112, 188, 255, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(56, 107, 140, 0.85); }
+        color: rgba(112, 188, 255, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #cecd93;
+    background-image: linear-gradient(to bottom, #eae9d0, #b2b156);
+    border: 1px solid #b8b762;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #ffffff; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #cecd93;
+    background-image: linear-gradient(to bottom, #eae9d0, #b2b156);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     infobar.warning button:focus, infobar.warning button:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
     infobar.warning button:active, infobar.warning button:active:hover, infobar.warning button:active:focus, infobar.warning button:active:hover:focus, infobar.warning button:checked, infobar.warning button:checked:hover, infobar.warning button:checked:focus, infobar.warning button:checked:hover:focus {
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(206, 205, 147, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,11 +3432,11 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d4d39f;
+      background-image: linear-gradient(to bottom, #f0f0df, #b7b55f);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
       infobar.warning button:hover:focus, infobar.warning button:hover:hover, infobar.warning button.flat:hover:focus, infobar.warning button.flat:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       infobar.warning button:hover:active, infobar.warning button:hover:active:hover, infobar.warning button:hover:active:focus, infobar.warning button:hover:active:hover:focus, infobar.warning button:hover:checked, infobar.warning button:hover:checked:hover, infobar.warning button:hover:checked:focus, infobar.warning button:hover:checked:hover:focus, infobar.warning button.flat:hover:active, infobar.warning button.flat:hover:active:hover, infobar.warning button.flat:hover:active:focus, infobar.warning button.flat:hover:active:hover:focus, infobar.warning button.flat:hover:checked, infobar.warning button.flat:hover:checked:hover, infobar.warning button.flat:hover:checked:focus, infobar.warning button.flat:hover:checked:hover:focus {
@@ -3446,20 +3446,20 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d4d39f;
+      background-image: linear-gradient(to bottom, #f0f0df, #b7b55f);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 107, 140, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #d9d8ab;
+        background-image: linear-gradient(to bottom, #f7f7ee, #bbb969);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
           border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
         infobar.warning button:focus:hover:active, infobar.warning button:focus:hover:active:hover, infobar.warning button:focus:hover:active:focus, infobar.warning button:focus:hover:active:hover:focus, infobar.warning button:focus:hover:checked, infobar.warning button:focus:hover:checked:hover, infobar.warning button:focus:hover:checked:focus, infobar.warning button:focus:hover:checked:hover:focus, infobar.warning button.flat:focus:hover:active, infobar.warning button.flat:focus:hover:active:hover, infobar.warning button.flat:focus:hover:active:focus, infobar.warning button.flat:focus:hover:active:hover:focus, infobar.warning button.flat:focus:hover:checked, infobar.warning button.flat:focus:hover:checked:hover, infobar.warning button.flat:focus:hover:checked:focus, infobar.warning button.flat:focus:hover:checked:hover:focus {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #ffffff; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#cecd93,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#cecd93,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#cecd93,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#ffffff,0.6);
+      color: mix(#cecd93,#ffffff,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#ffffff,0.6); }
+        color: mix(#cecd93,#ffffff,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -3508,22 +3508,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(206, 205, 147, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(206, 205, 147, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
-    border: 1px solid #2d5670;
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
+    border: 1px solid #279aff;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #ffffff; }
   infobar.question button {
-    background-color: #386b8c;
-    background-image: linear-gradient(to bottom, #4686af, #2a5069);
+    background-color: #70bcff;
+    background-image: linear-gradient(to bottom, #cce7ff, #1491ff);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     infobar.question button:focus, infobar.question button:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
     infobar.question button:active, infobar.question button:active:hover, infobar.question button:active:focus, infobar.question button:active:hover:focus, infobar.question button:checked, infobar.question button:checked:hover, infobar.question button:checked:focus, infobar.question button:checked:hover:focus {
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(56, 107, 140, 0);
+      background-color: rgba(112, 188, 255, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,11 +3587,11 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #3b7093;
-      background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+      background-color: #82c5ff;
+      background-image: linear-gradient(to bottom, #e3f2ff, #2297ff);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
       infobar.question button:hover:focus, infobar.question button:hover:hover, infobar.question button.flat:hover:focus, infobar.question button.flat:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       infobar.question button:hover:active, infobar.question button:hover:active:hover, infobar.question button:hover:active:focus, infobar.question button:hover:active:hover:focus, infobar.question button:hover:checked, infobar.question button:hover:checked:hover, infobar.question button:hover:checked:focus, infobar.question button:hover:checked:hover:focus, infobar.question button.flat:hover:active, infobar.question button.flat:hover:active:hover, infobar.question button.flat:hover:active:focus, infobar.question button.flat:hover:active:hover:focus, infobar.question button.flat:hover:checked, infobar.question button.flat:hover:checked:hover, infobar.question button.flat:hover:checked:focus, infobar.question button.flat:hover:checked:hover:focus {
@@ -3601,20 +3601,20 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #3b7093;
-      background-image: linear-gradient(to bottom, #4a8cb7, #2c546e);
+      background-color: #82c5ff;
+      background-image: linear-gradient(to bottom, #e3f2ff, #2297ff);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 107, 140, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #3e769a;
-        background-image: linear-gradient(to bottom, #5392ba, #2e5874);
+        background-color: #95cdff;
+        background-image: linear-gradient(to bottom, #fafcff, #309eff);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
           border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
         infobar.question button:focus:hover:active, infobar.question button:focus:hover:active:hover, infobar.question button:focus:hover:active:focus, infobar.question button:focus:hover:active:hover:focus, infobar.question button:focus:hover:checked, infobar.question button:focus:hover:checked:hover, infobar.question button:focus:hover:checked:focus, infobar.question button:focus:hover:checked:hover:focus, infobar.question button.flat:focus:hover:active, infobar.question button.flat:focus:hover:active:hover, infobar.question button.flat:focus:hover:active:focus, infobar.question button.flat:focus:hover:active:hover:focus, infobar.question button.flat:focus:hover:checked, infobar.question button.flat:focus:hover:checked:hover, infobar.question button.flat:focus:hover:checked:focus, infobar.question button.flat:focus:hover:checked:hover:focus {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #ffffff; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#386b8c,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#386b8c,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#70bcff,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#70bcff,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#70bcff,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#386b8c,#ffffff,0.6);
+      color: mix(#70bcff,#ffffff,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#386b8c,#ffffff,0.6); }
+        color: mix(#70bcff,#ffffff,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -3663,22 +3663,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(56, 107, 140, 0.9); }
+      color: rgba(112, 188, 255, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(56, 107, 140, 0.85); }
+        color: rgba(112, 188, 255, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #ce7575;
+    background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
+    border: 1px solid #bd4545;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #ffffff; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #ce7575;
+    background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     infobar.error button:focus, infobar.error button:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
     infobar.error button:active, infobar.error button:active:hover, infobar.error button:active:focus, infobar.error button:active:hover:focus, infobar.error button:checked, infobar.error button:checked:hover, infobar.error button:checked:focus, infobar.error button:checked:hover:focus {
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(206, 117, 117, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,11 +3742,11 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d28181;
+      background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
       infobar.error button:hover:focus, infobar.error button:hover:hover, infobar.error button.flat:hover:focus, infobar.error button.flat:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       infobar.error button:hover:active, infobar.error button:hover:active:hover, infobar.error button:hover:active:focus, infobar.error button:hover:active:hover:focus, infobar.error button:hover:checked, infobar.error button:hover:checked:hover, infobar.error button:hover:checked:focus, infobar.error button:hover:checked:hover:focus, infobar.error button.flat:hover:active, infobar.error button.flat:hover:active:hover, infobar.error button.flat:hover:active:focus, infobar.error button.flat:hover:active:hover:focus, infobar.error button.flat:hover:checked, infobar.error button.flat:hover:checked:hover, infobar.error button.flat:hover:checked:focus, infobar.error button.flat:hover:checked:hover:focus {
@@ -3756,20 +3756,20 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d28181;
+      background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 107, 140, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #d68d8d;
+        background-image: linear-gradient(to bottom, #eecece, #bf4b4b);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
           border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
         infobar.error button:focus:hover:active, infobar.error button:focus:hover:active:hover, infobar.error button:focus:hover:active:focus, infobar.error button:focus:hover:active:hover:focus, infobar.error button:focus:hover:checked, infobar.error button:focus:hover:checked:hover, infobar.error button:focus:hover:checked:focus, infobar.error button:focus:hover:checked:hover:focus, infobar.error button.flat:focus:hover:active, infobar.error button.flat:focus:hover:active:hover, infobar.error button.flat:focus:hover:active:focus, infobar.error button.flat:focus:hover:active:hover:focus, infobar.error button.flat:focus:hover:checked, infobar.error button.flat:focus:hover:checked:hover, infobar.error button.flat:focus:hover:checked:focus, infobar.error button.flat:focus:hover:checked:hover:focus {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #ffffff; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#ce7575,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#ffffff,0.6);
+      color: mix(#ce7575,#ffffff,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#ffffff,0.6); }
+        color: mix(#ce7575,#ffffff,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(206, 117, 117, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(206, 117, 117, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #b8b762;
+    background-color: mix(#99b0bf,#cecd93,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #ffffff; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#cecd93,0.3);
+      background-color: #cecd93;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #cecd93; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #bd4545;
+    background-color: mix(#99b0bf,#ce7575,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #ffffff; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#ce7575,0.3);
+      background-color: #ce7575;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce7575; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99b0bf,#ff0000,0.6); }
+    border-color: #bd4545;
+    background-color: mix(#99b0bf,#ce7575,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #ffffff; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #ffffff;
-      border-color: mix(#386b8c,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#386b8c,#ce7575,0.3);
+      background-color: #ce7575;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce7575; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#b7c4cc,#0c1419,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #e2adad; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #386b8c; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #cecd93;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #386b8c;
+    background-color: #90f395;
     border-color: transparent; }
   levelbar block.full {
     background-color: #2d5670;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #6f8fa4;
   background-color: #99b0bf; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #ce7575;
     background-image: none;
     color: #ffffff; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #ffffff;
-  background-color: #ff0000; }
+  background-color: #ce7575; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #d68d8d; }
 
 .conflict-row.activatable:selected {
   color: #ffffff;
@@ -8947,11 +8947,11 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #ce7575;
+  background-image: linear-gradient(to bottom, #e3b1b1, #b33f3f);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   #shutdown_button button:focus, #shutdown_button button:hover {
     border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
   #shutdown_button button:active, #shutdown_button button:active:hover, #shutdown_button button:active:focus, #shutdown_button button:active:hover:focus, #shutdown_button button:checked, #shutdown_button button:checked:hover, #shutdown_button button:checked:focus, #shutdown_button button:checked:hover:focus {
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(206, 117, 117, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,11 +9015,11 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d28181;
+    background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
     #shutdown_button button:hover:focus, #shutdown_button button:hover:hover, #shutdown_button button.flat:hover:focus, #shutdown_button button.flat:hover:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
     #shutdown_button button:hover:active, #shutdown_button button:hover:active:hover, #shutdown_button button:hover:active:focus, #shutdown_button button:hover:active:hover:focus, #shutdown_button button:hover:checked, #shutdown_button button:hover:checked:hover, #shutdown_button button:hover:checked:focus, #shutdown_button button:hover:checked:hover:focus, #shutdown_button button.flat:hover:active, #shutdown_button button.flat:hover:active:hover, #shutdown_button button.flat:hover:active:focus, #shutdown_button button.flat:hover:active:hover:focus, #shutdown_button button.flat:hover:checked, #shutdown_button button.flat:hover:checked:hover, #shutdown_button button.flat:hover:checked:focus, #shutdown_button button.flat:hover:checked:hover:focus {
@@ -9029,20 +9029,20 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d28181;
+    background-image: linear-gradient(to bottom, #e8bfbf, #bc4343);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 107, 140, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #d68d8d;
+      background-image: linear-gradient(to bottom, #eecece, #bf4b4b);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       #shutdown_button button:focus:hover:active, #shutdown_button button:focus:hover:active:hover, #shutdown_button button:focus:hover:active:focus, #shutdown_button button:focus:hover:active:hover:focus, #shutdown_button button:focus:hover:checked, #shutdown_button button:focus:hover:checked:hover, #shutdown_button button:focus:hover:checked:focus, #shutdown_button button:focus:hover:checked:hover:focus, #shutdown_button button.flat:focus:hover:active, #shutdown_button button.flat:focus:hover:active:hover, #shutdown_button button.flat:focus:hover:active:focus, #shutdown_button button.flat:focus:hover:active:hover:focus, #shutdown_button button.flat:focus:hover:checked, #shutdown_button button.flat:focus:hover:checked:hover, #shutdown_button button.flat:focus:hover:checked:focus, #shutdown_button button.flat:focus:hover:checked:hover:focus {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #ffffff; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#ce7575,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce7575,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#ce7575,#ffffff,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#ce7575,#ffffff,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(56, 107, 140, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -9091,17 +9091,17 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(255, 255, 255, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(206, 117, 117, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(206, 117, 117, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #cecd93;
+  background-image: linear-gradient(to bottom, #eae9d0, #b2b156);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
   #restart_button button:focus, #restart_button button:hover {
     border-color: mix(#386b8c,rgba(255, 255, 255, 0.22),0.3); }
   #restart_button button:active, #restart_button button:active:hover, #restart_button button:active:focus, #restart_button button:active:hover:focus, #restart_button button:checked, #restart_button button:checked:hover, #restart_button button:checked:focus, #restart_button button:checked:hover:focus {
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(206, 205, 147, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,11 +9165,11 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d4d39f;
+    background-image: linear-gradient(to bottom, #f0f0df, #b7b55f);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
     #restart_button button:hover:focus, #restart_button button:hover:hover, #restart_button button.flat:hover:focus, #restart_button button.flat:hover:hover {
       border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
     #restart_button button:hover:active, #restart_button button:hover:active:hover, #restart_button button:hover:active:focus, #restart_button button:hover:active:hover:focus, #restart_button button:hover:checked, #restart_button button:hover:checked:hover, #restart_button button:hover:checked:focus, #restart_button button:hover:checked:hover:focus, #restart_button button.flat:hover:active, #restart_button button.flat:hover:active:hover, #restart_button button.flat:hover:active:focus, #restart_button button.flat:hover:active:hover:focus, #restart_button button.flat:hover:checked, #restart_button button.flat:hover:checked:hover, #restart_button button.flat:hover:checked:focus, #restart_button button.flat:hover:checked:hover:focus {
@@ -9179,20 +9179,20 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d4d39f;
+    background-image: linear-gradient(to bottom, #f0f0df, #b7b55f);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 107, 140, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #d9d8ab;
+      background-image: linear-gradient(to bottom, #f7f7ee, #bbb969);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
         border-color: mix(#386b8c,rgba(255, 255, 255, 0.3),0.3); }
       #restart_button button:focus:hover:active, #restart_button button:focus:hover:active:hover, #restart_button button:focus:hover:active:focus, #restart_button button:focus:hover:active:hover:focus, #restart_button button:focus:hover:checked, #restart_button button:focus:hover:checked:hover, #restart_button button:focus:hover:checked:focus, #restart_button button:focus:hover:checked:hover:focus, #restart_button button.flat:focus:hover:active, #restart_button button.flat:focus:hover:active:hover, #restart_button button.flat:focus:hover:active:focus, #restart_button button.flat:focus:hover:active:hover:focus, #restart_button button.flat:focus:hover:checked, #restart_button button.flat:focus:hover:checked:hover, #restart_button button.flat:focus:hover:checked:focus, #restart_button button.flat:focus:hover:checked:hover:focus {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #ffffff; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#cecd93,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#cecd93,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#cecd93,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#cecd93,#ffffff,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#cecd93,#ffffff,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(56, 107, 140, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(255, 255, 255, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(206, 205, 147, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(206, 205, 147, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/info.json
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Heather", 
-	"description": "Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Heather/files/Cinnamox-Heather/qt5ct/Cinnamox-Heather.conf
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/qt5ct/Cinnamox-Heather.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#0c1419,          #b7c4cc, #b7c4cc, #b7c4cc, #72a0bf, #72a0bf, #0c1419,           #0c1419,           #0c1419,           #99b0bf, #b7c4cc, #72a0bf, #386b8c, #ffffff, #386b8c, #0c1419,            #b7c4cc, #0c1419,           72a0bf,  #0c1419
+disabled_colors=#364045, #b7c4cc, #b7c4cc, #b7c4cc, #72a0bf, #72a0bf, #2f3b42,  #2f3b42,  #364045,  #99b0bf, #b7c4cc, #72a0bf, #386b8c, #ffffff, #386b8c, #364045,   #b7c4cc, #364045,  #72a0bf, #253742
+inactive_colors=#0c1419,          #b7c4cc, #b7c4cc, #b7c4cc, #72a0bf, #72a0bf, #0c1419,           #0c1419,           #0c1419,           #99b0bf, #b7c4cc, #72a0bf, #386b8c, #ffffff, #386b8c, #0c1419,            #b7c4cc, #0c1419,           #72a0bf, #0c1419
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#0c1419,          #99b0bf, #b7c4cc, #cbc7c4, #9f9d9a, #b8b5b2, #0c1419,           #ff0000, #0c1419, #99b0bf, #b7c4cc, #767472, #386b8c, #ffffff, #386b8c, #0c1419,            #b7c4cc, #0c1419,           72a0bf, #0c1419
+#disabled_colors=#364045, #99b0bf, #b7c4cc, #cbc7c4, #9f9d9a, #b8b5b2, #2f3b42,  #ffec17, #0c1419, #99b0bf, #b7c4cc, #767472, #386b8c, #ffffff, #386b8c, #364045,   #b7c4cc, #364045,  #72a0bf, #253742
+#inactive_colors=#0c1419,          #99b0bf, #b7c4cc, #cbc7c4, #9f9d9a, #b8b5b2, #0c1419,           #ff9040, #0c1419, #99b0bf, #b7c4cc, #767472, #386b8c, #ffffff, #386b8c, #0c1419,            #b7c4cc, #0c1419,           #72a0bf, #0c1419

--- a/Cinnamox-Heather/files/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Heather.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Heather;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Heather/info.json
+++ b/Cinnamox-Heather/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Heather", 
-	"description": "Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Kashmir-Blue
 
-Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Kashmir-Blue
 
-Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Kashmir-Blue */
 /* Transparency: None */
-/* Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #daeaf2;
+    color: #a13434;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #a1a144;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #a13434;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Kashmir-Blue. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Kashmir-Blue
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/gtkrc
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#29404c\nbg_color:#577584\ntooltip_bg_color:#577584\nselected_bg_color:#23b29a\ntext_color:#daeaf2\nfg_color:#daeaf2\ntooltip_fg_color:#daeaf2\nselected_fg_color:#000000\nmenubar_bg_color:#28343a\nmenubar_fg_color:#daeaf2\ntoolbar_bg_color:#577584\ntoolbar_fg_color:#daeaf2\nmenu_bg_color:#28343a\nmenu_fg_color:#daeaf2\npanel_bg_color:#577584\npanel_fg_color:#daeaf2\nlink_color:#23b29a\nbtn_bg_color:#29404c\nbtn_fg_color:#daeaf2\ntitlebar_bg_color:#28343a\ntitlebar_fg_color:#daeaf2\nprimary_caret_color:#daeaf2\nsecondary_caret_color:#daeaf2\n"
+"base_color:#29404c\nbg_color:#577584\ntooltip_bg_color:#577584\nselected_bg_color:#23b29a\ntext_color:#daeaf2\nfg_color:#daeaf2\ntooltip_fg_color:#daeaf2\nselected_fg_color:#000000\nmenubar_bg_color:#28343a\nmenubar_fg_color:#daeaf2\ntoolbar_bg_color:#577584\ntoolbar_fg_color:#daeaf2\nmenu_bg_color:#28343a\nmenu_fg_color:#daeaf2\npanel_bg_color:#577584\npanel_fg_color:#daeaf2\nlink_color:#a9d9f2\nbtn_bg_color:#29404c\nbtn_fg_color:#daeaf2\ntitlebar_bg_color:#28343a\ntitlebar_fg_color:#daeaf2\nprimary_caret_color:#daeaf2\nsecondary_caret_color:#daeaf2\naccent_bg_color:#23b29a\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#29404c\nbg_color:#577584\ntooltip_bg_color:#577584\nselected_bg_color:#23b29a\ntext_color:#daeaf2\nfg_color:#daeaf2\ntooltip_fg_color:#daeaf2\nselected_fg_color:#000000\nmenubar_bg_color:#28343a\nmenubar_fg_color:#daeaf2\ntoolbar_bg_color:#577584\ntoolbar_fg_color:#daeaf2\nmenu_bg_color:#28343a\nmenu_fg_color:#daeaf2\npanel_bg_color:#577584\npanel_fg_color:#daeaf2\nlink_color:#23b29a\nbtn_bg_color:#29404c\nbtn_fg_color:#daeaf2\ntitlebar_bg_color:#28343a\ntitlebar_fg_color:#daeaf2\n"
+"base_color:#29404c\nbg_color:#577584\ntooltip_bg_color:#577584\nselected_bg_color:#23b29a\ntext_color:#daeaf2\nfg_color:#daeaf2\ntooltip_fg_color:#daeaf2\nselected_fg_color:#000000\nmenubar_bg_color:#28343a\nmenubar_fg_color:#daeaf2\ntoolbar_bg_color:#577584\ntoolbar_fg_color:#daeaf2\nmenu_bg_color:#28343a\nmenu_fg_color:#daeaf2\npanel_bg_color:#577584\npanel_fg_color:#daeaf2\nlink_color:#a9d9f2\nbtn_bg_color:#29404c\nbtn_fg_color:#daeaf2\ntitlebar_bg_color:#28343a\ntitlebar_fg_color:#daeaf2\nprimary_caret_color:#daeaf2\nsecondary_caret_color:#daeaf2\naccent_bg_color:#23b29a\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.0/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #183544;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #23b29a;
+@define-color info_bg_color #4334c2;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #a1a144;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #23b29a;
+@define-color question_bg_color #4334c2;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#23b29a,#daeaf2,0.6);
-@define-color success_color #23b29a;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #a13434;
+@define-color link_color #a9d9f2;
+@define-color success_color #7db246;
+@define-color warning_color #a1a144;
+@define-color error_color #a13434;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#23b29a,#daeaf2,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#23b29a,#daeaf2,0.6);
-  -GtkWidget-link-color: mix(#23b29a,#daeaf2,0.6);
-  -GtkWidget-visited-link-color: mix(#23b29a,#daeaf2,0.6); }
+  -GtkHTML-link-color: #a9d9f2;
+  -GtkIMHtml-hyperlink-color: #a9d9f2;
+  -GtkWidget-link-color: #a9d9f2;
+  -GtkWidget-visited-link-color: #a9d9f2; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#23b29a,#daeaf2,0.6); }
+    color: #a9d9f2; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#23b29a,#daeaf2,0.6); }
+    color: #a9d9f2; }
 
 .background {
   background-color: #577584;
@@ -898,8 +898,8 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #23b29a;
-  background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+  background-color: #7db246;
+  background-image: linear-gradient(to bottom, #9cc76f, #5e8635);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -913,7 +913,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(35, 178, 154, 0);
+    background-color: rgba(125, 178, 70, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
@@ -925,8 +925,8 @@ GtkComboBox .separator {
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #2ad5b9;
-    background-image: linear-gradient(to bottom, #60e0ca, #20a08b);
+    background-color: #96c367;
+    background-image: linear-gradient(to bottom, #bbd89c, #71a03f);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
@@ -949,32 +949,32 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #000000; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #20a08b;
-    background-image: linear-gradient(to bottom, #27c8ad, #187868);
+    background-color: #71a03f;
+    background-image: linear-gradient(to bottom, #8cbe59, #54782f);
     color: #000000;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: rgba(35, 178, 154, 0.3);
-    background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.3), rgba(26, 134, 116, 0.3));
-    color: mix(#23b29a,#000000,0.5);
+    background-color: rgba(125, 178, 70, 0.3);
+    background-image: linear-gradient(to bottom, rgba(156, 199, 111, 0.3), rgba(94, 134, 53, 0.3));
+    color: mix(#7db246,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #000000; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#23b29a,#000000,0.5);
+    color: mix(#7db246,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #20a08b; }
+    color: #71a03f; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #1e9783; }
+      color: #6a973c; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a13434;
+  background-image: linear-gradient(to bottom, #c34747, #792727);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -988,7 +988,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .destructive-action.button.flat {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(161, 52, 52, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
@@ -1000,8 +1000,8 @@ GtkComboBox .separator {
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
+    background-color: #c13f3f;
+    background-image: linear-gradient(to bottom, #d06f6f, #912f2f);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #912f2f;
+    background-image: linear-gradient(to bottom, #b53b3b, #6d2323);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#000000,0.5);
+    background-color: rgba(161, 52, 52, 0.3);
+    background-image: linear-gradient(to bottom, rgba(195, 71, 71, 0.3), rgba(121, 39, 39, 0.3));
+    color: mix(#a13434,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#000000,0.5);
+    color: mix(#a13434,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #912f2f; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #892c2c; }
 
 /******************
 * selection mode *
@@ -1424,14 +1424,14 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #23b29a;
-  background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
-  border: 1px solid #1c8e7b;
+  background-color: #4334c2;
+  background-image: linear-gradient(to bottom, #6c5fd4, #322792);
+  border: 1px solid #362a9b;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1445,7 +1445,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .info .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(35, 178, 154, 0);
+      background-color: rgba(67, 52, 194, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
@@ -1457,8 +1457,8 @@ GtkInfoBar {
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #2ad5b9;
-      background-image: linear-gradient(to bottom, #60e0ca, #20a08b);
+      background-color: #6356d2;
+      background-image: linear-gradient(to bottom, #9890e1, #3c2faf);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
@@ -1481,37 +1481,37 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #20a08b;
-      background-image: linear-gradient(to bottom, #27c8ad, #187868);
+      background-color: #3c2faf;
+      background-image: linear-gradient(to bottom, #5547ce, #2d2383);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: rgba(35, 178, 154, 0.3);
-      background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.3), rgba(26, 134, 116, 0.3));
-      color: mix(#23b29a,#000000,0.5);
+      background-color: rgba(67, 52, 194, 0.3);
+      background-image: linear-gradient(to bottom, rgba(108, 95, 212, 0.3), rgba(50, 39, 146, 0.3));
+      color: mix(#4334c2,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#23b29a,#000000,0.5);
+      color: mix(#4334c2,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #20a08b; }
+      color: #3c2faf; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #1e9783; }
+        color: #392ca5; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #a1a144;
+  background-image: linear-gradient(to bottom, #bdbd62, #797933);
+  border: 1px solid #818136;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #a1a144;
+    background-image: linear-gradient(to bottom, #bdbd62, #797933);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1525,7 +1525,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .warning .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(161, 161, 68, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
@@ -1537,8 +1537,8 @@ GtkInfoBar {
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #b9b95a;
+      background-image: linear-gradient(to bottom, #cece8a, #91913d);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
@@ -1561,37 +1561,37 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #91913d;
+      background-image: linear-gradient(to bottom, #b4b44e, #6d6d2e);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(161, 161, 68, 0.3);
+      background-image: linear-gradient(to bottom, rgba(189, 189, 98, 0.3), rgba(121, 121, 51, 0.3));
+      color: mix(#a1a144,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#a1a144,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #91913d; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #89893a; }
 
 .question {
-  background-color: #23b29a;
-  background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
-  border: 1px solid #1c8e7b;
+  background-color: #4334c2;
+  background-image: linear-gradient(to bottom, #6c5fd4, #322792);
+  border: 1px solid #362a9b;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1605,7 +1605,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .question .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(35, 178, 154, 0);
+      background-color: rgba(67, 52, 194, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
@@ -1617,8 +1617,8 @@ GtkInfoBar {
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #2ad5b9;
-      background-image: linear-gradient(to bottom, #60e0ca, #20a08b);
+      background-color: #6356d2;
+      background-image: linear-gradient(to bottom, #9890e1, #3c2faf);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
@@ -1641,37 +1641,37 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #20a08b;
-      background-image: linear-gradient(to bottom, #27c8ad, #187868);
+      background-color: #3c2faf;
+      background-image: linear-gradient(to bottom, #5547ce, #2d2383);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: rgba(35, 178, 154, 0.3);
-      background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.3), rgba(26, 134, 116, 0.3));
-      color: mix(#23b29a,#000000,0.5);
+      background-color: rgba(67, 52, 194, 0.3);
+      background-image: linear-gradient(to bottom, rgba(108, 95, 212, 0.3), rgba(50, 39, 146, 0.3));
+      color: mix(#4334c2,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#23b29a,#000000,0.5);
+      color: mix(#4334c2,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #20a08b; }
+      color: #3c2faf; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #1e9783; }
+        color: #392ca5; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #a13434;
+  background-image: linear-gradient(to bottom, #c34747, #792727);
+  border: 1px solid #812a2a;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #a13434;
+    background-image: linear-gradient(to bottom, #c34747, #792727);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1685,7 +1685,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .error .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(161, 52, 52, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
@@ -1697,8 +1697,8 @@ GtkInfoBar {
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #c13f3f;
+      background-image: linear-gradient(to bottom, #d06f6f, #912f2f);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #912f2f;
+      background-image: linear-gradient(to bottom, #b53b3b, #6d2323);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(161, 52, 52, 0.3);
+      background-image: linear-gradient(to bottom, rgba(195, 71, 71, 0.3), rgba(121, 39, 39, 0.3));
+      color: mix(#a13434,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#a13434,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #912f2f; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #892c2c; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #23b29a;
+    background-color: #7db246;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #a1a144;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #a13434; }
 
 .view, GtkHTML {
   color: #daeaf2;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #21333d;
   background-color: #29404c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #a13434;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #812a2a;
+  background-color: #ae3838;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #712424;
+    background-color: #a13434; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #818136;
+  background-color: #aeae49;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #717130;
+    background-color: #a1a144; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #183544;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #23b29a;
+@define-color info_bg_color #4334c2;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #a1a144;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #23b29a;
+@define-color question_bg_color #4334c2;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#23b29a,#daeaf2,0.6);
-@define-color success_color #23b29a;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #a13434;
+@define-color link_color #a9d9f2;
+@define-color success_color #7db246;
+@define-color warning_color #a1a144;
+@define-color error_color #a13434;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#23b29a,#daeaf2,0.6); }
+  -GtkIMHtml-hyperlink-color: #a9d9f2; }
   *:disabled, *:disabled:disabled {
-    color: mix(#23b29a,#daeaf2,0.6); }
+    color: #a9d9f2; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#23b29a,#daeaf2,0.6); }
+    color: #a9d9f2; }
 
 .background {
   background-color: #577584;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #818136;
+    background-color: mix(#29404c,#a1a144,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a1a144,0.3);
+      background-color: #a1a144;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a1a144; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #812a2a;
+    background-color: mix(#29404c,#a13434,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a13434,0.3);
+      background-color: #a13434;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a13434; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #812a2a;
+    background-color: mix(#29404c,#a13434,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a13434,0.3);
+      background-color: #a13434;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a13434; }
 
 entry {
   background-color: #29404c;
@@ -1727,8 +1727,8 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #23b29a;
-  background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+  background-color: #7db246;
+  background-image: linear-gradient(to bottom, #9cc76f, #5e8635);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(35, 178, 154, 0);
+    background-color: rgba(125, 178, 70, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,8 +1870,8 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #25bba2;
-    background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+    background-color: #83b94c;
+    background-image: linear-gradient(to bottom, #a3cb7b, #628c37);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -1891,8 +1891,8 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #25bba2;
-    background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+    background-color: #83b94c;
+    background-image: linear-gradient(to bottom, #a3cb7b, #628c37);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(35, 178, 154, 0.5);
     outline-width: 1px;
@@ -1902,8 +1902,8 @@ searchbar,
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #27c4a9;
-      background-image: linear-gradient(to bottom, #4adbc3, #1d937f);
+      background-color: #89bc55;
+      background-image: linear-gradient(to bottom, #abcf86, #67933a);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #000000; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#23b29a,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#23b29a,#000000,0.2),0.4),1.25), shade(alpha(mix(#23b29a,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#7db246,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#7db246,#000000,0.2),0.4),1.25), shade(alpha(mix(#7db246,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#23b29a,#000000,0.6);
+    color: mix(#7db246,#000000,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#23b29a,#000000,0.6); }
+      color: mix(#7db246,#000000,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,15 +1981,15 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(35, 178, 154, 0.9); }
+    color: rgba(125, 178, 70, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(35, 178, 154, 0.85); }
+      color: rgba(125, 178, 70, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a13434;
+  background-image: linear-gradient(to bottom, #c34747, #792727);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(161, 52, 52, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,8 +2056,8 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a93737;
+    background-image: linear-gradient(to bottom, #c75151, #7f2929);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -2070,8 +2070,8 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a93737;
+    background-image: linear-gradient(to bottom, #c75151, #7f2929);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(35, 178, 154, 0.5);
     outline-width: 1px;
@@ -2080,8 +2080,8 @@ searchbar,
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #b13939;
+      background-image: linear-gradient(to bottom, #ca5b5b, #852b2b);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a13434,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a13434,#000000,0.2),0.4),1.25), shade(alpha(mix(#a13434,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#a13434,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#a13434,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(35, 178, 154, 0.6);
     background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(161, 52, 52, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(161, 52, 52, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,15 +3202,15 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
-    border: 1px solid #1c8e7b;
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
+    border: 1px solid #362a9b;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(35, 178, 154, 0);
+      background-color: rgba(67, 52, 194, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,8 +3277,8 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #25bba2;
-      background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+      background-color: #4839ca;
+      background-image: linear-gradient(to bottom, #776bd7, #352999);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -3291,8 +3291,8 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #25bba2;
-      background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+      background-color: #4839ca;
+      background-image: linear-gradient(to bottom, #776bd7, #352999);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(35, 178, 154, 0.5);
       outline-width: 1px;
@@ -3301,8 +3301,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #27c4a9;
-        background-image: linear-gradient(to bottom, #4adbc3, #1d937f);
+        background-color: #5142cc;
+        background-image: linear-gradient(to bottom, #8278db, #372ba0);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#23b29a,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#23b29a,#000000,0.2),0.4),1.25), shade(alpha(mix(#23b29a,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4334c2,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4334c2,#000000,0.2),0.4),1.25), shade(alpha(mix(#4334c2,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#23b29a,#000000,0.6);
+      color: mix(#4334c2,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#23b29a,#000000,0.6); }
+        color: mix(#4334c2,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -3353,19 +3353,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(35, 178, 154, 0.9); }
+      color: rgba(67, 52, 194, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(35, 178, 154, 0.85); }
+        color: rgba(67, 52, 194, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #a1a144;
+    background-image: linear-gradient(to bottom, #bdbd62, #797933);
+    border: 1px solid #818136;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #a1a144;
+    background-image: linear-gradient(to bottom, #bdbd62, #797933);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(161, 161, 68, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,8 +3432,8 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a9a947;
+      background-image: linear-gradient(to bottom, #c1c16c, #7f7f36);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -3446,8 +3446,8 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a9a947;
+      background-image: linear-gradient(to bottom, #c1c16c, #7f7f36);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(35, 178, 154, 0.5);
       outline-width: 1px;
@@ -3456,8 +3456,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #b1b14b;
+        background-image: linear-gradient(to bottom, #c5c576, #858538);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#a1a144,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#a1a144,#000000,0.2),0.4),1.25), shade(alpha(mix(#a1a144,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#a1a144,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#a1a144,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -3508,19 +3508,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(161, 161, 68, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(161, 161, 68, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
-    border: 1px solid #1c8e7b;
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
+    border: 1px solid #362a9b;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #23b29a;
-    background-image: linear-gradient(to bottom, #33d7bb, #1a8674);
+    background-color: #4334c2;
+    background-image: linear-gradient(to bottom, #6c5fd4, #322792);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(35, 178, 154, 0);
+      background-color: rgba(67, 52, 194, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,8 +3587,8 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #25bba2;
-      background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+      background-color: #4839ca;
+      background-image: linear-gradient(to bottom, #776bd7, #352999);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -3601,8 +3601,8 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #25bba2;
-      background-image: linear-gradient(to bottom, #3ed9bf, #1c8c79);
+      background-color: #4839ca;
+      background-image: linear-gradient(to bottom, #776bd7, #352999);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(35, 178, 154, 0.5);
       outline-width: 1px;
@@ -3611,8 +3611,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #27c4a9;
-        background-image: linear-gradient(to bottom, #4adbc3, #1d937f);
+        background-color: #5142cc;
+        background-image: linear-gradient(to bottom, #8278db, #372ba0);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#23b29a,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#23b29a,#000000,0.2),0.4),1.25), shade(alpha(mix(#23b29a,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4334c2,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4334c2,#000000,0.2),0.4),1.25), shade(alpha(mix(#4334c2,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#23b29a,#000000,0.6);
+      color: mix(#4334c2,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#23b29a,#000000,0.6); }
+        color: mix(#4334c2,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -3663,19 +3663,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(35, 178, 154, 0.9); }
+      color: rgba(67, 52, 194, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(35, 178, 154, 0.85); }
+        color: rgba(67, 52, 194, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #a13434;
+    background-image: linear-gradient(to bottom, #c34747, #792727);
+    border: 1px solid #812a2a;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #a13434;
+    background-image: linear-gradient(to bottom, #c34747, #792727);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(161, 52, 52, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,8 +3742,8 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a93737;
+      background-image: linear-gradient(to bottom, #c75151, #7f2929);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -3756,8 +3756,8 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a93737;
+      background-image: linear-gradient(to bottom, #c75151, #7f2929);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(35, 178, 154, 0.5);
       outline-width: 1px;
@@ -3766,8 +3766,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #b13939;
+        background-image: linear-gradient(to bottom, #ca5b5b, #852b2b);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#a13434,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#a13434,#000000,0.2),0.4),1.25), shade(alpha(mix(#a13434,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#a13434,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#a13434,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(161, 52, 52, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(161, 52, 52, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #818136;
+    background-color: mix(#29404c,#a1a144,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a1a144,0.3);
+      background-color: #a1a144;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a1a144; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #812a2a;
+    background-color: mix(#29404c,#a13434,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a13434,0.3);
+      background-color: #a13434;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a13434; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#29404c,#ff0000,0.6); }
+    border-color: #812a2a;
+    background-color: mix(#29404c,#a13434,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#23b29a,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#23b29a,#a13434,0.3);
+      background-color: #a13434;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a13434; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#577584,#daeaf2,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #c95858; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #23b29a; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #a1a144;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #23b29a;
+    background-color: #7db246;
     border-color: transparent; }
   levelbar block.full {
     background-color: #1c8e7b;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #21333d;
   background-color: #29404c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #a13434;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #ff0000; }
+  background-color: #a13434; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #b13939; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,8 +8947,8 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a13434;
+  background-image: linear-gradient(to bottom, #c34747, #792727);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(161, 52, 52, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,8 +9015,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a93737;
+    background-image: linear-gradient(to bottom, #c75151, #7f2929);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -9029,8 +9029,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a93737;
+    background-image: linear-gradient(to bottom, #c75151, #7f2929);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(35, 178, 154, 0.5);
     outline-width: 1px;
@@ -9039,8 +9039,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #b13939;
+      background-image: linear-gradient(to bottom, #ca5b5b, #852b2b);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a13434,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a13434,#000000,0.2),0.4),1.25), shade(alpha(mix(#a13434,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#a13434,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#a13434,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(35, 178, 154, 0.6);
     background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -9091,14 +9091,14 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(161, 52, 52, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(161, 52, 52, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a1a144;
+  background-image: linear-gradient(to bottom, #bdbd62, #797933);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(161, 161, 68, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,8 +9165,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a9a947;
+    background-image: linear-gradient(to bottom, #c1c16c, #7f7f36);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -9179,8 +9179,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a9a947;
+    background-image: linear-gradient(to bottom, #c1c16c, #7f7f36);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(35, 178, 154, 0.5);
     outline-width: 1px;
@@ -9189,8 +9189,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #b1b14b;
+      background-image: linear-gradient(to bottom, #c5c576, #858538);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a1a144,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a1a144,#000000,0.2),0.4),1.25), shade(alpha(mix(#a1a144,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#a1a144,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#a1a144,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(35, 178, 154, 0.6);
     background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(161, 161, 68, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(161, 161, 68, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/info.json
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Kashmir-Blue", 
-	"description": "Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/qt5ct/Cinnamox-Kashmir-Blue.conf
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/qt5ct/Cinnamox-Kashmir-Blue.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#daeaf2,          #577584, #577584, #577584, #28343a, #28343a, #daeaf2,           #daeaf2,           #daeaf2,           #29404c, #577584, #28343a, #23b29a, #000000, #23b29a, #daeaf2,            #577584, #daeaf2,           28343a,  #daeaf2
+disabled_colors=#b9ccd6, #577584, #577584, #577584, #28343a, #28343a, #adbfc8,  #adbfc8,  #b9ccd6,  #29404c, #577584, #28343a, #23b29a, #000000, #23b29a, #b9ccd6,   #577584, #b9ccd6,  #28343a, #adbcc4
+inactive_colors=#daeaf2,          #577584, #577584, #577584, #28343a, #28343a, #daeaf2,           #daeaf2,           #daeaf2,           #29404c, #577584, #28343a, #23b29a, #000000, #23b29a, #daeaf2,            #577584, #daeaf2,           #28343a, #daeaf2
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#daeaf2,          #29404c, #577584, #cbc7c4, #9f9d9a, #b8b5b2, #daeaf2,           #ff0000, #daeaf2, #29404c, #577584, #767472, #23b29a, #000000, #23b29a, #daeaf2,            #577584, #daeaf2,           28343a, #daeaf2
+#disabled_colors=#b9ccd6, #29404c, #577584, #cbc7c4, #9f9d9a, #b8b5b2, #adbfc8,  #ffec17, #daeaf2, #29404c, #577584, #767472, #23b29a, #000000, #23b29a, #b9ccd6,   #577584, #b9ccd6,  #28343a, #adbcc4
+#inactive_colors=#daeaf2,          #29404c, #577584, #cbc7c4, #9f9d9a, #b8b5b2, #daeaf2,           #ff9040, #daeaf2, #29404c, #577584, #767472, #23b29a, #000000, #23b29a, #daeaf2,            #577584, #daeaf2,           #28343a, #daeaf2

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Kashmir-Blue.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Kashmir-Blue;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Kashmir-Blue/info.json
+++ b/Cinnamox-Kashmir-Blue/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Kashmir-Blue", 
-	"description": "Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Rhino
 
-Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Rhino
 
-Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Rhino */
 /* Transparency: None */
-/* Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #d8e5f2;
+    color: #a06060;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #d8d84e;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #a06060;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Rhino. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Rhino
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/gtkrc
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#3b444c\nbg_color:#434e5a\ntooltip_bg_color:#434e5a\nselected_bg_color:#3d80cc\ntext_color:#d8e5f2\nfg_color:#d8e5f2\ntooltip_fg_color:#d8e5f2\nselected_fg_color:#000000\nmenubar_bg_color:#1c2126\nmenubar_fg_color:#d8e5f2\ntoolbar_bg_color:#434e5a\ntoolbar_fg_color:#d8e5f2\nmenu_bg_color:#1c2126\nmenu_fg_color:#d8e5f2\npanel_bg_color:#434e5a\npanel_fg_color:#d8e5f2\nlink_color:#3d80cc\nbtn_bg_color:#3b444c\nbtn_fg_color:#d8e5f2\ntitlebar_bg_color:#1c2126\ntitlebar_fg_color:#d8e5f2\nprimary_caret_color:#d8e5f2\nsecondary_caret_color:#d8e5f2\n"
+"base_color:#3b444c\nbg_color:#434e5a\ntooltip_bg_color:#434e5a\nselected_bg_color:#3d80cc\ntext_color:#d8e5f2\nfg_color:#d8e5f2\ntooltip_fg_color:#d8e5f2\nselected_fg_color:#000000\nmenubar_bg_color:#1c2126\nmenubar_fg_color:#d8e5f2\ntoolbar_bg_color:#434e5a\ntoolbar_fg_color:#d8e5f2\nmenu_bg_color:#1c2126\nmenu_fg_color:#d8e5f2\npanel_bg_color:#434e5a\npanel_fg_color:#d8e5f2\nlink_color:#a9cdf2\nbtn_bg_color:#3b444c\nbtn_fg_color:#d8e5f2\ntitlebar_bg_color:#1c2126\ntitlebar_fg_color:#d8e5f2\nprimary_caret_color:#d8e5f2\nsecondary_caret_color:#d8e5f2\naccent_bg_color:#3d80cc\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#3b444c\nbg_color:#434e5a\ntooltip_bg_color:#434e5a\nselected_bg_color:#3d80cc\ntext_color:#d8e5f2\nfg_color:#d8e5f2\ntooltip_fg_color:#d8e5f2\nselected_fg_color:#000000\nmenubar_bg_color:#1c2126\nmenubar_fg_color:#d8e5f2\ntoolbar_bg_color:#434e5a\ntoolbar_fg_color:#d8e5f2\nmenu_bg_color:#1c2126\nmenu_fg_color:#d8e5f2\npanel_bg_color:#434e5a\npanel_fg_color:#d8e5f2\nlink_color:#3d80cc\nbtn_bg_color:#3b444c\nbtn_fg_color:#d8e5f2\ntitlebar_bg_color:#1c2126\ntitlebar_fg_color:#d8e5f2\n"
+"base_color:#3b444c\nbg_color:#434e5a\ntooltip_bg_color:#434e5a\nselected_bg_color:#3d80cc\ntext_color:#d8e5f2\nfg_color:#d8e5f2\ntooltip_fg_color:#d8e5f2\nselected_fg_color:#000000\nmenubar_bg_color:#1c2126\nmenubar_fg_color:#d8e5f2\ntoolbar_bg_color:#434e5a\ntoolbar_fg_color:#d8e5f2\nmenu_bg_color:#1c2126\nmenu_fg_color:#d8e5f2\npanel_bg_color:#434e5a\npanel_fg_color:#d8e5f2\nlink_color:#a9cdf2\nbtn_bg_color:#3b444c\nbtn_fg_color:#d8e5f2\ntitlebar_bg_color:#1c2126\ntitlebar_fg_color:#d8e5f2\nprimary_caret_color:#d8e5f2\nsecondary_caret_color:#d8e5f2\naccent_bg_color:#3d80cc\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.0/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #172e45;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #3d80cc;
+@define-color info_bg_color #3d3dcc;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #d8d84e;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #3d80cc;
+@define-color question_bg_color #3d3dcc;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#3d80cc,#d8e5f2,0.6);
-@define-color success_color #3d80cc;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #a06060;
+@define-color link_color #a9cdf2;
+@define-color success_color #5dfe50;
+@define-color warning_color #d8d84e;
+@define-color error_color #a06060;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#3d80cc,#d8e5f2,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#3d80cc,#d8e5f2,0.6);
-  -GtkWidget-link-color: mix(#3d80cc,#d8e5f2,0.6);
-  -GtkWidget-visited-link-color: mix(#3d80cc,#d8e5f2,0.6); }
+  -GtkHTML-link-color: #a9cdf2;
+  -GtkIMHtml-hyperlink-color: #a9cdf2;
+  -GtkWidget-link-color: #a9cdf2;
+  -GtkWidget-visited-link-color: #a9cdf2; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#3d80cc,#d8e5f2,0.6); }
+    color: #a9cdf2; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#3d80cc,#d8e5f2,0.6); }
+    color: #a9cdf2; }
 
 .background {
   background-color: #434e5a;
@@ -898,8 +898,8 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #3d80cc;
-  background-image: linear-gradient(to bottom, #71a2da, #29609d);
+  background-color: #5dfe50;
+  background-image: linear-gradient(to bottom, #aafea3, #14f901);
   border-color: rgba(0, 0, 0, 0.12);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -913,7 +913,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
     border-color: rgba(0, 0, 0, 0.1);
-    background-color: rgba(61, 128, 204, 0);
+    background-color: rgba(93, 254, 80, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
@@ -925,8 +925,8 @@ GtkComboBox .separator {
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.1); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #679bd7;
-    background-image: linear-gradient(to bottom, #a6c5e8, #3273bd);
+    background-color: #9afe92;
+    background-image: linear-gradient(to bottom, #f7fff6, #3efe2f);
     border-color: rgba(0, 0, 0, 0.2);
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
@@ -949,69 +949,69 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #000000; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #3273bd;
-    background-image: linear-gradient(to bottom, #5791d3, #25568e);
+    background-color: #3efe2f;
+    background-image: linear-gradient(to bottom, #83fe7a, #12e001);
     color: #000000;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: #3479c7;
-    background-image: linear-gradient(to bottom, #649ad6, #275b96);
-    color: mix(#3d80cc,#000000,0.5);
+    background-color: #4efe3f;
+    background-image: linear-gradient(to bottom, #97fe8e, #13ed01);
+    color: mix(#5dfe50,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #000000; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#3d80cc,#000000,0.5);
+    color: mix(#5dfe50,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #3273bd; }
+    color: #3efe2f; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #2f6cb2; }
+      color: #2ffe1e; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #a06060;
+  background-image: linear-gradient(to bottom, #b88888, #784848);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
   .destructive-action.button:focus, .destructive-action.button:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active, .destructive-action.button:active:hover, .destructive-action.button:active:focus, .destructive-action.button:active:hover:focus, .destructive-action.button:checked, .destructive-action.button:checked:hover, .destructive-action.button:checked:focus, .destructive-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button.flat {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(160, 96, 96, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active, .destructive-action.button.flat:active:hover, .destructive-action.button.flat:active:focus, .destructive-action.button.flat:active:hover:focus, .destructive-action.button.flat:checked, .destructive-action.button.flat:checked:hover, .destructive-action.button.flat:checked:focus, .destructive-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+    background-color: #b38080;
+    background-image: linear-gradient(to bottom, #d0b0b0, #905656);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active, .destructive-action.button:focus:active:hover, .destructive-action.button:focus:active:focus, .destructive-action.button:focus:active:hover:focus, .destructive-action.button:focus:checked, .destructive-action.button:focus:checked:hover, .destructive-action.button:focus:checked:focus, .destructive-action.button:focus:checked:hover:focus, .destructive-action.button:hover:active, .destructive-action.button:hover:active:hover, .destructive-action.button:hover:active:focus, .destructive-action.button:hover:active:hover:focus, .destructive-action.button:hover:checked, .destructive-action.button:hover:checked:hover, .destructive-action.button:hover:checked:focus, .destructive-action.button:hover:checked:hover:focus, .destructive-action.button.flat:focus:active, .destructive-action.button.flat:focus:active:hover, .destructive-action.button.flat:focus:active:focus, .destructive-action.button.flat:focus:active:hover:focus, .destructive-action.button.flat:focus:checked, .destructive-action.button.flat:focus:checked:hover, .destructive-action.button.flat:focus:checked:focus, .destructive-action.button.flat:focus:checked:hover:focus, .destructive-action.button.flat:hover:active, .destructive-action.button.flat:hover:active:hover, .destructive-action.button.flat:hover:active:focus, .destructive-action.button.flat:hover:active:hover:focus, .destructive-action.button.flat:hover:checked, .destructive-action.button.flat:hover:checked:hover, .destructive-action.button.flat:hover:checked:focus, .destructive-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:insensitive, .destructive-action.button:hover:insensitive, .destructive-action.button.flat:focus:insensitive, .destructive-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active:insensitive, .destructive-action.button:focus:checked:insensitive, .destructive-action.button:hover:active:insensitive, .destructive-action.button:hover:checked:insensitive, .destructive-action.button.flat:focus:active:insensitive, .destructive-action.button.flat:focus:checked:insensitive, .destructive-action.button.flat:hover:active:insensitive, .destructive-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:active, .destructive-action.button:checked, .destructive-action.button.flat:active, .destructive-action.button.flat:checked {
     background-color: #3273bd;
     background-image: linear-gradient(to top, #5791d3, #25568e);
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #905656;
+    background-image: linear-gradient(to bottom, #ac7474, #6c4141);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#000000,0.5);
+    background-color: #985b5b;
+    background-image: linear-gradient(to bottom, #b27e7e, #724444);
+    color: mix(#a06060,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#000000,0.5);
+    color: mix(#a06060,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #905656; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #885151; }
 
 /******************
 * selection mode *
@@ -1424,14 +1424,14 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #3d80cc;
-  background-image: linear-gradient(to bottom, #71a2da, #29609d);
-  border: 1px solid #2c66a8;
+  background-color: #3d3dcc;
+  background-image: linear-gradient(to bottom, #7171da, #29299d);
+  border: 1px solid #2c2ca8;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
     border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -1445,7 +1445,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.12); }
     .info .button.flat {
       border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(61, 128, 204, 0);
+      background-color: rgba(61, 61, 204, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
@@ -1457,8 +1457,8 @@ GtkInfoBar {
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.1); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #679bd7;
-      background-image: linear-gradient(to bottom, #a6c5e8, #3273bd);
+      background-color: #6767d7;
+      background-image: linear-gradient(to bottom, #a6a6e8, #3232bd);
       border-color: rgba(0, 0, 0, 0.2);
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
@@ -1481,74 +1481,74 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #3273bd;
-      background-image: linear-gradient(to bottom, #5791d3, #25568e);
+      background-color: #3232bd;
+      background-image: linear-gradient(to bottom, #5757d3, #25258e);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: #3479c7;
-      background-image: linear-gradient(to bottom, #649ad6, #275b96);
-      color: mix(#3d80cc,#000000,0.5);
+      background-color: #3434c7;
+      background-image: linear-gradient(to bottom, #6464d6, #272796);
+      color: mix(#3d3dcc,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#3d80cc,#000000,0.5);
+      color: mix(#3d3dcc,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #3273bd; }
+      color: #3232bd; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #2f6cb2; }
+        color: #2f2fb2; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #d8d84e;
+  background-image: linear-gradient(to bottom, #e5e58a, #b5b528);
+  border: 1px solid #c1c12a;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #d8d84e;
+    background-image: linear-gradient(to bottom, #e5e58a, #b5b528);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
     .warning .button:focus, .warning .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active, .warning .button:active:hover, .warning .button:active:focus, .warning .button:active:hover:focus, .warning .button:checked, .warning .button:checked:hover, .warning .button:checked:focus, .warning .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active:insensitive, .warning .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(216, 216, 78, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active, .warning .button.flat:active:hover, .warning .button.flat:active:focus, .warning .button.flat:active:hover:focus, .warning .button.flat:checked, .warning .button.flat:checked:hover, .warning .button.flat:checked:focus, .warning .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+      background-color: #e3e37e;
+      background-image: linear-gradient(to bottom, #f3f3c6, #d3d336);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active, .warning .button:focus:active:hover, .warning .button:focus:active:focus, .warning .button:focus:active:hover:focus, .warning .button:focus:checked, .warning .button:focus:checked:hover, .warning .button:focus:checked:focus, .warning .button:focus:checked:hover:focus, .warning .button:hover:active, .warning .button:hover:active:hover, .warning .button:hover:active:focus, .warning .button:hover:active:hover:focus, .warning .button:hover:checked, .warning .button:hover:checked:hover, .warning .button:hover:checked:focus, .warning .button:hover:checked:hover:focus, .warning .button.flat:focus:active, .warning .button.flat:focus:active:hover, .warning .button.flat:focus:active:focus, .warning .button.flat:focus:active:hover:focus, .warning .button.flat:focus:checked, .warning .button.flat:focus:checked:hover, .warning .button.flat:focus:checked:focus, .warning .button.flat:focus:checked:hover:focus, .warning .button.flat:hover:active, .warning .button.flat:hover:active:hover, .warning .button.flat:hover:active:focus, .warning .button.flat:hover:active:hover:focus, .warning .button.flat:hover:checked, .warning .button.flat:hover:checked:hover, .warning .button.flat:hover:checked:focus, .warning .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:insensitive, .warning .button:hover:insensitive, .warning .button.flat:focus:insensitive, .warning .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active:insensitive, .warning .button:focus:checked:insensitive, .warning .button:hover:active:insensitive, .warning .button:hover:checked:insensitive, .warning .button.flat:focus:active:insensitive, .warning .button.flat:focus:checked:insensitive, .warning .button.flat:hover:active:insensitive, .warning .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:active, .warning .button:checked, .warning .button.flat:active, .warning .button.flat:checked {
       background-color: #3273bd;
       background-image: linear-gradient(to top, #5791d3, #25568e);
@@ -1561,37 +1561,37 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #d3d336;
+      background-image: linear-gradient(to bottom, #dfdf6c, #a3a324);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: #d5d542;
+      background-image: linear-gradient(to bottom, #e2e27b, #acac26);
+      color: mix(#d8d84e,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#d8d84e,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #d3d336; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #cdcd2d; }
 
 .question {
-  background-color: #3d80cc;
-  background-image: linear-gradient(to bottom, #71a2da, #29609d);
-  border: 1px solid #2c66a8;
+  background-color: #3d3dcc;
+  background-image: linear-gradient(to bottom, #7171da, #29299d);
+  border: 1px solid #2c2ca8;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
     border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -1605,7 +1605,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.12); }
     .question .button.flat {
       border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(61, 128, 204, 0);
+      background-color: rgba(61, 61, 204, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
@@ -1617,8 +1617,8 @@ GtkInfoBar {
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.1); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #679bd7;
-      background-image: linear-gradient(to bottom, #a6c5e8, #3273bd);
+      background-color: #6767d7;
+      background-image: linear-gradient(to bottom, #a6a6e8, #3232bd);
       border-color: rgba(0, 0, 0, 0.2);
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
@@ -1641,74 +1641,74 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #3273bd;
-      background-image: linear-gradient(to bottom, #5791d3, #25568e);
+      background-color: #3232bd;
+      background-image: linear-gradient(to bottom, #5757d3, #25258e);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: #3479c7;
-      background-image: linear-gradient(to bottom, #649ad6, #275b96);
-      color: mix(#3d80cc,#000000,0.5);
+      background-color: #3434c7;
+      background-image: linear-gradient(to bottom, #6464d6, #272796);
+      color: mix(#3d3dcc,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#3d80cc,#000000,0.5);
+      color: mix(#3d3dcc,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #3273bd; }
+      color: #3232bd; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #2f6cb2; }
+        color: #2f2fb2; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #a06060;
+  background-image: linear-gradient(to bottom, #b88888, #784848);
+  border: 1px solid #804d4d;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #a06060;
+    background-image: linear-gradient(to bottom, #b88888, #784848);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
     .error .button:focus, .error .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active, .error .button:active:hover, .error .button:active:focus, .error .button:active:hover:focus, .error .button:checked, .error .button:checked:hover, .error .button:checked:focus, .error .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active:insensitive, .error .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(160, 96, 96, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active, .error .button.flat:active:hover, .error .button.flat:active:focus, .error .button.flat:active:hover:focus, .error .button.flat:checked, .error .button.flat:checked:hover, .error .button.flat:checked:focus, .error .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+      background-color: #b38080;
+      background-image: linear-gradient(to bottom, #d0b0b0, #905656);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active, .error .button:focus:active:hover, .error .button:focus:active:focus, .error .button:focus:active:hover:focus, .error .button:focus:checked, .error .button:focus:checked:hover, .error .button:focus:checked:focus, .error .button:focus:checked:hover:focus, .error .button:hover:active, .error .button:hover:active:hover, .error .button:hover:active:focus, .error .button:hover:active:hover:focus, .error .button:hover:checked, .error .button:hover:checked:hover, .error .button:hover:checked:focus, .error .button:hover:checked:hover:focus, .error .button.flat:focus:active, .error .button.flat:focus:active:hover, .error .button.flat:focus:active:focus, .error .button.flat:focus:active:hover:focus, .error .button.flat:focus:checked, .error .button.flat:focus:checked:hover, .error .button.flat:focus:checked:focus, .error .button.flat:focus:checked:hover:focus, .error .button.flat:hover:active, .error .button.flat:hover:active:hover, .error .button.flat:hover:active:focus, .error .button.flat:hover:active:hover:focus, .error .button.flat:hover:checked, .error .button.flat:hover:checked:hover, .error .button.flat:hover:checked:focus, .error .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:insensitive, .error .button:hover:insensitive, .error .button.flat:focus:insensitive, .error .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active:insensitive, .error .button:focus:checked:insensitive, .error .button:hover:active:insensitive, .error .button:hover:checked:insensitive, .error .button.flat:focus:active:insensitive, .error .button.flat:focus:checked:insensitive, .error .button.flat:hover:active:insensitive, .error .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .error .button:active, .error .button:checked, .error .button.flat:active, .error .button.flat:checked {
       background-color: #3273bd;
       background-image: linear-gradient(to top, #5791d3, #25568e);
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #905656;
+      background-image: linear-gradient(to bottom, #ac7474, #6c4141);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: #985b5b;
+      background-image: linear-gradient(to bottom, #b27e7e, #724444);
+      color: mix(#a06060,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#a06060,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #905656; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #885151; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #3d80cc;
+    background-color: #5dfe50;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #d8d84e;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #a06060; }
 
 .view, GtkHTML {
   color: #d8e5f2;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #2f363d;
   background-color: #3b444c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #a06060;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #804d4d;
+  background-color: #a86d6d;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #704343;
+    background-color: #a06060; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #c1c12a;
+  background-color: #dcdc61;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a9a925;
+    background-color: #d8d84e; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #172e45;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #3d80cc;
+@define-color info_bg_color #3d3dcc;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #d8d84e;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #3d80cc;
+@define-color question_bg_color #3d3dcc;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#3d80cc,#d8e5f2,0.6);
-@define-color success_color #3d80cc;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #a06060;
+@define-color link_color #a9cdf2;
+@define-color success_color #5dfe50;
+@define-color warning_color #d8d84e;
+@define-color error_color #a06060;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#3d80cc,#d8e5f2,0.6); }
+  -GtkIMHtml-hyperlink-color: #a9cdf2; }
   *:disabled, *:disabled:disabled {
-    color: mix(#3d80cc,#d8e5f2,0.6); }
+    color: #a9cdf2; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#3d80cc,#d8e5f2,0.6); }
+    color: #a9cdf2; }
 
 .background {
   background-color: #434e5a;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #c1c12a;
+    background-color: mix(#3b444c,#d8d84e,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#d8d84e,0.3);
+      background-color: #d8d84e;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #d8d84e; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #804d4d;
+    background-color: mix(#3b444c,#a06060,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#a06060,0.3);
+      background-color: #a06060;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a06060; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #804d4d;
+    background-color: mix(#3b444c,#a06060,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#a06060,0.3);
+      background-color: #a06060;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a06060; }
 
 entry {
   background-color: #3b444c;
@@ -1727,8 +1727,8 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #3d80cc;
-  background-image: linear-gradient(to bottom, #71a2da, #29609d);
+  background-color: #5dfe50;
+  background-image: linear-gradient(to bottom, #aafea3, #14f901);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(61, 128, 204, 0);
+    background-color: rgba(93, 254, 80, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,8 +1870,8 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #4787cf;
-    background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+    background-color: #6cfe61;
+    background-image: linear-gradient(to bottom, #bdffb8, #1cfe09);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -1891,8 +1891,8 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #4787cf;
-    background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+    background-color: #6cfe61;
+    background-image: linear-gradient(to bottom, #bdffb8, #1cfe09);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(61, 128, 204, 0.5);
     outline-width: 1px;
@@ -1902,8 +1902,8 @@ searchbar,
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #528ed2;
-      background-image: linear-gradient(to bottom, #8cb4e1, #2e69ad);
+      background-color: #7cfe71;
+      background-image: linear-gradient(to bottom, #d0ffcd, #27fe16);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #000000; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#3d80cc,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#3d80cc,#000000,0.2),0.4),1.25), shade(alpha(mix(#3d80cc,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#5dfe50,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#5dfe50,#000000,0.2),0.4),1.25), shade(alpha(mix(#5dfe50,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#3d80cc,#000000,0.6);
+    color: mix(#5dfe50,#000000,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#3d80cc,#000000,0.6); }
+      color: mix(#5dfe50,#000000,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,18 +1981,18 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(61, 128, 204, 0.9); }
+    color: rgba(93, 254, 80, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(61, 128, 204, 0.85); }
+      color: rgba(93, 254, 80, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a06060;
+  background-image: linear-gradient(to bottom, #b88888, #784848);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
   .destructive-action:focus, .destructive-action:hover {
     border-color: mix(#3d80cc,rgba(0, 0, 0, 0.32),0.3); }
   .destructive-action:active, .destructive-action:active:hover, .destructive-action:active:focus, .destructive-action:active:hover:focus, .destructive-action:checked, .destructive-action:checked:hover, .destructive-action:checked:focus, .destructive-action:checked:hover:focus {
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(160, 96, 96, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,11 +2056,11 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a56868;
+    background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     .destructive-action:hover:focus, .destructive-action:hover:hover, .destructive-action.flat:hover:focus, .destructive-action.flat:hover:hover {
       border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
     .destructive-action:hover:active, .destructive-action:hover:active:hover, .destructive-action:hover:active:focus, .destructive-action:hover:active:hover:focus, .destructive-action:hover:checked, .destructive-action:hover:checked:hover, .destructive-action:hover:checked:focus, .destructive-action:hover:checked:hover:focus, .destructive-action.flat:hover:active, .destructive-action.flat:hover:active:hover, .destructive-action.flat:hover:active:focus, .destructive-action.flat:hover:active:hover:focus, .destructive-action.flat:hover:checked, .destructive-action.flat:hover:checked:hover, .destructive-action.flat:hover:checked:focus, .destructive-action.flat:hover:checked:hover:focus {
@@ -2070,20 +2070,20 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a56868;
+    background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(61, 128, 204, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #aa7070;
+      background-image: linear-gradient(to bottom, #c49c9c, #844f4f);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
         border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
       .destructive-action:focus:hover:active, .destructive-action:focus:hover:active:hover, .destructive-action:focus:hover:active:focus, .destructive-action:focus:hover:active:hover:focus, .destructive-action:focus:hover:checked, .destructive-action:focus:hover:checked:hover, .destructive-action:focus:hover:checked:focus, .destructive-action:focus:hover:checked:hover:focus, .destructive-action.flat:focus:hover:active, .destructive-action.flat:focus:hover:active:hover, .destructive-action.flat:focus:hover:active:focus, .destructive-action.flat:focus:hover:active:hover:focus, .destructive-action.flat:focus:hover:checked, .destructive-action.flat:focus:hover:checked:hover, .destructive-action.flat:focus:hover:checked:focus, .destructive-action.flat:focus:hover:checked:hover:focus {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a06060,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a06060,#000000,0.2),0.4),1.25), shade(alpha(mix(#a06060,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#a06060,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#a06060,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(61, 128, 204, 0.6);
     background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(160, 96, 96, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(160, 96, 96, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,15 +3202,15 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
-    border: 1px solid #2c66a8;
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
+    border: 1px solid #2c2ca8;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(61, 128, 204, 0);
+      background-color: rgba(61, 61, 204, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,8 +3277,8 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #4787cf;
-      background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+      background-color: #4747cf;
+      background-image: linear-gradient(to bottom, #7f7fdd, #2b2ba5);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -3291,8 +3291,8 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #4787cf;
-      background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+      background-color: #4747cf;
+      background-image: linear-gradient(to bottom, #7f7fdd, #2b2ba5);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(61, 128, 204, 0.5);
       outline-width: 1px;
@@ -3301,8 +3301,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #528ed2;
-        background-image: linear-gradient(to bottom, #8cb4e1, #2e69ad);
+        background-color: #5252d2;
+        background-image: linear-gradient(to bottom, #8c8ce1, #2e2ead);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#3d80cc,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#3d80cc,#000000,0.2),0.4),1.25), shade(alpha(mix(#3d80cc,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#3d3dcc,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#3d3dcc,#000000,0.2),0.4),1.25), shade(alpha(mix(#3d3dcc,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#3d80cc,#000000,0.6);
+      color: mix(#3d3dcc,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#3d80cc,#000000,0.6); }
+        color: mix(#3d3dcc,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -3353,22 +3353,22 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(61, 128, 204, 0.9); }
+      color: rgba(61, 61, 204, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(61, 128, 204, 0.85); }
+        color: rgba(61, 61, 204, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #d8d84e;
+    background-image: linear-gradient(to bottom, #e5e58a, #b5b528);
+    border: 1px solid #c1c12a;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #d8d84e;
+    background-image: linear-gradient(to bottom, #e5e58a, #b5b528);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
     infobar.warning button:focus, infobar.warning button:hover {
       border-color: mix(#3d80cc,rgba(0, 0, 0, 0.32),0.3); }
     infobar.warning button:active, infobar.warning button:active:hover, infobar.warning button:active:focus, infobar.warning button:active:hover:focus, infobar.warning button:checked, infobar.warning button:checked:hover, infobar.warning button:checked:focus, infobar.warning button:checked:hover:focus {
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(216, 216, 78, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,11 +3432,11 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #dbdb5a;
+      background-image: linear-gradient(to bottom, #e9e999, #bebe2a);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
       infobar.warning button:hover:focus, infobar.warning button:hover:hover, infobar.warning button.flat:hover:focus, infobar.warning button.flat:hover:hover {
         border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
       infobar.warning button:hover:active, infobar.warning button:hover:active:hover, infobar.warning button:hover:active:focus, infobar.warning button:hover:active:hover:focus, infobar.warning button:hover:checked, infobar.warning button:hover:checked:hover, infobar.warning button:hover:checked:focus, infobar.warning button:hover:checked:hover:focus, infobar.warning button.flat:hover:active, infobar.warning button.flat:hover:active:hover, infobar.warning button.flat:hover:active:focus, infobar.warning button.flat:hover:active:hover:focus, infobar.warning button.flat:hover:checked, infobar.warning button.flat:hover:checked:hover, infobar.warning button.flat:hover:checked:focus, infobar.warning button.flat:hover:checked:hover:focus {
@@ -3446,20 +3446,20 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #dbdb5a;
+      background-image: linear-gradient(to bottom, #e9e999, #bebe2a);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(61, 128, 204, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #dddd66;
+        background-image: linear-gradient(to bottom, #ececa8, #c7c72c);
         border-color: rgba(0, 0, 0, 0.4);
-        box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
           border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
         infobar.warning button:focus:hover:active, infobar.warning button:focus:hover:active:hover, infobar.warning button:focus:hover:active:focus, infobar.warning button:focus:hover:active:hover:focus, infobar.warning button:focus:hover:checked, infobar.warning button:focus:hover:checked:hover, infobar.warning button:focus:hover:checked:focus, infobar.warning button:focus:hover:checked:hover:focus, infobar.warning button.flat:focus:hover:active, infobar.warning button.flat:focus:hover:active:hover, infobar.warning button.flat:focus:hover:active:focus, infobar.warning button.flat:focus:hover:active:hover:focus, infobar.warning button.flat:focus:hover:checked, infobar.warning button.flat:focus:hover:checked:hover, infobar.warning button.flat:focus:hover:checked:focus, infobar.warning button.flat:focus:hover:checked:hover:focus {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#d8d84e,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#d8d84e,#000000,0.2),0.4),1.25), shade(alpha(mix(#d8d84e,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#d8d84e,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#d8d84e,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -3508,19 +3508,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(216, 216, 78, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(216, 216, 78, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
-    border: 1px solid #2c66a8;
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
+    border: 1px solid #2c2ca8;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #3d80cc;
-    background-image: linear-gradient(to bottom, #71a2da, #29609d);
+    background-color: #3d3dcc;
+    background-image: linear-gradient(to bottom, #7171da, #29299d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(61, 128, 204, 0);
+      background-color: rgba(61, 61, 204, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,8 +3587,8 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #4787cf;
-      background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+      background-color: #4747cf;
+      background-image: linear-gradient(to bottom, #7f7fdd, #2b2ba5);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -3601,8 +3601,8 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #4787cf;
-      background-image: linear-gradient(to bottom, #7fabdd, #2b65a5);
+      background-color: #4747cf;
+      background-image: linear-gradient(to bottom, #7f7fdd, #2b2ba5);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(61, 128, 204, 0.5);
       outline-width: 1px;
@@ -3611,8 +3611,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #528ed2;
-        background-image: linear-gradient(to bottom, #8cb4e1, #2e69ad);
+        background-color: #5252d2;
+        background-image: linear-gradient(to bottom, #8c8ce1, #2e2ead);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#3d80cc,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#3d80cc,#000000,0.2),0.4),1.25), shade(alpha(mix(#3d80cc,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#3d3dcc,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#3d3dcc,#000000,0.2),0.4),1.25), shade(alpha(mix(#3d3dcc,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#3d80cc,#000000,0.6);
+      color: mix(#3d3dcc,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#3d80cc,#000000,0.6); }
+        color: mix(#3d3dcc,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -3663,22 +3663,22 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(61, 128, 204, 0.9); }
+      color: rgba(61, 61, 204, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(61, 128, 204, 0.85); }
+        color: rgba(61, 61, 204, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #a06060;
+    background-image: linear-gradient(to bottom, #b88888, #784848);
+    border: 1px solid #804d4d;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #a06060;
+    background-image: linear-gradient(to bottom, #b88888, #784848);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
     infobar.error button:focus, infobar.error button:hover {
       border-color: mix(#3d80cc,rgba(0, 0, 0, 0.32),0.3); }
     infobar.error button:active, infobar.error button:active:hover, infobar.error button:active:focus, infobar.error button:active:hover:focus, infobar.error button:checked, infobar.error button:checked:hover, infobar.error button:checked:focus, infobar.error button:checked:hover:focus {
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(160, 96, 96, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,11 +3742,11 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a56868;
+      background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
       infobar.error button:hover:focus, infobar.error button:hover:hover, infobar.error button.flat:hover:focus, infobar.error button.flat:hover:hover {
         border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
       infobar.error button:hover:active, infobar.error button:hover:active:hover, infobar.error button:hover:active:focus, infobar.error button:hover:active:hover:focus, infobar.error button:hover:checked, infobar.error button:hover:checked:hover, infobar.error button:hover:checked:focus, infobar.error button:hover:checked:hover:focus, infobar.error button.flat:hover:active, infobar.error button.flat:hover:active:hover, infobar.error button.flat:hover:active:focus, infobar.error button.flat:hover:active:hover:focus, infobar.error button.flat:hover:checked, infobar.error button.flat:hover:checked:hover, infobar.error button.flat:hover:checked:focus, infobar.error button.flat:hover:checked:hover:focus {
@@ -3756,20 +3756,20 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #a56868;
+      background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(61, 128, 204, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #000000;
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #aa7070;
+        background-image: linear-gradient(to bottom, #c49c9c, #844f4f);
         border-color: rgba(0, 0, 0, 0.4);
-        box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
           border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
         infobar.error button:focus:hover:active, infobar.error button:focus:hover:active:hover, infobar.error button:focus:hover:active:focus, infobar.error button:focus:hover:active:hover:focus, infobar.error button:focus:hover:checked, infobar.error button:focus:hover:checked:hover, infobar.error button:focus:hover:checked:focus, infobar.error button:focus:hover:checked:hover:focus, infobar.error button.flat:focus:hover:active, infobar.error button.flat:focus:hover:active:hover, infobar.error button.flat:focus:hover:active:focus, infobar.error button.flat:focus:hover:active:hover:focus, infobar.error button.flat:focus:hover:checked, infobar.error button.flat:focus:hover:checked:hover, infobar.error button.flat:focus:hover:checked:focus, infobar.error button.flat:focus:hover:checked:hover:focus {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#a06060,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#a06060,#000000,0.2),0.4),1.25), shade(alpha(mix(#a06060,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#a06060,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#a06060,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(160, 96, 96, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(160, 96, 96, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #c1c12a;
+    background-color: mix(#3b444c,#d8d84e,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#d8d84e,0.3);
+      background-color: #d8d84e;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #d8d84e; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #804d4d;
+    background-color: mix(#3b444c,#a06060,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#a06060,0.3);
+      background-color: #a06060;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a06060; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#3b444c,#ff0000,0.6); }
+    border-color: #804d4d;
+    background-color: mix(#3b444c,#a06060,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#3d80cc,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#3d80cc,#a06060,0.3);
+      background-color: #a06060;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #a06060; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#434e5a,#d8e5f2,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #bd9090; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #3d80cc; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #d8d84e;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #3d80cc;
+    background-color: #5dfe50;
     border-color: transparent; }
   levelbar block.full {
     background-color: #2c66a8;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #2f363d;
   background-color: #3b444c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #a06060;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #ff0000; }
+  background-color: #a06060; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #aa7070; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,11 +8947,11 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #a06060;
+  background-image: linear-gradient(to bottom, #b88888, #784848);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
   #shutdown_button button:focus, #shutdown_button button:hover {
     border-color: mix(#3d80cc,rgba(0, 0, 0, 0.32),0.3); }
   #shutdown_button button:active, #shutdown_button button:active:hover, #shutdown_button button:active:focus, #shutdown_button button:active:hover:focus, #shutdown_button button:checked, #shutdown_button button:checked:hover, #shutdown_button button:checked:focus, #shutdown_button button:checked:hover:focus {
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(160, 96, 96, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,11 +9015,11 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a56868;
+    background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     #shutdown_button button:hover:focus, #shutdown_button button:hover:hover, #shutdown_button button.flat:hover:focus, #shutdown_button button.flat:hover:hover {
       border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
     #shutdown_button button:hover:active, #shutdown_button button:hover:active:hover, #shutdown_button button:hover:active:focus, #shutdown_button button:hover:active:hover:focus, #shutdown_button button:hover:checked, #shutdown_button button:hover:checked:hover, #shutdown_button button:hover:checked:focus, #shutdown_button button:hover:checked:hover:focus, #shutdown_button button.flat:hover:active, #shutdown_button button.flat:hover:active:hover, #shutdown_button button.flat:hover:active:focus, #shutdown_button button.flat:hover:active:hover:focus, #shutdown_button button.flat:hover:checked, #shutdown_button button.flat:hover:checked:hover, #shutdown_button button.flat:hover:checked:focus, #shutdown_button button.flat:hover:checked:hover:focus {
@@ -9029,20 +9029,20 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #a56868;
+    background-image: linear-gradient(to bottom, #be9292, #7e4b4b);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(61, 128, 204, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #aa7070;
+      background-image: linear-gradient(to bottom, #c49c9c, #844f4f);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
         border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
       #shutdown_button button:focus:hover:active, #shutdown_button button:focus:hover:active:hover, #shutdown_button button:focus:hover:active:focus, #shutdown_button button:focus:hover:active:hover:focus, #shutdown_button button:focus:hover:checked, #shutdown_button button:focus:hover:checked:hover, #shutdown_button button:focus:hover:checked:focus, #shutdown_button button:focus:hover:checked:hover:focus, #shutdown_button button.flat:focus:hover:active, #shutdown_button button.flat:focus:hover:active:hover, #shutdown_button button.flat:focus:hover:active:focus, #shutdown_button button.flat:focus:hover:active:hover:focus, #shutdown_button button.flat:focus:hover:checked, #shutdown_button button.flat:focus:hover:checked:hover, #shutdown_button button.flat:focus:hover:checked:focus, #shutdown_button button.flat:focus:hover:checked:hover:focus {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#a06060,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#a06060,#000000,0.2),0.4),1.25), shade(alpha(mix(#a06060,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#a06060,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#a06060,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(61, 128, 204, 0.6);
     background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -9091,17 +9091,17 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(160, 96, 96, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(160, 96, 96, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #d8d84e;
+  background-image: linear-gradient(to bottom, #e5e58a, #b5b528);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
-  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.12); }
   #restart_button button:focus, #restart_button button:hover {
     border-color: mix(#3d80cc,rgba(0, 0, 0, 0.32),0.3); }
   #restart_button button:active, #restart_button button:active:hover, #restart_button button:active:focus, #restart_button button:active:hover:focus, #restart_button button:checked, #restart_button button:checked:hover, #restart_button button:checked:focus, #restart_button button:checked:hover:focus {
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(216, 216, 78, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,11 +9165,11 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #dbdb5a;
+    background-image: linear-gradient(to bottom, #e9e999, #bebe2a);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     #restart_button button:hover:focus, #restart_button button:hover:hover, #restart_button button.flat:hover:focus, #restart_button button.flat:hover:hover {
       border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
     #restart_button button:hover:active, #restart_button button:hover:active:hover, #restart_button button:hover:active:focus, #restart_button button:hover:active:hover:focus, #restart_button button:hover:checked, #restart_button button:hover:checked:hover, #restart_button button:hover:checked:focus, #restart_button button:hover:checked:hover:focus, #restart_button button.flat:hover:active, #restart_button button.flat:hover:active:hover, #restart_button button.flat:hover:active:focus, #restart_button button.flat:hover:active:hover:focus, #restart_button button.flat:hover:checked, #restart_button button.flat:hover:checked:hover, #restart_button button.flat:hover:checked:focus, #restart_button button.flat:hover:checked:hover:focus {
@@ -9179,20 +9179,20 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #dbdb5a;
+    background-image: linear-gradient(to bottom, #e9e999, #bebe2a);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(61, 128, 204, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #000000;
-    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #dddd66;
+      background-image: linear-gradient(to bottom, #ececa8, #c7c72c);
       border-color: rgba(0, 0, 0, 0.4);
-      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.38); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
         border-color: mix(#3d80cc,rgba(0, 0, 0, 0.4),0.3); }
       #restart_button button:focus:hover:active, #restart_button button:focus:hover:active:hover, #restart_button button:focus:hover:active:focus, #restart_button button:focus:hover:active:hover:focus, #restart_button button:focus:hover:checked, #restart_button button:focus:hover:checked:hover, #restart_button button:focus:hover:checked:focus, #restart_button button:focus:hover:checked:hover:focus, #restart_button button.flat:focus:hover:active, #restart_button button.flat:focus:hover:active:hover, #restart_button button.flat:focus:hover:active:focus, #restart_button button.flat:focus:hover:active:hover:focus, #restart_button button.flat:focus:hover:checked, #restart_button button.flat:focus:hover:checked:hover, #restart_button button.flat:focus:hover:checked:focus, #restart_button button.flat:focus:hover:checked:hover:focus {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#d8d84e,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#d8d84e,#000000,0.2),0.4),1.25), shade(alpha(mix(#d8d84e,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#d8d84e,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#d8d84e,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(61, 128, 204, 0.6);
     background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(216, 216, 78, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(216, 216, 78, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/info.json
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Rhino", 
-	"description": "Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/qt5ct/Cinnamox-Rhino.conf
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/qt5ct/Cinnamox-Rhino.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#d8e5f2,          #434e5a, #434e5a, #434e5a, #1c2126, #1c2126, #d8e5f2,           #d8e5f2,           #d8e5f2,           #3b444c, #434e5a, #1c2126, #3d80cc, #000000, #3d80cc, #d8e5f2,            #434e5a, #d8e5f2,           1c2126,  #d8e5f2
+disabled_colors=#b2bfcc, #434e5a, #434e5a, #434e5a, #1c2126, #1c2126, #b0bcc8,  #b0bcc8,  #b2bfcc,  #3b444c, #434e5a, #1c2126, #3d80cc, #000000, #3d80cc, #b2bfcc,   #434e5a, #b2bfcc,  #1c2126, #a9b4bf
+inactive_colors=#d8e5f2,          #434e5a, #434e5a, #434e5a, #1c2126, #1c2126, #d8e5f2,           #d8e5f2,           #d8e5f2,           #3b444c, #434e5a, #1c2126, #3d80cc, #000000, #3d80cc, #d8e5f2,            #434e5a, #d8e5f2,           #1c2126, #d8e5f2
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#d8e5f2,          #3b444c, #434e5a, #cbc7c4, #9f9d9a, #b8b5b2, #d8e5f2,           #ff0000, #d8e5f2, #3b444c, #434e5a, #767472, #3d80cc, #000000, #3d80cc, #d8e5f2,            #434e5a, #d8e5f2,           1c2126, #d8e5f2
+#disabled_colors=#b2bfcc, #3b444c, #434e5a, #cbc7c4, #9f9d9a, #b8b5b2, #b0bcc8,  #ffec17, #d8e5f2, #3b444c, #434e5a, #767472, #3d80cc, #000000, #3d80cc, #b2bfcc,   #434e5a, #b2bfcc,  #1c2126, #a9b4bf
+#inactive_colors=#d8e5f2,          #3b444c, #434e5a, #cbc7c4, #9f9d9a, #b8b5b2, #d8e5f2,           #ff9040, #d8e5f2, #3b444c, #434e5a, #767472, #3d80cc, #000000, #3d80cc, #d8e5f2,            #434e5a, #d8e5f2,           #1c2126, #d8e5f2

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Rhino.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Rhino;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Rhino/info.json
+++ b/Cinnamox-Rhino/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Rhino", 
-	"description": "Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Rosso-Cursa
 
-Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Rosso-Cursa
 
-Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Rosso-Cursa */
 /* Transparency: None */
-/* Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #f2dada;
+    color: #cc009c;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #cccc00;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #cc009c;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Rosso-Cursa. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Rosso-Cursa
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/gtkrc
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#800000\nbg_color:#CC0000\ntooltip_bg_color:#CC0000\nselected_bg_color:#CC6600\ntext_color:#f2dada\nfg_color:#f2dada\ntooltip_fg_color:#f2dada\nselected_fg_color:#000000\nmenubar_bg_color:#4C0000\nmenubar_fg_color:#f2dada\ntoolbar_bg_color:#CC0000\ntoolbar_fg_color:#f2dada\nmenu_bg_color:#4C0000\nmenu_fg_color:#f2dada\npanel_bg_color:#CC0000\npanel_fg_color:#f2dada\nlink_color:#CC6600\nbtn_bg_color:#800000\nbtn_fg_color:#f2dada\ntitlebar_bg_color:#4C0000\ntitlebar_fg_color:#f2dada\nprimary_caret_color:#f2dada\nsecondary_caret_color:#f2dada\n"
+"base_color:#800000\nbg_color:#CC0000\ntooltip_bg_color:#CC0000\nselected_bg_color:#CC6600\ntext_color:#f2dada\nfg_color:#f2dada\ntooltip_fg_color:#f2dada\nselected_fg_color:#000000\nmenubar_bg_color:#4C0000\nmenubar_fg_color:#f2dada\ntoolbar_bg_color:#CC0000\ntoolbar_fg_color:#f2dada\nmenu_bg_color:#4C0000\nmenu_fg_color:#f2dada\npanel_bg_color:#CC0000\npanel_fg_color:#f2dada\nlink_color:#f2a9a9\nbtn_bg_color:#800000\nbtn_fg_color:#f2dada\ntitlebar_bg_color:#4C0000\ntitlebar_fg_color:#f2dada\nprimary_caret_color:#f2dada\nsecondary_caret_color:#f2dada\naccent_bg_color:#CC6600\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#800000\nbg_color:#CC0000\ntooltip_bg_color:#CC0000\nselected_bg_color:#CC6600\ntext_color:#f2dada\nfg_color:#f2dada\ntooltip_fg_color:#f2dada\nselected_fg_color:#000000\nmenubar_bg_color:#4C0000\nmenubar_fg_color:#f2dada\ntoolbar_bg_color:#CC0000\ntoolbar_fg_color:#f2dada\nmenu_bg_color:#4C0000\nmenu_fg_color:#f2dada\npanel_bg_color:#CC0000\npanel_fg_color:#f2dada\nlink_color:#CC6600\nbtn_bg_color:#800000\nbtn_fg_color:#f2dada\ntitlebar_bg_color:#4C0000\ntitlebar_fg_color:#f2dada\n"
+"base_color:#800000\nbg_color:#CC0000\ntooltip_bg_color:#CC0000\nselected_bg_color:#CC6600\ntext_color:#f2dada\nfg_color:#f2dada\ntooltip_fg_color:#f2dada\nselected_fg_color:#000000\nmenubar_bg_color:#4C0000\nmenubar_fg_color:#f2dada\ntoolbar_bg_color:#CC0000\ntoolbar_fg_color:#f2dada\nmenu_bg_color:#4C0000\nmenu_fg_color:#f2dada\npanel_bg_color:#CC0000\npanel_fg_color:#f2dada\nlink_color:#f2a9a9\nbtn_bg_color:#800000\nbtn_fg_color:#f2dada\ntitlebar_bg_color:#4C0000\ntitlebar_fg_color:#f2dada\nprimary_caret_color:#f2dada\nsecondary_caret_color:#f2dada\naccent_bg_color:#CC6600\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.0/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #441818;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #CC6600;
+@define-color info_bg_color #6e6656;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #008763;
+@define-color warning_bg_color #cccc00;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #CC6600;
+@define-color question_bg_color #6e6656;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #008763;
-@define-color link_color mix(#CC6600,#f2dada,0.6);
-@define-color success_color #CC6600;
-@define-color warning_color #008763;
-@define-color error_color #008763;
+@define-color error_bg_color #cc009c;
+@define-color link_color #f2a9a9;
+@define-color success_color #8ee400;
+@define-color warning_color #cccc00;
+@define-color error_color #cc009c;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#CC6600,#f2dada,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#CC6600,#f2dada,0.6);
-  -GtkWidget-link-color: mix(#CC6600,#f2dada,0.6);
-  -GtkWidget-visited-link-color: mix(#CC6600,#f2dada,0.6); }
+  -GtkHTML-link-color: #f2a9a9;
+  -GtkIMHtml-hyperlink-color: #f2a9a9;
+  -GtkWidget-link-color: #f2a9a9;
+  -GtkWidget-visited-link-color: #f2a9a9; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#CC6600,#f2dada,0.6); }
+    color: #f2a9a9; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#CC6600,#f2dada,0.6); }
+    color: #f2a9a9; }
 
 .background {
   background-color: #CC0000;
@@ -898,8 +898,8 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #CC6600;
-  background-image: linear-gradient(to bottom, #ff8000, #994d00);
+  background-color: #8ee400;
+  background-image: linear-gradient(to bottom, #aaff1e, #6bab00);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -913,7 +913,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(204, 102, 0, 0);
+    background-color: rgba(142, 228, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
@@ -925,8 +925,8 @@ GtkComboBox .separator {
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #f57a00;
-    background-image: linear-gradient(to bottom, #ff9933, #b85c00);
+    background-color: #a6ff13;
+    background-image: linear-gradient(to bottom, #c0ff57, #80cd00);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
@@ -949,32 +949,32 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #000000; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #b85c00;
-    background-image: linear-gradient(to bottom, #e67300, #8a4500);
+    background-color: #80cd00;
+    background-image: linear-gradient(to bottom, #9fff02, #609a00);
     color: #000000;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: rgba(204, 102, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.3), rgba(153, 77, 0, 0.3));
-    color: mix(#CC6600,#000000,0.5);
+    background-color: rgba(142, 228, 0, 0.3);
+    background-image: linear-gradient(to bottom, rgba(170, 255, 30, 0.3), rgba(107, 171, 0, 0.3));
+    color: mix(#8ee400,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #000000; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#CC6600,#000000,0.5);
+    color: mix(#8ee400,#000000,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #b85c00; }
+    color: #80cd00; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #ad5700; }
+      color: #79c200; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
+  background-color: #cc009c;
+  background-image: linear-gradient(to bottom, #ff00c3, #990075);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -988,7 +988,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .destructive-action.button.flat {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(0, 135, 99, 0);
+    background-color: rgba(204, 0, 156, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
@@ -1000,8 +1000,8 @@ GtkComboBox .separator {
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #00a277;
-    background-image: linear-gradient(to bottom, #00cb95, #007a59);
+    background-color: #f500bb;
+    background-image: linear-gradient(to bottom, #ff33cf, #b8008c);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #007a59;
-    background-image: linear-gradient(to bottom, #00986f, #005b43);
+    background-color: #b8008c;
+    background-image: linear-gradient(to bottom, #e600b0, #8a0069);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(0, 135, 99, 0.3);
-    background-image: linear-gradient(to bottom, rgba(0, 169, 124, 0.3), rgba(0, 101, 74, 0.3));
-    color: mix(#008763,#000000,0.5);
+    background-color: rgba(204, 0, 156, 0.3);
+    background-image: linear-gradient(to bottom, rgba(255, 0, 195, 0.3), rgba(153, 0, 117, 0.3));
+    color: mix(#cc009c,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#008763,#000000,0.5);
+    color: mix(#cc009c,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #007a59; }
+    color: #b8008c; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #007354; }
+      color: #ad0085; }
 
 /******************
 * selection mode *
@@ -1424,14 +1424,14 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #CC6600;
-  background-image: linear-gradient(to bottom, #ff8000, #994d00);
-  border: 1px solid #a35200;
+  background-color: #6e6656;
+  background-image: linear-gradient(to bottom, #8a806c, #534d41);
+  border: 1px solid #585245;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1445,7 +1445,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .info .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(204, 102, 0, 0);
+      background-color: rgba(110, 102, 86, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
@@ -1457,8 +1457,8 @@ GtkInfoBar {
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #f57a00;
-      background-image: linear-gradient(to bottom, #ff9933, #b85c00);
+      background-color: #847a67;
+      background-image: linear-gradient(to bottom, #a09786, #635c4d);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
@@ -1481,37 +1481,37 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #b85c00;
-      background-image: linear-gradient(to bottom, #e67300, #8a4500);
+      background-color: #635c4d;
+      background-image: linear-gradient(to bottom, #7c7361, #4a453a);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: rgba(204, 102, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.3), rgba(153, 77, 0, 0.3));
-      color: mix(#CC6600,#000000,0.5);
+      background-color: rgba(110, 102, 86, 0.3);
+      background-image: linear-gradient(to bottom, rgba(138, 128, 108, 0.3), rgba(83, 77, 65, 0.3));
+      color: mix(#6e6656,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#CC6600,#000000,0.5);
+      color: mix(#6e6656,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #b85c00; }
+      color: #635c4d; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #ad5700; }
+        color: #5e5749; }
 
 .warning {
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
-  border: 1px solid #006c4f;
+  background-color: #cccc00;
+  background-image: linear-gradient(to bottom, yellow, #999900);
+  border: 1px solid #a3a300;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
+    background-color: #cccc00;
+    background-image: linear-gradient(to bottom, yellow, #999900);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1525,7 +1525,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .warning .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(0, 135, 99, 0);
+      background-color: rgba(204, 204, 0, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
@@ -1537,8 +1537,8 @@ GtkInfoBar {
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #00a277;
-      background-image: linear-gradient(to bottom, #00cb95, #007a59);
+      background-color: #f5f500;
+      background-image: linear-gradient(to bottom, #ffff33, #b8b800);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
@@ -1561,37 +1561,37 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #007a59;
-      background-image: linear-gradient(to bottom, #00986f, #005b43);
+      background-color: #b8b800;
+      background-image: linear-gradient(to bottom, #e6e600, #8a8a00);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(0, 135, 99, 0.3);
-      background-image: linear-gradient(to bottom, rgba(0, 169, 124, 0.3), rgba(0, 101, 74, 0.3));
-      color: mix(#008763,#000000,0.5);
+      background-color: rgba(204, 204, 0, 0.3);
+      background-image: linear-gradient(to bottom, rgba(255, 255, 0, 0.3), rgba(153, 153, 0, 0.3));
+      color: mix(#cccc00,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#008763,#000000,0.5);
+      color: mix(#cccc00,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #007a59; }
+      color: #b8b800; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #007354; }
+        color: #adad00; }
 
 .question {
-  background-color: #CC6600;
-  background-image: linear-gradient(to bottom, #ff8000, #994d00);
-  border: 1px solid #a35200;
+  background-color: #6e6656;
+  background-image: linear-gradient(to bottom, #8a806c, #534d41);
+  border: 1px solid #585245;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1605,7 +1605,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .question .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(204, 102, 0, 0);
+      background-color: rgba(110, 102, 86, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
@@ -1617,8 +1617,8 @@ GtkInfoBar {
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #f57a00;
-      background-image: linear-gradient(to bottom, #ff9933, #b85c00);
+      background-color: #847a67;
+      background-image: linear-gradient(to bottom, #a09786, #635c4d);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
@@ -1641,37 +1641,37 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #b85c00;
-      background-image: linear-gradient(to bottom, #e67300, #8a4500);
+      background-color: #635c4d;
+      background-image: linear-gradient(to bottom, #7c7361, #4a453a);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: rgba(204, 102, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.3), rgba(153, 77, 0, 0.3));
-      color: mix(#CC6600,#000000,0.5);
+      background-color: rgba(110, 102, 86, 0.3);
+      background-image: linear-gradient(to bottom, rgba(138, 128, 108, 0.3), rgba(83, 77, 65, 0.3));
+      color: mix(#6e6656,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#CC6600,#000000,0.5);
+      color: mix(#6e6656,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #b85c00; }
+      color: #635c4d; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #ad5700; }
+        color: #5e5749; }
 
 .error {
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
-  border: 1px solid #006c4f;
+  background-color: #cc009c;
+  background-image: linear-gradient(to bottom, #ff00c3, #990075);
+  border: 1px solid #a3007d;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
+    background-color: #cc009c;
+    background-image: linear-gradient(to bottom, #ff00c3, #990075);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1685,7 +1685,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .error .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(0, 135, 99, 0);
+      background-color: rgba(204, 0, 156, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
@@ -1697,8 +1697,8 @@ GtkInfoBar {
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #00a277;
-      background-image: linear-gradient(to bottom, #00cb95, #007a59);
+      background-color: #f500bb;
+      background-image: linear-gradient(to bottom, #ff33cf, #b8008c);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #007a59;
-      background-image: linear-gradient(to bottom, #00986f, #005b43);
+      background-color: #b8008c;
+      background-image: linear-gradient(to bottom, #e600b0, #8a0069);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(0, 135, 99, 0.3);
-      background-image: linear-gradient(to bottom, rgba(0, 169, 124, 0.3), rgba(0, 101, 74, 0.3));
-      color: mix(#008763,#000000,0.5);
+      background-color: rgba(204, 0, 156, 0.3);
+      background-image: linear-gradient(to bottom, rgba(255, 0, 195, 0.3), rgba(153, 0, 117, 0.3));
+      color: mix(#cc009c,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#008763,#000000,0.5);
+      color: mix(#cc009c,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #007a59; }
+      color: #b8008c; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #007354; }
+        color: #ad0085; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #CC6600;
+    background-color: #8ee400;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #008763;
+    background-color: #cccc00;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #008763; }
+  -GtkTextView-error-underline-color: #cc009c; }
 
 .view, GtkHTML {
   color: #f2dada;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #660000;
   background-color: #800000; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #008763;
+    background-color: #cc009c;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #006c4f;
-  background-color: #00926b;
+  border-color: #a3007d;
+  background-color: #dc00a8;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #005f45;
-    background-color: #008763; }
+    border-color: #8f006d;
+    background-color: #cc009c; }
 
 /* restart button */
 #restart_button {
-  border-color: #006c4f;
-  background-color: #00926b;
+  border-color: #a3a300;
+  background-color: #dcdc00;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #005f45;
-    background-color: #008763; }
+    border-color: #8f8f00;
+    background-color: #cccc00; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #441818;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #CC6600;
+@define-color info_bg_color #6e6656;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #008763;
+@define-color warning_bg_color #cccc00;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #CC6600;
+@define-color question_bg_color #6e6656;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #008763;
-@define-color link_color mix(#CC6600,#f2dada,0.6);
-@define-color success_color #CC6600;
-@define-color warning_color #008763;
-@define-color error_color #008763;
+@define-color error_bg_color #cc009c;
+@define-color link_color #f2a9a9;
+@define-color success_color #8ee400;
+@define-color warning_color #cccc00;
+@define-color error_color #cc009c;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#CC6600,#f2dada,0.6); }
+  -GtkIMHtml-hyperlink-color: #f2a9a9; }
   *:disabled, *:disabled:disabled {
-    color: mix(#CC6600,#f2dada,0.6); }
+    color: #f2a9a9; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#CC6600,#f2dada,0.6); }
+    color: #f2a9a9; }
 
 .background {
   background-color: #CC0000;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3a300;
+    background-color: mix(#800000,#cccc00,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cccc00,0.3);
+      background-color: #cccc00;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cccc00; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3007d;
+    background-color: mix(#800000,#cc009c,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cc009c,0.3);
+      background-color: #cc009c;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cc009c; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3007d;
+    background-color: mix(#800000,#cc009c,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cc009c,0.3);
+      background-color: #cc009c;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cc009c; }
 
 entry {
   background-color: #800000;
@@ -1727,8 +1727,8 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #CC6600;
-  background-image: linear-gradient(to bottom, #ff8000, #994d00);
+  background-color: #8ee400;
+  background-image: linear-gradient(to bottom, #aaff1e, #6bab00);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(204, 102, 0, 0);
+    background-color: rgba(142, 228, 0, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,8 +1870,8 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #d66b00;
-    background-image: linear-gradient(to bottom, #ff860d, #a15000);
+    background-color: #95ef00;
+    background-image: linear-gradient(to bottom, #b0ff2c, #70b400);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -1891,8 +1891,8 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #d66b00;
-    background-image: linear-gradient(to bottom, #ff860d, #a15000);
+    background-color: #95ef00;
+    background-image: linear-gradient(to bottom, #b0ff2c, #70b400);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(204, 102, 0, 0.5);
     outline-width: 1px;
@@ -1902,8 +1902,8 @@ searchbar,
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #e07000;
-      background-image: linear-gradient(to bottom, #ff8c1a, #a85400);
+      background-color: #9cfb00;
+      background-image: linear-gradient(to bottom, #b5ff3b, #75bc00);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #000000; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#CC6600,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#CC6600,#000000,0.2),0.4),1.25), shade(alpha(mix(#CC6600,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#8ee400,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#8ee400,#000000,0.2),0.4),1.25), shade(alpha(mix(#8ee400,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#CC6600,#000000,0.6);
+    color: mix(#8ee400,#000000,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#CC6600,#000000,0.6); }
+      color: mix(#8ee400,#000000,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,15 +1981,15 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(204, 102, 0, 0.9); }
+    color: rgba(142, 228, 0, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(204, 102, 0, 0.85); }
+      color: rgba(142, 228, 0, 0.85); }
 
 .destructive-action {
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
+  background-color: #cc009c;
+  background-image: linear-gradient(to bottom, #ff00c3, #990075);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(0, 135, 99, 0);
+    background-color: rgba(204, 0, 156, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,8 +2056,8 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d600a4;
+    background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -2070,8 +2070,8 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d600a4;
+    background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(204, 102, 0, 0.5);
     outline-width: 1px;
@@ -2080,8 +2080,8 @@ searchbar,
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #00956d;
-      background-image: linear-gradient(to bottom, #00ba88, #006f52);
+      background-color: #e000ac;
+      background-image: linear-gradient(to bottom, #ff1ac9, #a80081);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#008763,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#008763,#000000,0.2),0.4),1.25), shade(alpha(mix(#008763,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#cc009c,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#cc009c,#000000,0.2),0.4),1.25), shade(alpha(mix(#cc009c,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#008763,#000000,0.6);
+    color: mix(#cc009c,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#008763,#000000,0.6); }
+      color: mix(#cc009c,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(204, 102, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(0, 135, 99, 0.9); }
+    color: rgba(204, 0, 156, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(0, 135, 99, 0.85); }
+      color: rgba(204, 0, 156, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,15 +3202,15 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
-    border: 1px solid #a35200;
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
+    border: 1px solid #585245;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(204, 102, 0, 0);
+      background-color: rgba(110, 102, 86, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,8 +3277,8 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #d66b00;
-      background-image: linear-gradient(to bottom, #ff860d, #a15000);
+      background-color: #746b5a;
+      background-image: linear-gradient(to bottom, #908671, #575044);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -3291,8 +3291,8 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #d66b00;
-      background-image: linear-gradient(to bottom, #ff860d, #a15000);
+      background-color: #746b5a;
+      background-image: linear-gradient(to bottom, #908671, #575044);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(204, 102, 0, 0.5);
       outline-width: 1px;
@@ -3301,8 +3301,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #e07000;
-        background-image: linear-gradient(to bottom, #ff8c1a, #a85400);
+        background-color: #79705f;
+        background-image: linear-gradient(to bottom, #958c78, #5b5447);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#CC6600,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#CC6600,#000000,0.2),0.4),1.25), shade(alpha(mix(#CC6600,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#6e6656,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#6e6656,#000000,0.2),0.4),1.25), shade(alpha(mix(#6e6656,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#CC6600,#000000,0.6);
+      color: mix(#6e6656,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#CC6600,#000000,0.6); }
+        color: mix(#6e6656,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -3353,19 +3353,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(204, 102, 0, 0.9); }
+      color: rgba(110, 102, 86, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(204, 102, 0, 0.85); }
+        color: rgba(110, 102, 86, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
-    border: 1px solid #006c4f;
+    background-color: #cccc00;
+    background-image: linear-gradient(to bottom, yellow, #999900);
+    border: 1px solid #a3a300;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
+    background-color: #cccc00;
+    background-image: linear-gradient(to bottom, yellow, #999900);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(0, 135, 99, 0);
+      background-color: rgba(204, 204, 0, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,8 +3432,8 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #008e68;
-      background-image: linear-gradient(to bottom, #00b182, #006a4e);
+      background-color: #d6d600;
+      background-image: linear-gradient(to bottom, #ffff0d, #a1a100);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -3446,8 +3446,8 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #008e68;
-      background-image: linear-gradient(to bottom, #00b182, #006a4e);
+      background-color: #d6d600;
+      background-image: linear-gradient(to bottom, #ffff0d, #a1a100);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(204, 102, 0, 0.5);
       outline-width: 1px;
@@ -3456,8 +3456,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #00956d;
-        background-image: linear-gradient(to bottom, #00ba88, #006f52);
+        background-color: #e0e000;
+        background-image: linear-gradient(to bottom, #ffff1a, #a8a800);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#008763,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#008763,#000000,0.2),0.4),1.25), shade(alpha(mix(#008763,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#cccc00,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#cccc00,#000000,0.2),0.4),1.25), shade(alpha(mix(#cccc00,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#008763,#000000,0.6);
+      color: mix(#cccc00,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#008763,#000000,0.6); }
+        color: mix(#cccc00,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -3508,19 +3508,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(0, 135, 99, 0.9); }
+      color: rgba(204, 204, 0, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(0, 135, 99, 0.85); }
+        color: rgba(204, 204, 0, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
-    border: 1px solid #a35200;
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
+    border: 1px solid #585245;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #CC6600;
-    background-image: linear-gradient(to bottom, #ff8000, #994d00);
+    background-color: #6e6656;
+    background-image: linear-gradient(to bottom, #8a806c, #534d41);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(204, 102, 0, 0);
+      background-color: rgba(110, 102, 86, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,8 +3587,8 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #d66b00;
-      background-image: linear-gradient(to bottom, #ff860d, #a15000);
+      background-color: #746b5a;
+      background-image: linear-gradient(to bottom, #908671, #575044);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -3601,8 +3601,8 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #d66b00;
-      background-image: linear-gradient(to bottom, #ff860d, #a15000);
+      background-color: #746b5a;
+      background-image: linear-gradient(to bottom, #908671, #575044);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(204, 102, 0, 0.5);
       outline-width: 1px;
@@ -3611,8 +3611,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #e07000;
-        background-image: linear-gradient(to bottom, #ff8c1a, #a85400);
+        background-color: #79705f;
+        background-image: linear-gradient(to bottom, #958c78, #5b5447);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#CC6600,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#CC6600,#000000,0.2),0.4),1.25), shade(alpha(mix(#CC6600,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#6e6656,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#6e6656,#000000,0.2),0.4),1.25), shade(alpha(mix(#6e6656,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#CC6600,#000000,0.6);
+      color: mix(#6e6656,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#CC6600,#000000,0.6); }
+        color: mix(#6e6656,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -3663,19 +3663,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(204, 102, 0, 0.9); }
+      color: rgba(110, 102, 86, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(204, 102, 0, 0.85); }
+        color: rgba(110, 102, 86, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
-    border: 1px solid #006c4f;
+    background-color: #cc009c;
+    background-image: linear-gradient(to bottom, #ff00c3, #990075);
+    border: 1px solid #a3007d;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #008763;
-    background-image: linear-gradient(to bottom, #00a97c, #00654a);
+    background-color: #cc009c;
+    background-image: linear-gradient(to bottom, #ff00c3, #990075);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(0, 135, 99, 0);
+      background-color: rgba(204, 0, 156, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,8 +3742,8 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #008e68;
-      background-image: linear-gradient(to bottom, #00b182, #006a4e);
+      background-color: #d600a4;
+      background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -3756,8 +3756,8 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #008e68;
-      background-image: linear-gradient(to bottom, #00b182, #006a4e);
+      background-color: #d600a4;
+      background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(204, 102, 0, 0.5);
       outline-width: 1px;
@@ -3766,8 +3766,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #00956d;
-        background-image: linear-gradient(to bottom, #00ba88, #006f52);
+        background-color: #e000ac;
+        background-image: linear-gradient(to bottom, #ff1ac9, #a80081);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#008763,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#008763,#000000,0.2),0.4),1.25), shade(alpha(mix(#008763,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#cc009c,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#cc009c,#000000,0.2),0.4),1.25), shade(alpha(mix(#cc009c,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#008763,#000000,0.6);
+      color: mix(#cc009c,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#008763,#000000,0.6); }
+        color: mix(#cc009c,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(0, 135, 99, 0.9); }
+      color: rgba(204, 0, 156, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(0, 135, 99, 0.85); }
+        color: rgba(204, 0, 156, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3a300;
+    background-color: mix(#800000,#cccc00,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cccc00,0.3);
+      background-color: #cccc00;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cccc00; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3007d;
+    background-color: mix(#800000,#cc009c,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cc009c,0.3);
+      background-color: #cc009c;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cc009c; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #006c4f;
-    background-color: mix(#800000,#008763,0.6); }
+    border-color: #a3007d;
+    background-color: mix(#800000,#cc009c,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#CC6600,#008763,0.3);
-      background-color: #008763;
+      border-color: mix(#CC6600,#cc009c,0.3);
+      background-color: #cc009c;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #008763; }
+      color: #cc009c; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#CC0000,#f2dada,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #00d49b; }
+          color: #ff1ac9; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #CC6600; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #008763;
+    background-color: #cccc00;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #CC6600;
+    background-color: #8ee400;
     border-color: transparent; }
   levelbar block.full {
     background-color: #a35200;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #660000;
   background-color: #800000; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #008763;
+    background-color: #cc009c;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #008763; }
+  background-color: #cc009c; }
 
 .conflict-row.activatable:hover {
-  background-color: #00956d; }
+  background-color: #e000ac; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,8 +8947,8 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
+  background-color: #cc009c;
+  background-image: linear-gradient(to bottom, #ff00c3, #990075);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(0, 135, 99, 0);
+    background-color: rgba(204, 0, 156, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,8 +9015,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d600a4;
+    background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -9029,8 +9029,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d600a4;
+    background-image: linear-gradient(to bottom, #ff0dc6, #a1007b);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(204, 102, 0, 0.5);
     outline-width: 1px;
@@ -9039,8 +9039,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #00956d;
-      background-image: linear-gradient(to bottom, #00ba88, #006f52);
+      background-color: #e000ac;
+      background-image: linear-gradient(to bottom, #ff1ac9, #a80081);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#008763,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#008763,#000000,0.2),0.4),1.25), shade(alpha(mix(#008763,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#cc009c,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#cc009c,#000000,0.2),0.4),1.25), shade(alpha(mix(#cc009c,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#008763,#000000,0.6);
+    color: mix(#cc009c,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#008763,#000000,0.6); }
+      color: mix(#cc009c,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(204, 102, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -9091,14 +9091,14 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(0, 135, 99, 0.9); }
+    color: rgba(204, 0, 156, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(0, 135, 99, 0.85); }
+      color: rgba(204, 0, 156, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #008763;
-  background-image: linear-gradient(to bottom, #00a97c, #00654a);
+  background-color: #cccc00;
+  background-image: linear-gradient(to bottom, yellow, #999900);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(0, 135, 99, 0);
+    background-color: rgba(204, 204, 0, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,8 +9165,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d6d600;
+    background-image: linear-gradient(to bottom, #ffff0d, #a1a100);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -9179,8 +9179,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #008e68;
-    background-image: linear-gradient(to bottom, #00b182, #006a4e);
+    background-color: #d6d600;
+    background-image: linear-gradient(to bottom, #ffff0d, #a1a100);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(204, 102, 0, 0.5);
     outline-width: 1px;
@@ -9189,8 +9189,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #00956d;
-      background-image: linear-gradient(to bottom, #00ba88, #006f52);
+      background-color: #e0e000;
+      background-image: linear-gradient(to bottom, #ffff1a, #a8a800);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#008763,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#008763,#000000,0.2),0.4),1.25), shade(alpha(mix(#008763,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#cccc00,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#cccc00,#000000,0.2),0.4),1.25), shade(alpha(mix(#cccc00,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#008763,#000000,0.6);
+    color: mix(#cccc00,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#008763,#000000,0.6); }
+      color: mix(#cccc00,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(204, 102, 0, 0.6);
     background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(0, 135, 99, 0.9); }
+    color: rgba(204, 204, 0, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(0, 135, 99, 0.85); }
+      color: rgba(204, 204, 0, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/info.json
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Rosso-Cursa", 
-	"description": "Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/qt5ct/Cinnamox-Rosso-Cursa.conf
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/qt5ct/Cinnamox-Rosso-Cursa.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#f2dada,          #CC0000, #CC0000, #CC0000, #4C0000, #4C0000, #f2dada,           #f2dada,           #f2dada,           #800000, #CC0000, #4C0000, #CC6600, #000000, #CC6600, #f2dada,            #CC0000, #f2dada,           4C0000,  #f2dada
+disabled_colors=#e8a3a3, #CC0000, #CC0000, #CC0000, #4C0000, #4C0000, #d5a3a3,  #d5a3a3,  #e8a3a3,  #800000, #CC0000, #4C0000, #CC6600, #000000, #CC6600, #e8a3a3,   #CC0000, #e8a3a3,  #4C0000, #c8a3a3
+inactive_colors=#f2dada,          #CC0000, #CC0000, #CC0000, #4C0000, #4C0000, #f2dada,           #f2dada,           #f2dada,           #800000, #CC0000, #4C0000, #CC6600, #000000, #CC6600, #f2dada,            #CC0000, #f2dada,           #4C0000, #f2dada
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#f2dada,          #800000, #CC0000, #cbc7c4, #9f9d9a, #b8b5b2, #f2dada,           #ff0000, #f2dada, #800000, #CC0000, #767472, #CC6600, #000000, #CC6600, #f2dada,            #CC0000, #f2dada,           4C0000, #f2dada
+#disabled_colors=#e8a3a3, #800000, #CC0000, #cbc7c4, #9f9d9a, #b8b5b2, #d5a3a3,  #ffec17, #f2dada, #800000, #CC0000, #767472, #CC6600, #000000, #CC6600, #e8a3a3,   #CC0000, #e8a3a3,  #4C0000, #c8a3a3
+#inactive_colors=#f2dada,          #800000, #CC0000, #cbc7c4, #9f9d9a, #b8b5b2, #f2dada,           #ff9040, #f2dada, #800000, #CC0000, #767472, #CC6600, #000000, #CC6600, #f2dada,            #CC0000, #f2dada,           #4C0000, #f2dada

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Rosso-Cursa.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Rosso-Cursa;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Rosso-Cursa/info.json
+++ b/Cinnamox-Rosso-Cursa/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Rosso-Cursa", 
-	"description": "Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Willow-Grove
 
-Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Willow-Grove
 
-Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Willow-Grove */
 /* Transparency: None */
-/* Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #e6f2da;
+    color: #aa4e4e;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #aaaa3a;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #aa4e4e;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Willow-Grove. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Willow-Grove
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/gtkrc
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#4f5947\nbg_color:#6f7f5f\ntooltip_bg_color:#6f7f5f\nselected_bg_color:#6ccc3d\ntext_color:#e6f2da\nfg_color:#e6f2da\ntooltip_fg_color:#e6f2da\nselected_fg_color:#000000\nmenubar_bg_color:#444c3d\nmenubar_fg_color:#e6f2da\ntoolbar_bg_color:#6f7f5f\ntoolbar_fg_color:#e6f2da\nmenu_bg_color:#444c3d\nmenu_fg_color:#e6f2da\npanel_bg_color:#6f7f5f\npanel_fg_color:#e6f2da\nlink_color:#6ccc3d\nbtn_bg_color:#4f5947\nbtn_fg_color:#e6f2da\ntitlebar_bg_color:#444c3d\ntitlebar_fg_color:#e6f2da\nprimary_caret_color:#e6f2da\nsecondary_caret_color:#e6f2da\n"
+"base_color:#4f5947\nbg_color:#6f7f5f\ntooltip_bg_color:#6f7f5f\nselected_bg_color:#6ccc3d\ntext_color:#e6f2da\nfg_color:#e6f2da\ntooltip_fg_color:#e6f2da\nselected_fg_color:#000000\nmenubar_bg_color:#444c3d\nmenubar_fg_color:#e6f2da\ntoolbar_bg_color:#6f7f5f\ntoolbar_fg_color:#e6f2da\nmenu_bg_color:#444c3d\nmenu_fg_color:#e6f2da\npanel_bg_color:#6f7f5f\npanel_fg_color:#e6f2da\nlink_color:#cdf2a9\nbtn_bg_color:#4f5947\nbtn_fg_color:#e6f2da\ntitlebar_bg_color:#444c3d\ntitlebar_fg_color:#e6f2da\nprimary_caret_color:#e6f2da\nsecondary_caret_color:#e6f2da\naccent_bg_color:#6ccc3d\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#4f5947\nbg_color:#6f7f5f\ntooltip_bg_color:#6f7f5f\nselected_bg_color:#6ccc3d\ntext_color:#e6f2da\nfg_color:#e6f2da\ntooltip_fg_color:#e6f2da\nselected_fg_color:#000000\nmenubar_bg_color:#444c3d\nmenubar_fg_color:#e6f2da\ntoolbar_bg_color:#6f7f5f\ntoolbar_fg_color:#e6f2da\nmenu_bg_color:#444c3d\nmenu_fg_color:#e6f2da\npanel_bg_color:#6f7f5f\npanel_fg_color:#e6f2da\nlink_color:#6ccc3d\nbtn_bg_color:#4f5947\nbtn_fg_color:#e6f2da\ntitlebar_bg_color:#444c3d\ntitlebar_fg_color:#e6f2da\n"
+"base_color:#4f5947\nbg_color:#6f7f5f\ntooltip_bg_color:#6f7f5f\nselected_bg_color:#6ccc3d\ntext_color:#e6f2da\nfg_color:#e6f2da\ntooltip_fg_color:#e6f2da\nselected_fg_color:#000000\nmenubar_bg_color:#444c3d\nmenubar_fg_color:#e6f2da\ntoolbar_bg_color:#6f7f5f\ntoolbar_fg_color:#e6f2da\nmenu_bg_color:#444c3d\nmenu_fg_color:#e6f2da\npanel_bg_color:#6f7f5f\npanel_fg_color:#e6f2da\nlink_color:#cdf2a9\nbtn_bg_color:#4f5947\nbtn_fg_color:#e6f2da\ntitlebar_bg_color:#444c3d\ntitlebar_fg_color:#e6f2da\nprimary_caret_color:#e6f2da\nsecondary_caret_color:#e6f2da\naccent_bg_color:#6ccc3d\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.0/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #2e4418;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #6ccc3d;
+@define-color info_bg_color #4c4eb9;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #aaaa3a;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #6ccc3d;
+@define-color question_bg_color #4c4eb9;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#6ccc3d,#e6f2da,0.6);
+@define-color error_bg_color #aa4e4e;
+@define-color link_color #cdf2a9;
 @define-color success_color #6ccc3d;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color warning_color #aaaa3a;
+@define-color error_color #aa4e4e;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#6ccc3d,#e6f2da,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#6ccc3d,#e6f2da,0.6);
-  -GtkWidget-link-color: mix(#6ccc3d,#e6f2da,0.6);
-  -GtkWidget-visited-link-color: mix(#6ccc3d,#e6f2da,0.6); }
+  -GtkHTML-link-color: #cdf2a9;
+  -GtkIMHtml-hyperlink-color: #cdf2a9;
+  -GtkWidget-link-color: #cdf2a9;
+  -GtkWidget-visited-link-color: #cdf2a9; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#6ccc3d,#e6f2da,0.6); }
+    color: #cdf2a9; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#6ccc3d,#e6f2da,0.6); }
+    color: #cdf2a9; }
 
 .background {
   background-color: #6f7f5f;
@@ -973,8 +973,8 @@ GtkComboBox .separator {
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #aa4e4e;
+  background-image: linear-gradient(to bottom, #c07676, #803b3b);
   border-color: rgba(0, 0, 0, 0.22);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -988,7 +988,7 @@ GtkComboBox .separator {
     border-color: rgba(0, 0, 0, 0.22); }
   .destructive-action.button.flat {
     border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(170, 78, 78, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
@@ -1000,8 +1000,8 @@ GtkComboBox .separator {
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
       border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
+    background-color: #bc6d6d;
+    background-image: linear-gradient(to bottom, #d4a0a0, #994646);
     border-color: rgba(0, 0, 0, 0.3);
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #000000; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #994646;
+    background-image: linear-gradient(to bottom, #b66161, #733535);
     color: #000000;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#000000,0.5);
+    background-color: rgba(170, 78, 78, 0.3);
+    background-image: linear-gradient(to bottom, rgba(192, 118, 118, 0.3), rgba(128, 59, 59, 0.3));
+    color: mix(#aa4e4e,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #000000; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#000000,0.5);
+    color: mix(#aa4e4e,#000000,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #994646; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #914242; }
 
 /******************
 * selection mode *
@@ -1424,14 +1424,14 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #6ccc3d;
-  background-image: linear-gradient(to bottom, #94da71, #509d29);
-  border: 1px solid #55a82c;
+  background-color: #4c4eb9;
+  background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
+  border: 1px solid #3b3c96;
   color: #000000; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
     border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.12); }
@@ -1445,7 +1445,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.12); }
     .info .button.flat {
       border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(108, 204, 61, 0);
+      background-color: rgba(76, 78, 185, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
@@ -1457,8 +1457,8 @@ GtkInfoBar {
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.1); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #8cd767;
-      background-image: linear-gradient(to bottom, #bce8a6, #5fbd32);
+      background-color: #7273c8;
+      background-image: linear-gradient(to bottom, #aaabde, #4244a9);
       border-color: rgba(0, 0, 0, 0.2);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
@@ -1481,37 +1481,37 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #000000; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #5fbd32;
-      background-image: linear-gradient(to bottom, #80d357, #488e25);
+      background-color: #4244a9;
+      background-image: linear-gradient(to bottom, #6365c2, #32337f);
       color: #000000;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: #65c734;
-      background-image: linear-gradient(to bottom, #8ad664, #4c9627);
-      color: mix(#6ccc3d,#000000,0.5);
+      background-color: #4648b2;
+      background-image: linear-gradient(to bottom, #6f71c7, #343686);
+      color: mix(#4c4eb9,#000000,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #000000; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#6ccc3d,#000000,0.5);
+      color: mix(#4c4eb9,#000000,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #5fbd32; }
+      color: #4244a9; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #5ab22f; }
+        color: #3e409f; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #aaaa3a;
+  background-image: linear-gradient(to bottom, #c6c657, #80802c);
+  border: 1px solid #88882e;
   color: #000000; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #aaaa3a;
+    background-image: linear-gradient(to bottom, #c6c657, #80802c);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -1525,7 +1525,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .warning .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(170, 170, 58, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
@@ -1537,8 +1537,8 @@ GtkInfoBar {
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #c3c34f;
+      background-image: linear-gradient(to bottom, #d4d482, #999934);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
@@ -1561,37 +1561,37 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #000000; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #999934;
+      background-image: linear-gradient(to bottom, #bfbf42, #737327);
       color: #000000;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(170, 170, 58, 0.3);
+      background-image: linear-gradient(to bottom, rgba(198, 198, 87, 0.3), rgba(128, 128, 44, 0.3));
+      color: mix(#aaaa3a,#000000,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #000000; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#aaaa3a,#000000,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #999934; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #919131; }
 
 .question {
-  background-color: #6ccc3d;
-  background-image: linear-gradient(to bottom, #94da71, #509d29);
-  border: 1px solid #55a82c;
+  background-color: #4c4eb9;
+  background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
+  border: 1px solid #3b3c96;
   color: #000000; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
     border-color: rgba(0, 0, 0, 0.12);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.12); }
@@ -1605,7 +1605,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.12); }
     .question .button.flat {
       border-color: rgba(0, 0, 0, 0.1);
-      background-color: rgba(108, 204, 61, 0);
+      background-color: rgba(76, 78, 185, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
@@ -1617,8 +1617,8 @@ GtkInfoBar {
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.1); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #8cd767;
-      background-image: linear-gradient(to bottom, #bce8a6, #5fbd32);
+      background-color: #7273c8;
+      background-image: linear-gradient(to bottom, #aaabde, #4244a9);
       border-color: rgba(0, 0, 0, 0.2);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
@@ -1641,37 +1641,37 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #000000; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #5fbd32;
-      background-image: linear-gradient(to bottom, #80d357, #488e25);
+      background-color: #4244a9;
+      background-image: linear-gradient(to bottom, #6365c2, #32337f);
       color: #000000;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: #65c734;
-      background-image: linear-gradient(to bottom, #8ad664, #4c9627);
-      color: mix(#6ccc3d,#000000,0.5);
+      background-color: #4648b2;
+      background-image: linear-gradient(to bottom, #6f71c7, #343686);
+      color: mix(#4c4eb9,#000000,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #000000; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#6ccc3d,#000000,0.5);
+      color: mix(#4c4eb9,#000000,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #5fbd32; }
+      color: #4244a9; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #5ab22f; }
+        color: #3e409f; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #aa4e4e;
+  background-image: linear-gradient(to bottom, #c07676, #803b3b);
+  border: 1px solid #883e3e;
   color: #000000; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #aa4e4e;
+    background-image: linear-gradient(to bottom, #c07676, #803b3b);
     border-color: rgba(0, 0, 0, 0.22);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -1685,7 +1685,7 @@ GtkInfoBar {
       border-color: rgba(0, 0, 0, 0.22); }
     .error .button.flat {
       border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(170, 78, 78, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
@@ -1697,8 +1697,8 @@ GtkInfoBar {
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
         border-color: rgba(0, 0, 0, 0.2); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
+      background-color: #bc6d6d;
+      background-image: linear-gradient(to bottom, #d4a0a0, #994646);
       border-color: rgba(0, 0, 0, 0.3);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #000000; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #994646;
+      background-image: linear-gradient(to bottom, #b66161, #733535);
       color: #000000;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#000000,0.5);
+      background-color: rgba(170, 78, 78, 0.3);
+      background-image: linear-gradient(to bottom, rgba(192, 118, 118, 0.3), rgba(128, 59, 59, 0.3));
+      color: mix(#aa4e4e,#000000,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #000000; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#000000,0.5);
+      color: mix(#aa4e4e,#000000,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #994646; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #914242; }
 
 /*********
  ! Entry *
@@ -3101,7 +3101,7 @@ GtkLevelBar {
     background-color: #6ccc3d;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #aaaa3a;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #aa4e4e; }
 
 .view, GtkHTML {
   color: #e6f2da;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #3f4739;
   background-color: #4f5947; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #aa4e4e;
     background-image: none;
     color: #000000; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #883e3e;
+  background-color: #b35959;
   background-image: none;
   color: #000000; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #773737;
+    background-color: #aa4e4e; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #88882e;
+  background-color: #b8b83f;
   background-image: none;
   color: #000000; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #777729;
+    background-color: #aaaa3a; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #2e4418;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #000000;
-@define-color info_bg_color #6ccc3d;
+@define-color info_bg_color #4c4eb9;
 @define-color warning_fg_color #000000;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #aaaa3a;
 @define-color question_fg_color #000000;
-@define-color question_bg_color #6ccc3d;
+@define-color question_bg_color #4c4eb9;
 @define-color error_fg_color #000000;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#6ccc3d,#e6f2da,0.6);
+@define-color error_bg_color #aa4e4e;
+@define-color link_color #cdf2a9;
 @define-color success_color #6ccc3d;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color warning_color #aaaa3a;
+@define-color error_color #aa4e4e;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#6ccc3d,#e6f2da,0.6); }
+  -GtkIMHtml-hyperlink-color: #cdf2a9; }
   *:disabled, *:disabled:disabled {
-    color: mix(#6ccc3d,#e6f2da,0.6); }
+    color: #cdf2a9; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#6ccc3d,#e6f2da,0.6); }
+    color: #cdf2a9; }
 
 .background {
   background-color: #6f7f5f;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #88882e;
+    background-color: mix(#4f5947,#aaaa3a,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aaaa3a,0.3);
+      background-color: #aaaa3a;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aaaa3a; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #883e3e;
+    background-color: mix(#4f5947,#aa4e4e,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aa4e4e,0.3);
+      background-color: #aa4e4e;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aa4e4e; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #883e3e;
+    background-color: mix(#4f5947,#aa4e4e,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aa4e4e,0.3);
+      background-color: #aa4e4e;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aa4e4e; }
 
 entry {
   background-color: #4f5947;
@@ -1988,8 +1988,8 @@ searchbar,
       color: rgba(108, 204, 61, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #aa4e4e;
+  background-image: linear-gradient(to bottom, #c07676, #803b3b);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(170, 78, 78, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,8 +2056,8 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b05454;
+    background-image: linear-gradient(to bottom, #c58181, #863d3d);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -2070,8 +2070,8 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b05454;
+    background-image: linear-gradient(to bottom, #c58181, #863d3d);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(108, 204, 61, 0.5);
     outline-width: 1px;
@@ -2080,8 +2080,8 @@ searchbar,
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #b45c5c;
+      background-image: linear-gradient(to bottom, #ca8b8b, #8c4040);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #000000; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#aa4e4e,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),1.25), shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#aa4e4e,#000000,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#aa4e4e,#000000,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(108, 204, 61, 0.6);
     background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(0, 0, 0, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(170, 78, 78, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(170, 78, 78, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,15 +3202,15 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
-    border: 1px solid #55a82c;
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
+    border: 1px solid #3b3c96;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #000000; }
   infobar.info button {
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.12); }
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(108, 204, 61, 0);
+      background-color: rgba(76, 78, 185, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,8 +3277,8 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #74cf47;
-      background-image: linear-gradient(to bottom, #9edd7f, #53a52b);
+      background-color: #5557bd;
+      background-image: linear-gradient(to bottom, #8788d0, #3a3b94);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -3291,8 +3291,8 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #74cf47;
-      background-image: linear-gradient(to bottom, #9edd7f, #53a52b);
+      background-color: #5557bd;
+      background-image: linear-gradient(to bottom, #8788d0, #3a3b94);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(108, 204, 61, 0.5);
       outline-width: 1px;
@@ -3301,8 +3301,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #7cd252;
-        background-image: linear-gradient(to bottom, #a8e18c, #57ad2e);
+        background-color: #5f61c0;
+        background-image: linear-gradient(to bottom, #9294d5, #3d3e9b);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.38); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #000000; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#6ccc3d,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#6ccc3d,#000000,0.2),0.4),1.25), shade(alpha(mix(#6ccc3d,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4c4eb9,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4c4eb9,#000000,0.2),0.4),1.25), shade(alpha(mix(#4c4eb9,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#6ccc3d,#000000,0.6);
+      color: mix(#4c4eb9,#000000,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#6ccc3d,#000000,0.6); }
+        color: mix(#4c4eb9,#000000,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -3353,19 +3353,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(108, 204, 61, 0.9); }
+      color: rgba(76, 78, 185, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(108, 204, 61, 0.85); }
+        color: rgba(76, 78, 185, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #aaaa3a;
+    background-image: linear-gradient(to bottom, #c6c657, #80802c);
+    border: 1px solid #88882e;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #000000; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #aaaa3a;
+    background-image: linear-gradient(to bottom, #c6c657, #80802c);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(170, 170, 58, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,8 +3432,8 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #b3b33d;
+      background-image: linear-gradient(to bottom, #c9c962, #86862e);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -3446,8 +3446,8 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #b3b33d;
+      background-image: linear-gradient(to bottom, #c9c962, #86862e);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(108, 204, 61, 0.5);
       outline-width: 1px;
@@ -3456,8 +3456,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #bbbb40;
+        background-image: linear-gradient(to bottom, #cdcd6c, #8c8c30);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #000000; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#aaaa3a,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#aaaa3a,#000000,0.2),0.4),1.25), shade(alpha(mix(#aaaa3a,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#aaaa3a,#000000,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#aaaa3a,#000000,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -3508,19 +3508,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(170, 170, 58, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(170, 170, 58, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
-    border: 1px solid #55a82c;
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
+    border: 1px solid #3b3c96;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #000000; }
   infobar.question button {
-    background-color: #6ccc3d;
-    background-image: linear-gradient(to bottom, #94da71, #509d29);
+    background-color: #4c4eb9;
+    background-image: linear-gradient(to bottom, #7b7ccb, #37398d);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.12); }
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(108, 204, 61, 0);
+      background-color: rgba(76, 78, 185, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,8 +3587,8 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #74cf47;
-      background-image: linear-gradient(to bottom, #9edd7f, #53a52b);
+      background-color: #5557bd;
+      background-image: linear-gradient(to bottom, #8788d0, #3a3b94);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -3601,8 +3601,8 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #74cf47;
-      background-image: linear-gradient(to bottom, #9edd7f, #53a52b);
+      background-color: #5557bd;
+      background-image: linear-gradient(to bottom, #8788d0, #3a3b94);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(108, 204, 61, 0.5);
       outline-width: 1px;
@@ -3611,8 +3611,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #7cd252;
-        background-image: linear-gradient(to bottom, #a8e18c, #57ad2e);
+        background-color: #5f61c0;
+        background-image: linear-gradient(to bottom, #9294d5, #3d3e9b);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.38); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #000000; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#6ccc3d,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#6ccc3d,#000000,0.2),0.4),1.25), shade(alpha(mix(#6ccc3d,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#4c4eb9,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4c4eb9,#000000,0.2),0.4),1.25), shade(alpha(mix(#4c4eb9,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#6ccc3d,#000000,0.6);
+      color: mix(#4c4eb9,#000000,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#6ccc3d,#000000,0.6); }
+        color: mix(#4c4eb9,#000000,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -3663,19 +3663,19 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(108, 204, 61, 0.9); }
+      color: rgba(76, 78, 185, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(108, 204, 61, 0.85); }
+        color: rgba(76, 78, 185, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #aa4e4e;
+    background-image: linear-gradient(to bottom, #c07676, #803b3b);
+    border: 1px solid #883e3e;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #000000; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #aa4e4e;
+    background-image: linear-gradient(to bottom, #c07676, #803b3b);
     border-color: rgba(0, 0, 0, 0.32);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(0, 0, 0, 0.3);
       color: #000000;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(170, 78, 78, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,8 +3742,8 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(0, 0, 0, 0.3); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #b05454;
+      background-image: linear-gradient(to bottom, #c58181, #863d3d);
       border-color: rgba(0, 0, 0, 0.4);
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -3756,8 +3756,8 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(0, 0, 0, 0.4); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #b05454;
+      background-image: linear-gradient(to bottom, #c58181, #863d3d);
       border-color: rgba(0, 0, 0, 0.32);
       outline-color: rgba(108, 204, 61, 0.5);
       outline-width: 1px;
@@ -3766,8 +3766,8 @@ infobar {
       color: #000000;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #b45c5c;
+        background-image: linear-gradient(to bottom, #ca8b8b, #8c4040);
         border-color: rgba(0, 0, 0, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #000000; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+      background-color: alpha(mix(#aa4e4e,#000000,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),1.25), shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#000000,0.6);
+      color: mix(#aa4e4e,#000000,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#000000,0.6); }
+        color: mix(#aa4e4e,#000000,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(0, 0, 0, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(170, 78, 78, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(170, 78, 78, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #88882e;
+    background-color: mix(#4f5947,#aaaa3a,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #000000; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aaaa3a,0.3);
+      background-color: #aaaa3a;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aaaa3a; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #883e3e;
+    background-color: mix(#4f5947,#aa4e4e,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #000000; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aa4e4e,0.3);
+      background-color: #aa4e4e;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aa4e4e; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #000000;
-    border-color: #cc0000;
-    background-color: mix(#4f5947,#ff0000,0.6); }
+    border-color: #883e3e;
+    background-color: mix(#4f5947,#aa4e4e,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #000000; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #000000;
-      border-color: mix(#6ccc3d,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#6ccc3d,#aa4e4e,0.3);
+      background-color: #aa4e4e;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #000000;
-      color: #ff0000; }
+      color: #aa4e4e; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#6f7f5f,#e6f2da,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #c58080; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #6ccc3d; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,7 +7030,7 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #aaaa3a;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
     background-color: #6ccc3d;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #3f4739;
   background-color: #4f5947; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #aa4e4e;
     background-image: none;
     color: #000000; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #000000;
-  background-color: #ff0000; }
+  background-color: #aa4e4e; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #b45c5c; }
 
 .conflict-row.activatable:selected {
   color: #000000;
@@ -8947,8 +8947,8 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #aa4e4e;
+  background-image: linear-gradient(to bottom, #c07676, #803b3b);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(170, 78, 78, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,8 +9015,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b05454;
+    background-image: linear-gradient(to bottom, #c58181, #863d3d);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -9029,8 +9029,8 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b05454;
+    background-image: linear-gradient(to bottom, #c58181, #863d3d);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(108, 204, 61, 0.5);
     outline-width: 1px;
@@ -9039,8 +9039,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #b45c5c;
+      background-image: linear-gradient(to bottom, #ca8b8b, #8c4040);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #000000; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#aa4e4e,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),1.25), shade(alpha(mix(#aa4e4e,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#aa4e4e,#000000,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#aa4e4e,#000000,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(108, 204, 61, 0.6);
     background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -9091,14 +9091,14 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(170, 78, 78, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(170, 78, 78, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #aaaa3a;
+  background-image: linear-gradient(to bottom, #c6c657, #80802c);
   border-color: rgba(0, 0, 0, 0.32);
   color: #000000;
   box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(0, 0, 0, 0.3);
     color: #000000;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(170, 170, 58, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,8 +9165,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(0, 0, 0, 0.3); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b3b33d;
+    background-image: linear-gradient(to bottom, #c9c962, #86862e);
     border-color: rgba(0, 0, 0, 0.4);
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -9179,8 +9179,8 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(0, 0, 0, 0.4); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #b3b33d;
+    background-image: linear-gradient(to bottom, #c9c962, #86862e);
     border-color: rgba(0, 0, 0, 0.32);
     outline-color: rgba(108, 204, 61, 0.5);
     outline-width: 1px;
@@ -9189,8 +9189,8 @@ SheetStyleDialog.unity-force-quit {
     color: #000000;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #bbbb40;
+      background-image: linear-gradient(to bottom, #cdcd6c, #8c8c30);
       border-color: rgba(0, 0, 0, 0.4);
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #000000; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#000000,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#000000,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#000000,0.2),0.4),0.75));
+    background-color: alpha(mix(#aaaa3a,#000000,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#aaaa3a,#000000,0.2),0.4),1.25), shade(alpha(mix(#aaaa3a,#000000,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#000000,0.6);
+    color: mix(#aaaa3a,#000000,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#000000,0.6); }
+      color: mix(#aaaa3a,#000000,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(108, 204, 61, 0.6);
     background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(0, 0, 0, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(170, 170, 58, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(170, 170, 58, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/info.json
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Willow-Grove", 
-	"description": "Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/qt5ct/Cinnamox-Willow-Grove.conf
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/qt5ct/Cinnamox-Willow-Grove.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#e6f2da,          #6f7f5f, #6f7f5f, #6f7f5f, #444c3d, #444c3d, #e6f2da,           #e6f2da,           #e6f2da,           #4f5947, #6f7f5f, #444c3d, #6ccc3d, #000000, #6ccc3d, #e6f2da,            #6f7f5f, #e6f2da,           444c3d,  #e6f2da
+disabled_colors=#c8d5bb, #6f7f5f, #6f7f5f, #6f7f5f, #444c3d, #444c3d, #c0cbb5,  #c0cbb5,  #c8d5bb,  #4f5947, #6f7f5f, #444c3d, #6ccc3d, #000000, #6ccc3d, #c8d5bb,   #6f7f5f, #c8d5bb,  #444c3d, #bdc8b2
+inactive_colors=#e6f2da,          #6f7f5f, #6f7f5f, #6f7f5f, #444c3d, #444c3d, #e6f2da,           #e6f2da,           #e6f2da,           #4f5947, #6f7f5f, #444c3d, #6ccc3d, #000000, #6ccc3d, #e6f2da,            #6f7f5f, #e6f2da,           #444c3d, #e6f2da
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#e6f2da,          #4f5947, #6f7f5f, #cbc7c4, #9f9d9a, #b8b5b2, #e6f2da,           #ff0000, #e6f2da, #4f5947, #6f7f5f, #767472, #6ccc3d, #000000, #6ccc3d, #e6f2da,            #6f7f5f, #e6f2da,           444c3d, #e6f2da
+#disabled_colors=#c8d5bb, #4f5947, #6f7f5f, #cbc7c4, #9f9d9a, #b8b5b2, #c0cbb5,  #ffec17, #e6f2da, #4f5947, #6f7f5f, #767472, #6ccc3d, #000000, #6ccc3d, #c8d5bb,   #6f7f5f, #c8d5bb,  #444c3d, #bdc8b2
+#inactive_colors=#e6f2da,          #4f5947, #6f7f5f, #cbc7c4, #9f9d9a, #b8b5b2, #e6f2da,           #ff9040, #e6f2da, #4f5947, #6f7f5f, #767472, #6ccc3d, #000000, #6ccc3d, #e6f2da,            #6f7f5f, #e6f2da,           #444c3d, #e6f2da

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Willow-Grove.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Willow-Grove;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Willow-Grove/info.json
+++ b/Cinnamox-Willow-Grove/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Willow-Grove", 
-	"description": "Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Zanah/README.md
+++ b/Cinnamox-Zanah/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Zanah
 
-Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/README.md
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/README.md
@@ -1,10 +1,10 @@
 ## Cinnamox-Zanah
 
-Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme.
+Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme.
 
 ## Credits
 
-Cinnamon theme crafted by smurphos. Build tools are at [cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
+Cinnamon theme crafted by smurphos. Build tools are at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master).
 
 GTK2, GTK3 and Metacity1 themes built with [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
 
@@ -14,7 +14,9 @@ Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vib
 
 ## Installation
 
-Install via Cinnamon's Themes module in Cinnamon settings or download from Cinnamon Spices and unzip into your `~/.themes` directory.
+Install via Cinnamon's Themes module in Cinnamon settings or download from [Cinnamon Spices](https://cinnamon-spices.linuxmint.com/themes) and unzip into your `~/.themes` directory.
+
+The themes are also available via [openDesktop.org](https://www.opendesktop.org/member/491875/) or [my Github repository](https://github.com/smurphos/cinnamox_themes/releases).
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
@@ -24,6 +26,8 @@ To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as roo
 
 ## Tweaking
 
+### Cinnamon Theme Transparency
+
 The theme includes an interactive bash script that allows end users to adjust the transparency of the Cinnamon Theme. The default is no transparency.
 
 To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
@@ -31,6 +35,24 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh && ~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh` again to chose another option including the default.
+
+### GTK2 HIDPI support
+
+If you need HIDPI Support in GTK2 the theme includes a HIDPI version of the gtkrc theme file and a helper script to toggle between the regular and HIDPI version.
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh && ~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+After the first run you can toggle between the two using `~/.themes/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh`
+
+### qt5ct support
+
+If you need support for qt5ct configuration the theme includes a premade qt5ct.conf file and a helper script to install it to the correct location `~/.config/qt5ct/colors`
+
+To run the script open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh && ~/.themes/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh`
 
 ## Compatibility
 

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/cinnamon/cinnamon.css
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/cinnamon/cinnamon.css
@@ -4,7 +4,7 @@
  * ###################################################################*/
 /* Cinnamox-Zanah */
 /* Transparency: None */
-/* Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme. */
+/* Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme. */
 stage {
     font-family: sans, sans-serif;
     font-size: 1em;
@@ -882,7 +882,7 @@ StScrollBar StButton#hhandle:hover {
 }
 .run-dialog-error-label {
     font-size: 1em;
-    color: #0c190d;
+    color: #ce6f6f;
 }
 .run-dialog-error-box {
     padding-top: 15px;
@@ -1595,10 +1595,10 @@ StScrollBar StButton#hhandle:hover {
     spacing: 0px;
 }
 .system-status-icon.warning {
-    color: #FFC600;
+    color: #eeee47;
 }
 .system-status-icon.error {
-    color: #FF0000;
+    color: #ce6f6f;
 }
 /*Used by keyboard applet*/
 .panel-status-button {

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/cinnamon/cinnamox_transparency.sh
@@ -34,7 +34,7 @@ elif grep -q "Transparency: High" cinnamon.css && grep -q "$HIGHTRANSLIGHTBG" ci
 	CURRENT="Transparency: High";LIGHTBGC=$HIGHTRANSLIGHTBG; DARKBGC=$HIGHTRANSDARKBG;
 	VARIANT=("Transparency: None" "Transparency: Low" "Transparency: Medium" "Quit");
 else
-	echo "Cannot confirm the current transparency of Cinnamox-Zanah. Something is wrong.";
+	echo "Cannot confirm the current transparency of $THEMENAME. Something is wrong.";
 	echo "";
 	read -p "Press enter to exit script.";
 	exit 1;

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/cinnamox_toggle_GTK2_HIDPI.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#Description: Helper script to toggle GTK2 HIDPI Support
+THEMENAME=Cinnamox-Zanah
+if [ ! -f "$PWD/gtkrc" ]; then
+	echo "Something is wrong. Cannot find $PWD/gtkrc"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -f "gtkrc.nohidpi" ]; then
+    cp gtkrc gtkrc.nohidpi && cp -f gtkrc.hidpi gtkrc && echo "Enabled HIDPI in GTK2. Reloading $THEMENAME.";
+    gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+else
+	cp -f gtkrc.nohidpi gtkrc && rm gtkrc.nohidpi && echo "Disabled HIDPI in GTK2. Reloading $THEMENAME.";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "Mint-Y";
+	gsettings set org.cinnamon.desktop.interface gtk-theme "$THEMENAME";
+fi
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit;

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/gtkrc
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#99bf9c\nbg_color:#b7ccb9\ntooltip_bg_color:#b7ccb9\nselected_bg_color:#388c40\ntext_color:#0c190d\nfg_color:#0c190d\ntooltip_fg_color:#0c190d\nselected_fg_color:#ffffff\nmenubar_bg_color:#72bf78\nmenubar_fg_color:#0c190d\ntoolbar_bg_color:#b7ccb9\ntoolbar_fg_color:#0c190d\nmenu_bg_color:#72bf78\nmenu_fg_color:#0c190d\npanel_bg_color:#b7ccb9\npanel_fg_color:#0c190d\nlink_color:#388c40\nbtn_bg_color:#99bf9c\nbtn_fg_color:#0c190d\ntitlebar_bg_color:#72bf78\ntitlebar_fg_color:#0c190d\nprimary_caret_color:#0c190d\nsecondary_caret_color:#0c190d\n"
+"base_color:#99bf9c\nbg_color:#b7ccb9\ntooltip_bg_color:#b7ccb9\nselected_bg_color:#388c40\ntext_color:#0c190d\nfg_color:#0c190d\ntooltip_fg_color:#0c190d\nselected_fg_color:#ffffff\nmenubar_bg_color:#72bf78\nmenubar_fg_color:#0c190d\ntoolbar_bg_color:#b7ccb9\ntoolbar_fg_color:#0c190d\nmenu_bg_color:#72bf78\nmenu_fg_color:#0c190d\npanel_bg_color:#b7ccb9\npanel_fg_color:#0c190d\nlink_color:#244c27\nbtn_bg_color:#99bf9c\nbtn_fg_color:#0c190d\ntitlebar_bg_color:#72bf78\ntitlebar_fg_color:#0c190d\nprimary_caret_color:#0c190d\nsecondary_caret_color:#0c190d\naccent_bg_color:#388c40\n"
 # Default Style
 
 style "murrine-default" {
@@ -320,8 +320,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 4.0

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/gtkrc.hidpi
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-2.0/gtkrc.hidpi
@@ -1,7 +1,7 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#99bf9c\nbg_color:#b7ccb9\ntooltip_bg_color:#b7ccb9\nselected_bg_color:#388c40\ntext_color:#0c190d\nfg_color:#0c190d\ntooltip_fg_color:#0c190d\nselected_fg_color:#ffffff\nmenubar_bg_color:#72bf78\nmenubar_fg_color:#0c190d\ntoolbar_bg_color:#b7ccb9\ntoolbar_fg_color:#0c190d\nmenu_bg_color:#72bf78\nmenu_fg_color:#0c190d\npanel_bg_color:#b7ccb9\npanel_fg_color:#0c190d\nlink_color:#388c40\nbtn_bg_color:#99bf9c\nbtn_fg_color:#0c190d\ntitlebar_bg_color:#72bf78\ntitlebar_fg_color:#0c190d\n"
+"base_color:#99bf9c\nbg_color:#b7ccb9\ntooltip_bg_color:#b7ccb9\nselected_bg_color:#388c40\ntext_color:#0c190d\nfg_color:#0c190d\ntooltip_fg_color:#0c190d\nselected_fg_color:#ffffff\nmenubar_bg_color:#72bf78\nmenubar_fg_color:#0c190d\ntoolbar_bg_color:#b7ccb9\ntoolbar_fg_color:#0c190d\nmenu_bg_color:#72bf78\nmenu_fg_color:#0c190d\npanel_bg_color:#b7ccb9\npanel_fg_color:#0c190d\nlink_color:#244c27\nbtn_bg_color:#99bf9c\nbtn_fg_color:#0c190d\ntitlebar_bg_color:#72bf78\ntitlebar_fg_color:#0c190d\nprimary_caret_color:#0c190d\nsecondary_caret_color:#0c190d\naccent_bg_color:#388c40\n"
 # Default Style
 
 style "murrine-default" {
@@ -316,8 +316,8 @@ style "clearlooks-radiocheck" = "murrine-default" {
 	bg[SELECTED] = @base_color
 	bg[PRELIGHT] = @bg_color
 
-	text[NORMAL] = @selected_bg_color
-	text[PRELIGHT] = @selected_bg_color
+	text[NORMAL] = @accent_bg_color
+	text[PRELIGHT] = @accent_bg_color
 
 	engine "clearlooks" {
 		radius = 20.0

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-3.0/gtk.css
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-3.0/gtk.css
@@ -19,17 +19,17 @@
 @define-color dark_shadow #020503;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #ffffff;
-@define-color info_bg_color #388c40;
+@define-color info_bg_color #7096c5;
 @define-color warning_fg_color #ffffff;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #eeee47;
 @define-color question_fg_color #ffffff;
-@define-color question_bg_color #388c40;
+@define-color question_bg_color #7096c5;
 @define-color error_fg_color #ffffff;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#388c40,#0c190d,0.6);
-@define-color success_color #388c40;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #ce6f6f;
+@define-color link_color #244c27;
+@define-color success_color #90ff49;
+@define-color warning_color #eeee47;
+@define-color error_color #ce6f6f;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -92,18 +92,18 @@
 
 * {
   /* hyperlinks */
-  -GtkHTML-link-color: mix(#388c40,#0c190d,0.6);
-  -GtkIMHtml-hyperlink-color: mix(#388c40,#0c190d,0.6);
-  -GtkWidget-link-color: mix(#388c40,#0c190d,0.6);
-  -GtkWidget-visited-link-color: mix(#388c40,#0c190d,0.6); }
+  -GtkHTML-link-color: #244c27;
+  -GtkIMHtml-hyperlink-color: #244c27;
+  -GtkWidget-link-color: #244c27;
+  -GtkWidget-visited-link-color: #244c27; }
   *:insensitive, *:insensitive:insensitive {
-    color: mix(#388c40,#0c190d,0.6); }
+    color: #244c27; }
   *:insensitive {
     -gtk-image-effect: dim; }
   *:hover {
     -gtk-image-effect: highlight; }
   *:link, *:visited {
-    color: mix(#388c40,#0c190d,0.6); }
+    color: #244c27; }
 
 .background {
   background-color: #b7ccb9;
@@ -898,45 +898,45 @@ GtkComboBox .separator {
 *******************/
 .suggested-action.button, .selection-mode.header-bar .button.suggested-action, .selection-mode.toolbar .button.suggested-action {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #388c40;
-  background-image: linear-gradient(to bottom, #46af50, #2a6930);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #90ff49;
+  background-image: linear-gradient(to bottom, #c2ff9b, #60f600);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:active:hover, .suggested-action.button:active:focus, .suggested-action.button:active:hover:focus, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button:checked:hover, .suggested-action.button:checked:focus, .suggested-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:insensitive, .selection-mode.header-bar .button.suggested-action:insensitive, .selection-mode.toolbar .button.suggested-action:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .suggested-action.button.flat, .selection-mode.header-bar .flat.button.suggested-action, .selection-mode.toolbar .flat.button.suggested-action {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(56, 140, 64, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(144, 255, 73, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:active, .suggested-action.button.flat:active:hover, .suggested-action.button.flat:active:focus, .suggested-action.button.flat:active:hover:focus, .suggested-action.button.flat:checked, .suggested-action.button.flat:checked:hover, .suggested-action.button.flat:checked:focus, .suggested-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
-    background-color: #43a84d;
-    background-image: linear-gradient(to bottom, #65c16e, #327e3a);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    background-color: #b8ff8b;
+    background-image: linear-gradient(to bottom, #f4ffed, #7cff28);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     .suggested-action.button:focus:focus, .suggested-action.button:focus:hover, .suggested-action.button:hover:focus, .suggested-action.button:hover:hover, .suggested-action.button.flat:focus:focus, .suggested-action.button.flat:focus:hover, .suggested-action.button.flat:hover:focus, .suggested-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:active, .suggested-action.button:focus:active:hover, .suggested-action.button:focus:active:focus, .suggested-action.button:focus:active:hover:focus, .suggested-action.button:focus:checked, .suggested-action.button:focus:checked:hover, .suggested-action.button:focus:checked:focus, .suggested-action.button:focus:checked:hover:focus, .suggested-action.button:hover:active, .suggested-action.button:hover:active:hover, .suggested-action.button:hover:active:focus, .suggested-action.button:hover:active:hover:focus, .suggested-action.button:hover:checked, .suggested-action.button:hover:checked:hover, .suggested-action.button:hover:checked:focus, .suggested-action.button:hover:checked:hover:focus, .suggested-action.button.flat:focus:active, .suggested-action.button.flat:focus:active:hover, .suggested-action.button.flat:focus:active:focus, .suggested-action.button.flat:focus:active:hover:focus, .suggested-action.button.flat:focus:checked, .suggested-action.button.flat:focus:checked:hover, .suggested-action.button.flat:focus:checked:focus, .suggested-action.button.flat:focus:checked:hover:focus, .suggested-action.button.flat:hover:active, .suggested-action.button.flat:hover:active:hover, .suggested-action.button.flat:hover:active:focus, .suggested-action.button.flat:hover:active:hover:focus, .suggested-action.button.flat:hover:checked, .suggested-action.button.flat:hover:checked:hover, .suggested-action.button.flat:hover:checked:focus, .suggested-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:insensitive, .suggested-action.button:hover:insensitive, .suggested-action.button.flat:focus:insensitive, .suggested-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .suggested-action.button:focus:active:insensitive, .suggested-action.button:focus:checked:insensitive, .suggested-action.button:hover:active:insensitive, .suggested-action.button:hover:checked:insensitive, .suggested-action.button.flat:focus:active:insensitive, .suggested-action.button.flat:focus:checked:insensitive, .suggested-action.button.flat:hover:active:insensitive, .suggested-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active, .suggested-action.button:checked, .selection-mode.header-bar .button.suggested-action:checked, .selection-mode.toolbar .button.suggested-action:checked, .suggested-action.button.flat:active, .suggested-action.button.flat:checked {
     background-color: #327e3a;
     background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -949,69 +949,69 @@ GtkComboBox .separator {
   .suggested-action.button:focus, .selection-mode.header-bar .button.suggested-action:focus, .selection-mode.toolbar .button.suggested-action:focus, .suggested-action.button:hover, .selection-mode.header-bar .button.suggested-action:hover, .selection-mode.toolbar .button.suggested-action:hover, .suggested-action.button.flat:focus, .suggested-action.button.flat:hover {
     color: #ffffff; }
   .suggested-action.button:active:insensitive, .suggested-action.button:checked:insensitive, .suggested-action.button.flat:active:insensitive, .suggested-action.button.flat:checked:insensitive {
-    background-color: #327e3a;
-    background-image: linear-gradient(to bottom, #3f9e48, #265f2b);
+    background-color: #7cff28;
+    background-image: linear-gradient(to bottom, #a9ff72, #56dd00);
     color: #ffffff;
     box-shadow: none; }
   .suggested-action.button:insensitive:insensitive, .suggested-action.button.flat:insensitive:insensitive {
-    background-color: rgba(56, 140, 64, 0.3);
-    background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.3), rgba(42, 105, 48, 0.3));
-    color: mix(#388c40,#ffffff,0.5);
+    background-color: #86ff39;
+    background-image: linear-gradient(to bottom, #b6ff87, #5bea00);
+    color: mix(#90ff49,#ffffff,0.5);
     box-shadow: none; }
   .suggested-action.button:active, .selection-mode.header-bar .button.suggested-action:active, .selection-mode.toolbar .button.suggested-action:active {
     color: #ffffff; }
   .suggested-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#388c40,#ffffff,0.5);
+    color: mix(#90ff49,#ffffff,0.5);
     box-shadow: none; }
   .suggested-action.button.separator, .selection-mode.header-bar .separator.button.suggested-action, .selection-mode.toolbar .separator.button.suggested-action, .suggested-action.button .separator, .selection-mode.header-bar .button.suggested-action .separator, .selection-mode.toolbar .button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: #327e3a; }
+    color: #7cff28; }
     .suggested-action.button.separator:insensitive, .suggested-action.button .separator:insensitive {
-      color: #307736; }
+      color: #72ff18; }
 
 .destructive-action.button {
   /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border-color: rgba(0, 0, 0, 0.22);
+  background-color: #ce6f6f;
+  background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
+  border-color: rgba(0, 0, 0, 0.12);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   .destructive-action.button:focus, .destructive-action.button:hover {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active, .destructive-action.button:active:hover, .destructive-action.button:active:focus, .destructive-action.button:active:hover:focus, .destructive-action.button:checked, .destructive-action.button:checked:hover, .destructive-action.button:checked:focus, .destructive-action.button:checked:hover:focus {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive {
-    border-color: rgba(0, 0, 0, 0.22); }
+    border-color: rgba(0, 0, 0, 0.12); }
   .destructive-action.button.flat {
-    border-color: rgba(0, 0, 0, 0.2);
-    background-color: rgba(255, 0, 0, 0);
+    border-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(206, 111, 111, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active, .destructive-action.button.flat:active:hover, .destructive-action.button.flat:active:focus, .destructive-action.button.flat:active:hover:focus, .destructive-action.button.flat:checked, .destructive-action.button.flat:checked:hover, .destructive-action.button.flat:checked:focus, .destructive-action.button.flat:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
     .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.2); }
+      border-color: rgba(0, 0, 0, 0.1); }
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
-    background-color: #ff3333;
-    background-image: linear-gradient(to bottom, #ff8080, #e60000);
-    border-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    background-color: #de9e9e;
+    background-image: linear-gradient(to bottom, #f6e5e5, #c65757);
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     .destructive-action.button:focus:focus, .destructive-action.button:focus:hover, .destructive-action.button:hover:focus, .destructive-action.button:hover:hover, .destructive-action.button.flat:focus:focus, .destructive-action.button.flat:focus:hover, .destructive-action.button.flat:hover:focus, .destructive-action.button.flat:hover:hover {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active, .destructive-action.button:focus:active:hover, .destructive-action.button:focus:active:focus, .destructive-action.button:focus:active:hover:focus, .destructive-action.button:focus:checked, .destructive-action.button:focus:checked:hover, .destructive-action.button:focus:checked:focus, .destructive-action.button:focus:checked:hover:focus, .destructive-action.button:hover:active, .destructive-action.button:hover:active:hover, .destructive-action.button:hover:active:focus, .destructive-action.button:hover:active:hover:focus, .destructive-action.button:hover:checked, .destructive-action.button:hover:checked:hover, .destructive-action.button:hover:checked:focus, .destructive-action.button:hover:checked:hover:focus, .destructive-action.button.flat:focus:active, .destructive-action.button.flat:focus:active:hover, .destructive-action.button.flat:focus:active:focus, .destructive-action.button.flat:focus:active:hover:focus, .destructive-action.button.flat:focus:checked, .destructive-action.button.flat:focus:checked:hover, .destructive-action.button.flat:focus:checked:focus, .destructive-action.button.flat:focus:checked:hover:focus, .destructive-action.button.flat:hover:active, .destructive-action.button.flat:hover:active:hover, .destructive-action.button.flat:hover:active:focus, .destructive-action.button.flat:hover:active:hover:focus, .destructive-action.button.flat:hover:checked, .destructive-action.button.flat:hover:checked:hover, .destructive-action.button.flat:hover:checked:focus, .destructive-action.button.flat:hover:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:insensitive, .destructive-action.button:hover:insensitive, .destructive-action.button.flat:focus:insensitive, .destructive-action.button.flat:hover:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
     .destructive-action.button:focus:active:insensitive, .destructive-action.button:focus:checked:insensitive, .destructive-action.button:hover:active:insensitive, .destructive-action.button:hover:checked:insensitive, .destructive-action.button.flat:focus:active:insensitive, .destructive-action.button.flat:focus:checked:insensitive, .destructive-action.button.flat:hover:active:insensitive, .destructive-action.button.flat:hover:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.3); }
+      border-color: rgba(0, 0, 0, 0.2); }
   .destructive-action.button:active, .destructive-action.button:checked, .destructive-action.button.flat:active, .destructive-action.button.flat:checked {
     background-color: #327e3a;
     background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -1024,27 +1024,27 @@ GtkComboBox .separator {
   .destructive-action.button:focus, .destructive-action.button:hover, .destructive-action.button.flat:focus, .destructive-action.button.flat:hover {
     color: #ffffff; }
   .destructive-action.button:active:insensitive, .destructive-action.button:checked:insensitive, .destructive-action.button.flat:active:insensitive, .destructive-action.button.flat:checked:insensitive {
-    background-color: #e60000;
-    background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+    background-color: #c65757;
+    background-image: linear-gradient(to bottom, #d88d8d, #a03636);
     color: #ffffff;
     box-shadow: none; }
   .destructive-action.button:insensitive:insensitive, .destructive-action.button.flat:insensitive:insensitive {
-    background-color: rgba(255, 0, 0, 0.3);
-    background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-    color: mix(#ff0000,#ffffff,0.5);
+    background-color: #ca6363;
+    background-image: linear-gradient(to bottom, #dd9b9b, #a93939);
+    color: mix(#ce6f6f,#ffffff,0.5);
     box-shadow: none; }
   .destructive-action.button:active {
     color: #ffffff; }
   .destructive-action.button.flat:insensitive:insensitive {
     background-color: transparent;
     background-image: none;
-    color: mix(#ff0000,#ffffff,0.5);
+    color: mix(#ce6f6f,#ffffff,0.5);
     box-shadow: none; }
   .destructive-action.button.separator, .destructive-action.button .separator {
     border: 1px solid currentColor;
-    color: #e60000; }
+    color: #c65757; }
     .destructive-action.button.separator:insensitive, .destructive-action.button .separator:insensitive {
-      color: #d90000; }
+      color: #c24c4c; }
 
 /******************
 * selection mode *
@@ -1424,51 +1424,51 @@ GtkInfoBar {
   border: 0; }
 
 .info {
-  background-color: #388c40;
-  background-image: linear-gradient(to bottom, #46af50, #2a6930);
-  border: 1px solid #2d7033;
+  background-color: #7096c5;
+  background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+  border: 1px solid #4776b0;
   color: #ffffff; }
   .info .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     .info .button:focus, .info .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:active, .info .button:active:hover, .info .button:active:focus, .info .button:active:hover:focus, .info .button:checked, .info .button:checked:hover, .info .button:checked:focus, .info .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button:active:insensitive, .info .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .info .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(56, 140, 64, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(112, 150, 197, 0);
       background-image: none;
       box-shadow: none; }
       .info .button.flat:focus, .info .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:active, .info .button.flat:active:hover, .info .button.flat:active:focus, .info .button.flat:active:hover:focus, .info .button.flat:checked, .info .button.flat:checked:hover, .info .button.flat:checked:focus, .info .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
-      background-color: #43a84d;
-      background-image: linear-gradient(to bottom, #65c16e, #327e3a);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      background-color: #9cb6d7;
+      background-image: linear-gradient(to bottom, #dee7f2, #5a86bc);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       .info .button:focus:focus, .info .button:focus:hover, .info .button:hover:focus, .info .button:hover:hover, .info .button.flat:focus:focus, .info .button.flat:focus:hover, .info .button.flat:hover:focus, .info .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:active, .info .button:focus:active:hover, .info .button:focus:active:focus, .info .button:focus:active:hover:focus, .info .button:focus:checked, .info .button:focus:checked:hover, .info .button:focus:checked:focus, .info .button:focus:checked:hover:focus, .info .button:hover:active, .info .button:hover:active:hover, .info .button:hover:active:focus, .info .button:hover:active:hover:focus, .info .button:hover:checked, .info .button:hover:checked:hover, .info .button:hover:checked:focus, .info .button:hover:checked:hover:focus, .info .button.flat:focus:active, .info .button.flat:focus:active:hover, .info .button.flat:focus:active:focus, .info .button.flat:focus:active:hover:focus, .info .button.flat:focus:checked, .info .button.flat:focus:checked:hover, .info .button.flat:focus:checked:focus, .info .button.flat:focus:checked:hover:focus, .info .button.flat:hover:active, .info .button.flat:hover:active:hover, .info .button.flat:hover:active:focus, .info .button.flat:hover:active:hover:focus, .info .button.flat:hover:checked, .info .button.flat:hover:checked:hover, .info .button.flat:hover:checked:focus, .info .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:insensitive, .info .button:hover:insensitive, .info .button.flat:focus:insensitive, .info .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .info .button:focus:active:insensitive, .info .button:focus:checked:insensitive, .info .button:hover:active:insensitive, .info .button:hover:checked:insensitive, .info .button.flat:focus:active:insensitive, .info .button.flat:focus:checked:insensitive, .info .button.flat:hover:active:insensitive, .info .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .info .button:active, .info .button:checked, .info .button.flat:active, .info .button.flat:checked {
       background-color: #327e3a;
       background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -1481,74 +1481,74 @@ GtkInfoBar {
     .info .button:focus, .info .button:hover, .info .button.flat:focus, .info .button.flat:hover {
       color: #ffffff; }
     .info .button:active:insensitive, .info .button:checked:insensitive, .info .button.flat:active:insensitive, .info .button.flat:checked:insensitive {
-      background-color: #327e3a;
-      background-image: linear-gradient(to bottom, #3f9e48, #265f2b);
+      background-color: #5a86bc;
+      background-image: linear-gradient(to bottom, #8baad0, #3c6494);
       color: #ffffff;
       box-shadow: none; }
     .info .button:insensitive:insensitive, .info .button.flat:insensitive:insensitive {
-      background-color: rgba(56, 140, 64, 0.3);
-      background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.3), rgba(42, 105, 48, 0.3));
-      color: mix(#388c40,#ffffff,0.5);
+      background-color: #658ec1;
+      background-image: linear-gradient(to bottom, #99b4d6, #40699d);
+      color: mix(#7096c5,#ffffff,0.5);
       box-shadow: none; }
     .info .button:active {
       color: #ffffff; }
     .info .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#388c40,#ffffff,0.5);
+      color: mix(#7096c5,#ffffff,0.5);
       box-shadow: none; }
     .info .button.separator, .info .button .separator {
       border: 1px solid currentColor;
-      color: #327e3a; }
+      color: #5a86bc; }
       .info .button.separator:insensitive, .info .button .separator:insensitive {
-        color: #307736; }
+        color: #4f7eb8; }
 
 .warning {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #eeee47;
+  background-image: linear-gradient(to bottom, #f5f58e, #d4d414);
+  border: 1px solid #e2e215;
   color: #ffffff; }
   .warning .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #eeee47;
+    background-image: linear-gradient(to bottom, #f5f58e, #d4d414);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     .warning .button:focus, .warning .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active, .warning .button:active:hover, .warning .button:active:focus, .warning .button:active:hover:focus, .warning .button:checked, .warning .button:checked:hover, .warning .button:checked:focus, .warning .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button:active:insensitive, .warning .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .warning .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(238, 238, 71, 0);
       background-image: none;
       box-shadow: none; }
       .warning .button.flat:focus, .warning .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active, .warning .button.flat:active:hover, .warning .button.flat:active:focus, .warning .button.flat:active:hover:focus, .warning .button.flat:checked, .warning .button.flat:checked:hover, .warning .button.flat:checked:focus, .warning .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      background-color: #f3f380;
+      background-image: linear-gradient(to bottom, #fbfbd4, #ebeb2b);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       .warning .button:focus:focus, .warning .button:focus:hover, .warning .button:hover:focus, .warning .button:hover:hover, .warning .button.flat:focus:focus, .warning .button.flat:focus:hover, .warning .button.flat:hover:focus, .warning .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active, .warning .button:focus:active:hover, .warning .button:focus:active:focus, .warning .button:focus:active:hover:focus, .warning .button:focus:checked, .warning .button:focus:checked:hover, .warning .button:focus:checked:focus, .warning .button:focus:checked:hover:focus, .warning .button:hover:active, .warning .button:hover:active:hover, .warning .button:hover:active:focus, .warning .button:hover:active:hover:focus, .warning .button:hover:checked, .warning .button:hover:checked:hover, .warning .button:hover:checked:focus, .warning .button:hover:checked:hover:focus, .warning .button.flat:focus:active, .warning .button.flat:focus:active:hover, .warning .button.flat:focus:active:focus, .warning .button.flat:focus:active:hover:focus, .warning .button.flat:focus:checked, .warning .button.flat:focus:checked:hover, .warning .button.flat:focus:checked:focus, .warning .button.flat:focus:checked:hover:focus, .warning .button.flat:hover:active, .warning .button.flat:hover:active:hover, .warning .button.flat:hover:active:focus, .warning .button.flat:hover:active:hover:focus, .warning .button.flat:hover:checked, .warning .button.flat:hover:checked:hover, .warning .button.flat:hover:checked:focus, .warning .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:insensitive, .warning .button:hover:insensitive, .warning .button.flat:focus:insensitive, .warning .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .warning .button:focus:active:insensitive, .warning .button:focus:checked:insensitive, .warning .button:hover:active:insensitive, .warning .button:hover:checked:insensitive, .warning .button.flat:focus:active:insensitive, .warning .button.flat:focus:checked:insensitive, .warning .button.flat:hover:active:insensitive, .warning .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .warning .button:active, .warning .button:checked, .warning .button.flat:active, .warning .button.flat:checked {
       background-color: #327e3a;
       background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -1561,74 +1561,74 @@ GtkInfoBar {
     .warning .button:focus, .warning .button:hover, .warning .button.flat:focus, .warning .button.flat:hover {
       color: #ffffff; }
     .warning .button:active:insensitive, .warning .button:checked:insensitive, .warning .button.flat:active:insensitive, .warning .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #ebeb2b;
+      background-image: linear-gradient(to bottom, #f1f16a, #bfbf12);
       color: #ffffff;
       box-shadow: none; }
     .warning .button:insensitive:insensitive, .warning .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#ffffff,0.5);
+      background-color: #eded39;
+      background-image: linear-gradient(to bottom, #f3f37c, #caca13);
+      color: mix(#eeee47,#ffffff,0.5);
       box-shadow: none; }
     .warning .button:active {
       color: #ffffff; }
     .warning .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#ffffff,0.5);
+      color: mix(#eeee47,#ffffff,0.5);
       box-shadow: none; }
     .warning .button.separator, .warning .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #ebeb2b; }
       .warning .button.separator:insensitive, .warning .button .separator:insensitive {
-        color: #d90000; }
+        color: #eaea1d; }
 
 .question {
-  background-color: #388c40;
-  background-image: linear-gradient(to bottom, #46af50, #2a6930);
-  border: 1px solid #2d7033;
+  background-color: #7096c5;
+  background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+  border: 1px solid #4776b0;
   color: #ffffff; }
   .question .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     .question .button:focus, .question .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:active, .question .button:active:hover, .question .button:active:focus, .question .button:active:hover:focus, .question .button:checked, .question .button:checked:hover, .question .button:checked:focus, .question .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button:active:insensitive, .question .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .question .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(56, 140, 64, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(112, 150, 197, 0);
       background-image: none;
       box-shadow: none; }
       .question .button.flat:focus, .question .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:active, .question .button.flat:active:hover, .question .button.flat:active:focus, .question .button.flat:active:hover:focus, .question .button.flat:checked, .question .button.flat:checked:hover, .question .button.flat:checked:focus, .question .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
-      background-color: #43a84d;
-      background-image: linear-gradient(to bottom, #65c16e, #327e3a);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      background-color: #9cb6d7;
+      background-image: linear-gradient(to bottom, #dee7f2, #5a86bc);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       .question .button:focus:focus, .question .button:focus:hover, .question .button:hover:focus, .question .button:hover:hover, .question .button.flat:focus:focus, .question .button.flat:focus:hover, .question .button.flat:hover:focus, .question .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:active, .question .button:focus:active:hover, .question .button:focus:active:focus, .question .button:focus:active:hover:focus, .question .button:focus:checked, .question .button:focus:checked:hover, .question .button:focus:checked:focus, .question .button:focus:checked:hover:focus, .question .button:hover:active, .question .button:hover:active:hover, .question .button:hover:active:focus, .question .button:hover:active:hover:focus, .question .button:hover:checked, .question .button:hover:checked:hover, .question .button:hover:checked:focus, .question .button:hover:checked:hover:focus, .question .button.flat:focus:active, .question .button.flat:focus:active:hover, .question .button.flat:focus:active:focus, .question .button.flat:focus:active:hover:focus, .question .button.flat:focus:checked, .question .button.flat:focus:checked:hover, .question .button.flat:focus:checked:focus, .question .button.flat:focus:checked:hover:focus, .question .button.flat:hover:active, .question .button.flat:hover:active:hover, .question .button.flat:hover:active:focus, .question .button.flat:hover:active:hover:focus, .question .button.flat:hover:checked, .question .button.flat:hover:checked:hover, .question .button.flat:hover:checked:focus, .question .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:insensitive, .question .button:hover:insensitive, .question .button.flat:focus:insensitive, .question .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .question .button:focus:active:insensitive, .question .button:focus:checked:insensitive, .question .button:hover:active:insensitive, .question .button:hover:checked:insensitive, .question .button.flat:focus:active:insensitive, .question .button.flat:focus:checked:insensitive, .question .button.flat:hover:active:insensitive, .question .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .question .button:active, .question .button:checked, .question .button.flat:active, .question .button.flat:checked {
       background-color: #327e3a;
       background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -1641,74 +1641,74 @@ GtkInfoBar {
     .question .button:focus, .question .button:hover, .question .button.flat:focus, .question .button.flat:hover {
       color: #ffffff; }
     .question .button:active:insensitive, .question .button:checked:insensitive, .question .button.flat:active:insensitive, .question .button.flat:checked:insensitive {
-      background-color: #327e3a;
-      background-image: linear-gradient(to bottom, #3f9e48, #265f2b);
+      background-color: #5a86bc;
+      background-image: linear-gradient(to bottom, #8baad0, #3c6494);
       color: #ffffff;
       box-shadow: none; }
     .question .button:insensitive:insensitive, .question .button.flat:insensitive:insensitive {
-      background-color: rgba(56, 140, 64, 0.3);
-      background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.3), rgba(42, 105, 48, 0.3));
-      color: mix(#388c40,#ffffff,0.5);
+      background-color: #658ec1;
+      background-image: linear-gradient(to bottom, #99b4d6, #40699d);
+      color: mix(#7096c5,#ffffff,0.5);
       box-shadow: none; }
     .question .button:active {
       color: #ffffff; }
     .question .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#388c40,#ffffff,0.5);
+      color: mix(#7096c5,#ffffff,0.5);
       box-shadow: none; }
     .question .button.separator, .question .button .separator {
       border: 1px solid currentColor;
-      color: #327e3a; }
+      color: #5a86bc; }
       .question .button.separator:insensitive, .question .button .separator:insensitive {
-        color: #307736; }
+        color: #4f7eb8; }
 
 .error {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-  border: 1px solid #cc0000;
+  background-color: #ce6f6f;
+  background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
+  border: 1px solid #bd4040;
   color: #ffffff; }
   .error .button {
     /*$button_bg: if(hue($bg) == 0deg, shade($bg, 1.2), $bg);*/
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border-color: rgba(0, 0, 0, 0.22);
+    background-color: #ce6f6f;
+    background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
+    border-color: rgba(0, 0, 0, 0.12);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     .error .button:focus, .error .button:hover {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active, .error .button:active:hover, .error .button:active:focus, .error .button:active:hover:focus, .error .button:checked, .error .button:checked:hover, .error .button:checked:focus, .error .button:checked:hover:focus {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button:active:insensitive, .error .button:checked:insensitive {
-      border-color: rgba(0, 0, 0, 0.22); }
+      border-color: rgba(0, 0, 0, 0.12); }
     .error .button.flat {
-      border-color: rgba(0, 0, 0, 0.2);
-      background-color: rgba(255, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(206, 111, 111, 0);
       background-image: none;
       box-shadow: none; }
       .error .button.flat:focus, .error .button.flat:hover {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active, .error .button.flat:active:hover, .error .button.flat:active:focus, .error .button.flat:active:hover:focus, .error .button.flat:checked, .error .button.flat:checked:hover, .error .button.flat:checked:focus, .error .button.flat:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
       .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.2); }
+        border-color: rgba(0, 0, 0, 0.1); }
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
-      background-color: #ff3333;
-      background-image: linear-gradient(to bottom, #ff8080, #e60000);
-      border-color: rgba(0, 0, 0, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      background-color: #de9e9e;
+      background-image: linear-gradient(to bottom, #f6e5e5, #c65757);
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       .error .button:focus:focus, .error .button:focus:hover, .error .button:hover:focus, .error .button:hover:hover, .error .button.flat:focus:focus, .error .button.flat:focus:hover, .error .button.flat:hover:focus, .error .button.flat:hover:hover {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active, .error .button:focus:active:hover, .error .button:focus:active:focus, .error .button:focus:active:hover:focus, .error .button:focus:checked, .error .button:focus:checked:hover, .error .button:focus:checked:focus, .error .button:focus:checked:hover:focus, .error .button:hover:active, .error .button:hover:active:hover, .error .button:hover:active:focus, .error .button:hover:active:hover:focus, .error .button:hover:checked, .error .button:hover:checked:hover, .error .button:hover:checked:focus, .error .button:hover:checked:hover:focus, .error .button.flat:focus:active, .error .button.flat:focus:active:hover, .error .button.flat:focus:active:focus, .error .button.flat:focus:active:hover:focus, .error .button.flat:focus:checked, .error .button.flat:focus:checked:hover, .error .button.flat:focus:checked:focus, .error .button.flat:focus:checked:hover:focus, .error .button.flat:hover:active, .error .button.flat:hover:active:hover, .error .button.flat:hover:active:focus, .error .button.flat:hover:active:hover:focus, .error .button.flat:hover:checked, .error .button.flat:hover:checked:hover, .error .button.flat:hover:checked:focus, .error .button.flat:hover:checked:hover:focus {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:insensitive, .error .button:hover:insensitive, .error .button.flat:focus:insensitive, .error .button.flat:hover:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
       .error .button:focus:active:insensitive, .error .button:focus:checked:insensitive, .error .button:hover:active:insensitive, .error .button:hover:checked:insensitive, .error .button.flat:focus:active:insensitive, .error .button.flat:focus:checked:insensitive, .error .button.flat:hover:active:insensitive, .error .button.flat:hover:checked:insensitive {
-        border-color: rgba(0, 0, 0, 0.3); }
+        border-color: rgba(0, 0, 0, 0.2); }
     .error .button:active, .error .button:checked, .error .button.flat:active, .error .button.flat:checked {
       background-color: #327e3a;
       background-image: linear-gradient(to top, #3f9e48, #265f2b);
@@ -1721,27 +1721,27 @@ GtkInfoBar {
     .error .button:focus, .error .button:hover, .error .button.flat:focus, .error .button.flat:hover {
       color: #ffffff; }
     .error .button:active:insensitive, .error .button:checked:insensitive, .error .button.flat:active:insensitive, .error .button.flat:checked:insensitive {
-      background-color: #e60000;
-      background-image: linear-gradient(to bottom, #ff2020, #ac0000);
+      background-color: #c65757;
+      background-image: linear-gradient(to bottom, #d88d8d, #a03636);
       color: #ffffff;
       box-shadow: none; }
     .error .button:insensitive:insensitive, .error .button.flat:insensitive:insensitive {
-      background-color: rgba(255, 0, 0, 0.3);
-      background-image: linear-gradient(to bottom, rgba(255, 64, 64, 0.3), rgba(191, 0, 0, 0.3));
-      color: mix(#ff0000,#ffffff,0.5);
+      background-color: #ca6363;
+      background-image: linear-gradient(to bottom, #dd9b9b, #a93939);
+      color: mix(#ce6f6f,#ffffff,0.5);
       box-shadow: none; }
     .error .button:active {
       color: #ffffff; }
     .error .button.flat:insensitive:insensitive {
       background-color: transparent;
       background-image: none;
-      color: mix(#ff0000,#ffffff,0.5);
+      color: mix(#ce6f6f,#ffffff,0.5);
       box-shadow: none; }
     .error .button.separator, .error .button .separator {
       border: 1px solid currentColor;
-      color: #e60000; }
+      color: #c65757; }
       .error .button.separator:insensitive, .error .button .separator:insensitive {
-        color: #d90000; }
+        color: #c24c4c; }
 
 /*********
  ! Entry *
@@ -3098,10 +3098,10 @@ GtkLevelBar {
   .level-bar.fill-block.indicator-discrete.vertical {
     margin-bottom: 1px; }
   .level-bar.fill-block.level-high {
-    background-color: #388c40;
+    background-color: #90ff49;
     border-color: transparent; }
   .level-bar.fill-block.level-low {
-    background-color: #ff0000;
+    background-color: #eeee47;
     border-color: transparent; }
   .level-bar.fill-block.empty-fill-block {
     background-color: transparent;
@@ -3486,7 +3486,7 @@ GtkSwitch {
  ! Generic views
 ****************/
 * {
-  -GtkTextView-error-underline-color: #ff0000; }
+  -GtkTextView-error-underline-color: #ce6f6f; }
 
 .view, GtkHTML {
   color: #0c190d;
@@ -3852,7 +3852,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #6fa473;
   background-color: #99bf9c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #ce6f6f;
     background-image: none;
     color: #ffffff; }
 
@@ -4270,23 +4270,23 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #bd4040;
+  background-color: #d48282;
   background-image: none;
   color: #ffffff; }
   #shutdown_button:hover, #shutdown_button:active, #shutdown_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #a63838;
+    background-color: #ce6f6f; }
 
 /* restart button */
 #restart_button {
-  border-color: #cc0000;
-  background-color: #ff1414;
+  border-color: #e2e215;
+  background-color: #f0f05e;
   background-image: none;
   color: #ffffff; }
   #restart_button:hover, #restart_button:active, #restart_button:active:hover {
-    border-color: #b30000;
-    background-color: #ff0000; }
+    border-color: #c6c612;
+    background-color: #eeee47; }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-3.20/gtk.css
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/gtk-3.20/gtk.css
@@ -27,17 +27,17 @@
 @define-color dark_shadow #020503;
 /* misc colors used by gtk+ */
 @define-color info_fg_color #ffffff;
-@define-color info_bg_color #388c40;
+@define-color info_bg_color #7096c5;
 @define-color warning_fg_color #ffffff;
-@define-color warning_bg_color #ff0000;
+@define-color warning_bg_color #eeee47;
 @define-color question_fg_color #ffffff;
-@define-color question_bg_color #388c40;
+@define-color question_bg_color #7096c5;
 @define-color error_fg_color #ffffff;
-@define-color error_bg_color #ff0000;
-@define-color link_color mix(#388c40,#0c190d,0.6);
-@define-color success_color #388c40;
-@define-color warning_color #ff0000;
-@define-color error_color #ff0000;
+@define-color error_bg_color #ce6f6f;
+@define-color link_color #244c27;
+@define-color success_color #90ff49;
+@define-color warning_color #eeee47;
+@define-color error_color #ce6f6f;
 /* widget colors */
 @define-color titlebar_bg_focused @dark_bg_color;
 @define-color titlebar_bg_unfocused @theme_bg_color;
@@ -119,15 +119,15 @@
 
 * {
   /* hyperlinks */
-  -GtkIMHtml-hyperlink-color: mix(#388c40,#0c190d,0.6); }
+  -GtkIMHtml-hyperlink-color: #244c27; }
   *:disabled, *:disabled:disabled {
-    color: mix(#388c40,#0c190d,0.6); }
+    color: #244c27; }
   *:disabled, *:disabled {
     -gtk-icon-effect: dim; }
   *:hover {
     -gtk-icon-effect: highlight; }
   *:link, *:visited {
-    color: mix(#388c40,#0c190d,0.6); }
+    color: #244c27; }
 
 .background {
   background-color: #b7ccb9;
@@ -775,57 +775,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #e2e215;
+    background-color: mix(#99bf9c,#eeee47,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #ffffff; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#eeee47,0.3);
+      background-color: #eeee47;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #eeee47; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #bd4040;
+    background-color: mix(#99bf9c,#ce6f6f,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #ffffff; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#ce6f6f,0.3);
+      background-color: #ce6f6f;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce6f6f; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #bd4040;
+    background-color: mix(#99bf9c,#ce6f6f,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #ffffff; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#ce6f6f,0.3);
+      background-color: #ce6f6f;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce6f6f; }
 
 entry {
   background-color: #99bf9c;
@@ -1727,11 +1727,11 @@ searchbar,
 *******************/
 .suggested-action, headerbar.selection-mode button.suggested-action,
 .titlebar:not(headerbar).selection-mode button.suggested-action {
-  background-color: #388c40;
-  background-image: linear-gradient(to bottom, #46af50, #2a6930);
+  background-color: #90ff49;
+  background-image: linear-gradient(to bottom, #c2ff9b, #60f600);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover {
@@ -1851,7 +1851,7 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(56, 140, 64, 0);
+    background-color: rgba(144, 255, 73, 0);
     background-image: none;
     box-shadow: none; }
     .suggested-action.flat:focus,
@@ -1870,11 +1870,11 @@ searchbar,
   .suggested-action:hover, headerbar.selection-mode button.suggested-action:hover,
   .titlebar:not(headerbar).selection-mode button.suggested-action:hover, .suggested-action.flat:hover,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:hover {
-    background-color: #3b9343;
-    background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+    background-color: #9aff59;
+    background-image: linear-gradient(to bottom, #cfffb0, #65ff03);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
     .suggested-action:hover:focus,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:focus, .suggested-action:hover:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:hover:hover, .suggested-action.flat:hover:focus, .suggested-action.flat:hover:hover {
@@ -1891,21 +1891,21 @@ searchbar,
   .suggested-action:focus, headerbar.selection-mode button.suggested-action:focus,
   .titlebar:not(headerbar).selection-mode button.suggested-action:focus, .suggested-action.flat:focus,
   .titlebar:not(headerbar).selection-mode button.flat.suggested-action:focus {
-    background-color: #3b9343;
-    background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+    background-color: #9aff59;
+    background-image: linear-gradient(to bottom, #cfffb0, #65ff03);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 140, 64, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     .suggested-action:focus:hover,
     .titlebar:not(headerbar).selection-mode button.suggested-action:focus:hover, .suggested-action.flat:focus:hover {
-      background-color: #3e9a46;
-      background-image: linear-gradient(to bottom, #53ba5d, #2e7435);
+      background-color: #a4ff6a;
+      background-image: linear-gradient(to bottom, #dbffc4, #6dff10);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
       .suggested-action:focus:hover:focus, .suggested-action:focus:hover:hover, .suggested-action.flat:focus:hover:focus, .suggested-action.flat:focus:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       .suggested-action:focus:hover:active, .suggested-action:focus:hover:active:hover, .suggested-action:focus:hover:active:focus, .suggested-action:focus:hover:active:hover:focus, .suggested-action:focus:hover:checked, .suggested-action:focus:hover:checked:hover, .suggested-action:focus:hover:checked:focus, .suggested-action:focus:hover:checked:hover:focus, .suggested-action.flat:focus:hover:active, .suggested-action.flat:focus:hover:active:hover, .suggested-action.flat:focus:hover:active:focus, .suggested-action.flat:focus:hover:active:hover:focus, .suggested-action.flat:focus:hover:checked, .suggested-action.flat:focus:hover:checked:hover, .suggested-action.flat:focus:hover:checked:focus, .suggested-action.flat:focus:hover:checked:hover:focus {
@@ -1960,14 +1960,14 @@ searchbar,
     color: #ffffff; }
   .suggested-action:disabled:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:disabled:disabled, .suggested-action.flat:disabled:disabled {
-    background-color: alpha(mix(#388c40,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#388c40,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#388c40,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#90ff49,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#90ff49,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#90ff49,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#388c40,#ffffff,0.6);
+    color: mix(#90ff49,#ffffff,0.6);
     box-shadow: none; }
     .suggested-action:disabled:disabled :disabled, .suggested-action.flat:disabled:disabled :disabled {
-      color: mix(#388c40,#ffffff,0.6); }
+      color: mix(#90ff49,#ffffff,0.6); }
   .suggested-action:active:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:active:disabled, .suggested-action:checked:disabled,
   .titlebar:not(headerbar).selection-mode button.suggested-action:checked:disabled, .suggested-action.flat:active:disabled, .suggested-action.flat:checked:disabled {
@@ -1981,18 +1981,18 @@ searchbar,
   .titlebar:not(headerbar).selection-mode button.separator.suggested-action, .suggested-action .separator, headerbar.selection-mode button.suggested-action .separator,
   .titlebar:not(headerbar).selection-mode button.suggested-action .separator {
     border: 1px solid currentColor;
-    color: rgba(56, 140, 64, 0.9); }
+    color: rgba(144, 255, 73, 0.9); }
     .suggested-action.separator:disabled,
     .titlebar:not(headerbar).selection-mode button.separator.suggested-action:disabled, .suggested-action .separator:disabled,
     .titlebar:not(headerbar).selection-mode button.suggested-action .separator:disabled {
-      color: rgba(56, 140, 64, 0.85); }
+      color: rgba(144, 255, 73, 0.85); }
 
 .destructive-action {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #ce6f6f;
+  background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   .destructive-action:focus, .destructive-action:hover {
     border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
   .destructive-action:active, .destructive-action:active:hover, .destructive-action:active:focus, .destructive-action:active:hover:focus, .destructive-action:checked, .destructive-action:checked:hover, .destructive-action:checked:focus, .destructive-action:checked:hover:focus {
@@ -2044,7 +2044,7 @@ searchbar,
   .destructive-action.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(206, 111, 111, 0);
     background-image: none;
     box-shadow: none; }
     .destructive-action.flat:focus, .destructive-action.flat:hover {
@@ -2056,11 +2056,11 @@ searchbar,
     .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   .destructive-action:hover, .destructive-action.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d27b7b;
+    background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
     .destructive-action:hover:focus, .destructive-action:hover:hover, .destructive-action.flat:hover:focus, .destructive-action.flat:hover:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
     .destructive-action:hover:active, .destructive-action:hover:active:hover, .destructive-action:hover:active:focus, .destructive-action:hover:active:hover:focus, .destructive-action:hover:checked, .destructive-action:hover:checked:hover, .destructive-action:hover:checked:focus, .destructive-action:hover:checked:hover:focus, .destructive-action.flat:hover:active, .destructive-action.flat:hover:active:hover, .destructive-action.flat:hover:active:focus, .destructive-action.flat:hover:active:hover:focus, .destructive-action.flat:hover:checked, .destructive-action.flat:hover:checked:hover, .destructive-action.flat:hover:checked:focus, .destructive-action.flat:hover:checked:hover:focus {
@@ -2070,20 +2070,20 @@ searchbar,
     .destructive-action:hover:active:disabled, .destructive-action:hover:checked:disabled, .destructive-action.flat:hover:active:disabled, .destructive-action.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   .destructive-action:focus, .destructive-action.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d27b7b;
+    background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 140, 64, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     .destructive-action:focus:hover, .destructive-action.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #d68787;
+      background-image: linear-gradient(to bottom, #ecc8c8, #c04646);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
       .destructive-action:focus:hover:focus, .destructive-action:focus:hover:hover, .destructive-action.flat:focus:hover:focus, .destructive-action.flat:focus:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       .destructive-action:focus:hover:active, .destructive-action:focus:hover:active:hover, .destructive-action:focus:hover:active:focus, .destructive-action:focus:hover:active:hover:focus, .destructive-action:focus:hover:checked, .destructive-action:focus:hover:checked:hover, .destructive-action:focus:hover:checked:focus, .destructive-action:focus:hover:checked:hover:focus, .destructive-action.flat:focus:hover:active, .destructive-action.flat:focus:hover:active:hover, .destructive-action.flat:focus:hover:active:focus, .destructive-action.flat:focus:hover:active:hover:focus, .destructive-action.flat:focus:hover:checked, .destructive-action.flat:focus:hover:checked:hover, .destructive-action.flat:focus:hover:checked:focus, .destructive-action.flat:focus:hover:checked:hover:focus {
@@ -2115,14 +2115,14 @@ searchbar,
   .destructive-action:focus, .destructive-action:hover, .destructive-action.flat:focus, .destructive-action.flat:hover {
     color: #ffffff; }
   .destructive-action:disabled:disabled, .destructive-action.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#ce6f6f,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#ce6f6f,#ffffff,0.6);
     box-shadow: none; }
     .destructive-action:disabled:disabled :disabled, .destructive-action.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#ce6f6f,#ffffff,0.6); }
   .destructive-action:active:disabled, .destructive-action:checked:disabled, .destructive-action.flat:active:disabled, .destructive-action.flat:checked:disabled {
     background-color: rgba(56, 140, 64, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -2132,9 +2132,9 @@ searchbar,
       color: rgba(255, 255, 255, 0.85); }
   .destructive-action.separator, .destructive-action .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(206, 111, 111, 0.9); }
     .destructive-action.separator:disabled, .destructive-action .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(206, 111, 111, 0.85); }
 
 /******************
  ! Selection mode *
@@ -3202,18 +3202,18 @@ flowbox flowboxchild {
 infobar {
   border: 0; }
   infobar.info, infobar.info:backdrop {
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
-    border: 1px solid #2d7033;
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+    border: 1px solid #4776b0;
     caret-color: currentColor; }
     infobar.info label, infobar.info, infobar.info:backdrop label, infobar.info:backdrop {
       color: #ffffff; }
   infobar.info button {
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     infobar.info button:focus, infobar.info button:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
     infobar.info button:active, infobar.info button:active:hover, infobar.info button:active:focus, infobar.info button:active:hover:focus, infobar.info button:checked, infobar.info button:checked:hover, infobar.info button:checked:focus, infobar.info button:checked:hover:focus {
@@ -3265,7 +3265,7 @@ infobar {
     infobar.info button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(56, 140, 64, 0);
+      background-color: rgba(112, 150, 197, 0);
       background-image: none;
       box-shadow: none; }
       infobar.info button.flat:focus, infobar.info button.flat:hover {
@@ -3277,11 +3277,11 @@ infobar {
       infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.info button:hover, infobar.info button.flat:hover {
-      background-color: #3b9343;
-      background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+      background-color: #7b9ec9;
+      background-image: linear-gradient(to bottom, #b5c8e1, #4674ad);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
       infobar.info button:hover:focus, infobar.info button:hover:hover, infobar.info button.flat:hover:focus, infobar.info button.flat:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       infobar.info button:hover:active, infobar.info button:hover:active:hover, infobar.info button:hover:active:focus, infobar.info button:hover:active:hover:focus, infobar.info button:hover:checked, infobar.info button:hover:checked:hover, infobar.info button:hover:checked:focus, infobar.info button:hover:checked:hover:focus, infobar.info button.flat:hover:active, infobar.info button.flat:hover:active:hover, infobar.info button.flat:hover:active:focus, infobar.info button.flat:hover:active:hover:focus, infobar.info button.flat:hover:checked, infobar.info button.flat:hover:checked:hover, infobar.info button.flat:hover:checked:focus, infobar.info button.flat:hover:checked:hover:focus {
@@ -3291,20 +3291,20 @@ infobar {
       infobar.info button:hover:active:disabled, infobar.info button:hover:checked:disabled, infobar.info button.flat:hover:active:disabled, infobar.info button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.info button:focus, infobar.info button.flat:focus {
-      background-color: #3b9343;
-      background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+      background-color: #7b9ec9;
+      background-image: linear-gradient(to bottom, #b5c8e1, #4674ad);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 140, 64, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       infobar.info button:focus:hover, infobar.info button.flat:focus:hover {
-        background-color: #3e9a46;
-        background-image: linear-gradient(to bottom, #53ba5d, #2e7435);
+        background-color: #86a6ce;
+        background-image: linear-gradient(to bottom, #c2d3e6, #4a7ab5);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
         infobar.info button:focus:hover:focus, infobar.info button:focus:hover:hover, infobar.info button.flat:focus:hover:focus, infobar.info button.flat:focus:hover:hover {
           border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
         infobar.info button:focus:hover:active, infobar.info button:focus:hover:active:hover, infobar.info button:focus:hover:active:focus, infobar.info button:focus:hover:active:hover:focus, infobar.info button:focus:hover:checked, infobar.info button:focus:hover:checked:hover, infobar.info button:focus:hover:checked:focus, infobar.info button:focus:hover:checked:hover:focus, infobar.info button.flat:focus:hover:active, infobar.info button.flat:focus:hover:active:hover, infobar.info button.flat:focus:hover:active:focus, infobar.info button.flat:focus:hover:active:hover:focus, infobar.info button.flat:focus:hover:checked, infobar.info button.flat:focus:hover:checked:hover, infobar.info button.flat:focus:hover:checked:focus, infobar.info button.flat:focus:hover:checked:hover:focus {
@@ -3336,14 +3336,14 @@ infobar {
     infobar.info button:focus, infobar.info button:hover, infobar.info button.flat:focus, infobar.info button.flat:hover {
       color: #ffffff; }
     infobar.info button:disabled:disabled, infobar.info button.flat:disabled:disabled {
-      background-color: alpha(mix(#388c40,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#388c40,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#388c40,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#7096c5,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#7096c5,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#7096c5,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#388c40,#ffffff,0.6);
+      color: mix(#7096c5,#ffffff,0.6);
       box-shadow: none; }
       infobar.info button:disabled:disabled :disabled, infobar.info button.flat:disabled:disabled :disabled {
-        color: mix(#388c40,#ffffff,0.6); }
+        color: mix(#7096c5,#ffffff,0.6); }
     infobar.info button:active:disabled, infobar.info button:checked:disabled, infobar.info button.flat:active:disabled, infobar.info button.flat:checked:disabled {
       background-color: rgba(56, 140, 64, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -3353,22 +3353,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.info button.separator, infobar.info button .separator {
       border: 1px solid currentColor;
-      color: rgba(56, 140, 64, 0.9); }
+      color: rgba(112, 150, 197, 0.9); }
       infobar.info button.separator:disabled, infobar.info button .separator:disabled {
-        color: rgba(56, 140, 64, 0.85); }
+        color: rgba(112, 150, 197, 0.85); }
   infobar.warning, infobar.warning:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #eeee47;
+    background-image: linear-gradient(to bottom, #f5f58e, #d4d414);
+    border: 1px solid #e2e215;
     caret-color: currentColor; }
     infobar.warning label, infobar.warning, infobar.warning:backdrop label, infobar.warning:backdrop {
       color: #ffffff; }
   infobar.warning button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #eeee47;
+    background-image: linear-gradient(to bottom, #f5f58e, #d4d414);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     infobar.warning button:focus, infobar.warning button:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
     infobar.warning button:active, infobar.warning button:active:hover, infobar.warning button:active:focus, infobar.warning button:active:hover:focus, infobar.warning button:checked, infobar.warning button:checked:hover, infobar.warning button:checked:focus, infobar.warning button:checked:hover:focus {
@@ -3420,7 +3420,7 @@ infobar {
     infobar.warning button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(238, 238, 71, 0);
       background-image: none;
       box-shadow: none; }
       infobar.warning button.flat:focus, infobar.warning button.flat:hover {
@@ -3432,11 +3432,11 @@ infobar {
       infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.warning button:hover, infobar.warning button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #efef55;
+      background-image: linear-gradient(to bottom, #f6f69f, #dfdf15);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
       infobar.warning button:hover:focus, infobar.warning button:hover:hover, infobar.warning button.flat:hover:focus, infobar.warning button.flat:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       infobar.warning button:hover:active, infobar.warning button:hover:active:hover, infobar.warning button:hover:active:focus, infobar.warning button:hover:active:hover:focus, infobar.warning button:hover:checked, infobar.warning button:hover:checked:hover, infobar.warning button:hover:checked:focus, infobar.warning button:hover:checked:hover:focus, infobar.warning button.flat:hover:active, infobar.warning button.flat:hover:active:hover, infobar.warning button.flat:hover:active:focus, infobar.warning button.flat:hover:active:hover:focus, infobar.warning button.flat:hover:checked, infobar.warning button.flat:hover:checked:hover, infobar.warning button.flat:hover:checked:focus, infobar.warning button.flat:hover:checked:hover:focus {
@@ -3446,20 +3446,20 @@ infobar {
       infobar.warning button:hover:active:disabled, infobar.warning button:hover:checked:disabled, infobar.warning button.flat:hover:active:disabled, infobar.warning button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.warning button:focus, infobar.warning button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #efef55;
+      background-image: linear-gradient(to bottom, #f6f69f, #dfdf15);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 140, 64, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       infobar.warning button:focus:hover, infobar.warning button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #f1f163;
+        background-image: linear-gradient(to bottom, #f8f8b1, #e9e916);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
         infobar.warning button:focus:hover:focus, infobar.warning button:focus:hover:hover, infobar.warning button.flat:focus:hover:focus, infobar.warning button.flat:focus:hover:hover {
           border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
         infobar.warning button:focus:hover:active, infobar.warning button:focus:hover:active:hover, infobar.warning button:focus:hover:active:focus, infobar.warning button:focus:hover:active:hover:focus, infobar.warning button:focus:hover:checked, infobar.warning button:focus:hover:checked:hover, infobar.warning button:focus:hover:checked:focus, infobar.warning button:focus:hover:checked:hover:focus, infobar.warning button.flat:focus:hover:active, infobar.warning button.flat:focus:hover:active:hover, infobar.warning button.flat:focus:hover:active:focus, infobar.warning button.flat:focus:hover:active:hover:focus, infobar.warning button.flat:focus:hover:checked, infobar.warning button.flat:focus:hover:checked:hover, infobar.warning button.flat:focus:hover:checked:focus, infobar.warning button.flat:focus:hover:checked:hover:focus {
@@ -3491,14 +3491,14 @@ infobar {
     infobar.warning button:focus, infobar.warning button:hover, infobar.warning button.flat:focus, infobar.warning button.flat:hover {
       color: #ffffff; }
     infobar.warning button:disabled:disabled, infobar.warning button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#eeee47,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#eeee47,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#eeee47,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#ffffff,0.6);
+      color: mix(#eeee47,#ffffff,0.6);
       box-shadow: none; }
       infobar.warning button:disabled:disabled :disabled, infobar.warning button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#ffffff,0.6); }
+        color: mix(#eeee47,#ffffff,0.6); }
     infobar.warning button:active:disabled, infobar.warning button:checked:disabled, infobar.warning button.flat:active:disabled, infobar.warning button.flat:checked:disabled {
       background-color: rgba(56, 140, 64, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -3508,22 +3508,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.warning button.separator, infobar.warning button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(238, 238, 71, 0.9); }
       infobar.warning button.separator:disabled, infobar.warning button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(238, 238, 71, 0.85); }
   infobar.question, infobar.question:backdrop {
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
-    border: 1px solid #2d7033;
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
+    border: 1px solid #4776b0;
     caret-color: currentColor; }
     infobar.question label, infobar.question, infobar.question:backdrop label, infobar.question:backdrop {
       color: #ffffff; }
   infobar.question button {
-    background-color: #388c40;
-    background-image: linear-gradient(to bottom, #46af50, #2a6930);
+    background-color: #7096c5;
+    background-image: linear-gradient(to bottom, #a7bedb, #436fa5);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     infobar.question button:focus, infobar.question button:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
     infobar.question button:active, infobar.question button:active:hover, infobar.question button:active:focus, infobar.question button:active:hover:focus, infobar.question button:checked, infobar.question button:checked:hover, infobar.question button:checked:focus, infobar.question button:checked:hover:focus {
@@ -3575,7 +3575,7 @@ infobar {
     infobar.question button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(56, 140, 64, 0);
+      background-color: rgba(112, 150, 197, 0);
       background-image: none;
       box-shadow: none; }
       infobar.question button.flat:focus, infobar.question button.flat:hover {
@@ -3587,11 +3587,11 @@ infobar {
       infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.question button:hover, infobar.question button.flat:hover {
-      background-color: #3b9343;
-      background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+      background-color: #7b9ec9;
+      background-image: linear-gradient(to bottom, #b5c8e1, #4674ad);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
       infobar.question button:hover:focus, infobar.question button:hover:hover, infobar.question button.flat:hover:focus, infobar.question button.flat:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       infobar.question button:hover:active, infobar.question button:hover:active:hover, infobar.question button:hover:active:focus, infobar.question button:hover:active:hover:focus, infobar.question button:hover:checked, infobar.question button:hover:checked:hover, infobar.question button:hover:checked:focus, infobar.question button:hover:checked:hover:focus, infobar.question button.flat:hover:active, infobar.question button.flat:hover:active:hover, infobar.question button.flat:hover:active:focus, infobar.question button.flat:hover:active:hover:focus, infobar.question button.flat:hover:checked, infobar.question button.flat:hover:checked:hover, infobar.question button.flat:hover:checked:focus, infobar.question button.flat:hover:checked:hover:focus {
@@ -3601,20 +3601,20 @@ infobar {
       infobar.question button:hover:active:disabled, infobar.question button:hover:checked:disabled, infobar.question button.flat:hover:active:disabled, infobar.question button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.question button:focus, infobar.question button.flat:focus {
-      background-color: #3b9343;
-      background-image: linear-gradient(to bottom, #4ab755, #2c6e32);
+      background-color: #7b9ec9;
+      background-image: linear-gradient(to bottom, #b5c8e1, #4674ad);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 140, 64, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       infobar.question button:focus:hover, infobar.question button.flat:focus:hover {
-        background-color: #3e9a46;
-        background-image: linear-gradient(to bottom, #53ba5d, #2e7435);
+        background-color: #86a6ce;
+        background-image: linear-gradient(to bottom, #c2d3e6, #4a7ab5);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
         infobar.question button:focus:hover:focus, infobar.question button:focus:hover:hover, infobar.question button.flat:focus:hover:focus, infobar.question button.flat:focus:hover:hover {
           border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
         infobar.question button:focus:hover:active, infobar.question button:focus:hover:active:hover, infobar.question button:focus:hover:active:focus, infobar.question button:focus:hover:active:hover:focus, infobar.question button:focus:hover:checked, infobar.question button:focus:hover:checked:hover, infobar.question button:focus:hover:checked:focus, infobar.question button:focus:hover:checked:hover:focus, infobar.question button.flat:focus:hover:active, infobar.question button.flat:focus:hover:active:hover, infobar.question button.flat:focus:hover:active:focus, infobar.question button.flat:focus:hover:active:hover:focus, infobar.question button.flat:focus:hover:checked, infobar.question button.flat:focus:hover:checked:hover, infobar.question button.flat:focus:hover:checked:focus, infobar.question button.flat:focus:hover:checked:hover:focus {
@@ -3646,14 +3646,14 @@ infobar {
     infobar.question button:focus, infobar.question button:hover, infobar.question button.flat:focus, infobar.question button.flat:hover {
       color: #ffffff; }
     infobar.question button:disabled:disabled, infobar.question button.flat:disabled:disabled {
-      background-color: alpha(mix(#388c40,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#388c40,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#388c40,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#7096c5,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#7096c5,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#7096c5,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#388c40,#ffffff,0.6);
+      color: mix(#7096c5,#ffffff,0.6);
       box-shadow: none; }
       infobar.question button:disabled:disabled :disabled, infobar.question button.flat:disabled:disabled :disabled {
-        color: mix(#388c40,#ffffff,0.6); }
+        color: mix(#7096c5,#ffffff,0.6); }
     infobar.question button:active:disabled, infobar.question button:checked:disabled, infobar.question button.flat:active:disabled, infobar.question button.flat:checked:disabled {
       background-color: rgba(56, 140, 64, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -3663,22 +3663,22 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.question button.separator, infobar.question button .separator {
       border: 1px solid currentColor;
-      color: rgba(56, 140, 64, 0.9); }
+      color: rgba(112, 150, 197, 0.9); }
       infobar.question button.separator:disabled, infobar.question button .separator:disabled {
-        color: rgba(56, 140, 64, 0.85); }
+        color: rgba(112, 150, 197, 0.85); }
   infobar.error, infobar.error:backdrop {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
-    border: 1px solid #cc0000;
+    background-color: #ce6f6f;
+    background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
+    border: 1px solid #bd4040;
     caret-color: currentColor; }
     infobar.error label, infobar.error, infobar.error:backdrop label, infobar.error:backdrop {
       color: #ffffff; }
   infobar.error button {
-    background-color: #ff0000;
-    background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+    background-color: #ce6f6f;
+    background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
     border-color: rgba(204, 204, 204, 0.22);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
     infobar.error button:focus, infobar.error button:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
     infobar.error button:active, infobar.error button:active:hover, infobar.error button:active:focus, infobar.error button:active:hover:focus, infobar.error button:checked, infobar.error button:checked:hover, infobar.error button:checked:focus, infobar.error button:checked:hover:focus {
@@ -3730,7 +3730,7 @@ infobar {
     infobar.error button.flat {
       border-color: rgba(204, 204, 204, 0.2);
       color: #ffffff;
-      background-color: rgba(255, 0, 0, 0);
+      background-color: rgba(206, 111, 111, 0);
       background-image: none;
       box-shadow: none; }
       infobar.error button.flat:focus, infobar.error button.flat:hover {
@@ -3742,11 +3742,11 @@ infobar {
       infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
         border-color: rgba(204, 204, 204, 0.2); }
     infobar.error button:hover, infobar.error button.flat:hover {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d27b7b;
+      background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
       border-color: rgba(204, 204, 204, 0.3);
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
       infobar.error button:hover:focus, infobar.error button:hover:hover, infobar.error button.flat:hover:focus, infobar.error button.flat:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       infobar.error button:hover:active, infobar.error button:hover:active:hover, infobar.error button:hover:active:focus, infobar.error button:hover:active:hover:focus, infobar.error button:hover:checked, infobar.error button:hover:checked:hover, infobar.error button:hover:checked:focus, infobar.error button:hover:checked:hover:focus, infobar.error button.flat:hover:active, infobar.error button.flat:hover:active:hover, infobar.error button.flat:hover:active:focus, infobar.error button.flat:hover:active:hover:focus, infobar.error button.flat:hover:checked, infobar.error button.flat:hover:checked:hover, infobar.error button.flat:hover:checked:focus, infobar.error button.flat:hover:checked:hover:focus {
@@ -3756,20 +3756,20 @@ infobar {
       infobar.error button:hover:active:disabled, infobar.error button:hover:checked:disabled, infobar.error button.flat:hover:active:disabled, infobar.error button.flat:hover:checked:disabled {
         border-color: rgba(204, 204, 204, 0.3); }
     infobar.error button:focus, infobar.error button.flat:focus {
-      background-color: #ff0d0d;
-      background-image: linear-gradient(to bottom, #ff5050, #c90000);
+      background-color: #d27b7b;
+      background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
       border-color: rgba(255, 255, 255, 0.22);
       outline-color: rgba(56, 140, 64, 0.5);
       outline-width: 1px;
       outline-style: solid;
       outline-offset: -3px;
       color: #ffffff;
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
       infobar.error button:focus:hover, infobar.error button.flat:focus:hover {
-        background-color: #ff1a1a;
-        background-image: linear-gradient(to bottom, #ff6060, #d20000);
+        background-color: #d68787;
+        background-image: linear-gradient(to bottom, #ecc8c8, #c04646);
         border-color: rgba(204, 204, 204, 0.3);
-        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+        box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
         infobar.error button:focus:hover:focus, infobar.error button:focus:hover:hover, infobar.error button.flat:focus:hover:focus, infobar.error button.flat:focus:hover:hover {
           border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
         infobar.error button:focus:hover:active, infobar.error button:focus:hover:active:hover, infobar.error button:focus:hover:active:focus, infobar.error button:focus:hover:active:hover:focus, infobar.error button:focus:hover:checked, infobar.error button:focus:hover:checked:hover, infobar.error button:focus:hover:checked:focus, infobar.error button:focus:hover:checked:hover:focus, infobar.error button.flat:focus:hover:active, infobar.error button.flat:focus:hover:active:hover, infobar.error button.flat:focus:hover:active:focus, infobar.error button.flat:focus:hover:active:hover:focus, infobar.error button.flat:focus:hover:checked, infobar.error button.flat:focus:hover:checked:hover, infobar.error button.flat:focus:hover:checked:focus, infobar.error button.flat:focus:hover:checked:hover:focus {
@@ -3801,14 +3801,14 @@ infobar {
     infobar.error button:focus, infobar.error button:hover, infobar.error button.flat:focus, infobar.error button.flat:hover {
       color: #ffffff; }
     infobar.error button:disabled:disabled, infobar.error button.flat:disabled:disabled {
-      background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+      background-color: alpha(mix(#ce6f6f,#ffffff,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),0.75));
       /*border: 1px solid alpha($bg, .2);*/
       opacity: .6;
-      color: mix(#ff0000,#ffffff,0.6);
+      color: mix(#ce6f6f,#ffffff,0.6);
       box-shadow: none; }
       infobar.error button:disabled:disabled :disabled, infobar.error button.flat:disabled:disabled :disabled {
-        color: mix(#ff0000,#ffffff,0.6); }
+        color: mix(#ce6f6f,#ffffff,0.6); }
     infobar.error button:active:disabled, infobar.error button:checked:disabled, infobar.error button.flat:active:disabled, infobar.error button.flat:checked:disabled {
       background-color: rgba(56, 140, 64, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -3818,9 +3818,9 @@ infobar {
         color: rgba(255, 255, 255, 0.85); }
     infobar.error button.separator, infobar.error button .separator {
       border: 1px solid currentColor;
-      color: rgba(255, 0, 0, 0.9); }
+      color: rgba(206, 111, 111, 0.9); }
       infobar.error button.separator:disabled, infobar.error button .separator:disabled {
-        color: rgba(255, 0, 0, 0.85); }
+        color: rgba(206, 111, 111, 0.85); }
 
 /*********
  ! Entry *
@@ -3919,57 +3919,57 @@ entry, menuitem entry, popover.background entry, .osd entry,
   entry.warning, popover.background entry.warning,
   #XfceNotifyWindow entry.warning, #login_window entry.warning {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #e2e215;
+    background-color: mix(#99bf9c,#eeee47,0.6); }
     entry.warning image,
     #XfceNotifyWindow entry.warning image, #login_window entry.warning image {
       color: #ffffff; }
     entry.warning:focus,
     #XfceNotifyWindow entry.warning:focus, #login_window entry.warning:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#eeee47,0.3);
+      background-color: #eeee47;
       box-shadow: none; }
     entry.warning selection,
     #XfceNotifyWindow entry.warning selection, #login_window entry.warning selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #eeee47; }
   entry.error, popover.background entry.error,
   #XfceNotifyWindow entry.error, #login_window entry.error {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #bd4040;
+    background-color: mix(#99bf9c,#ce6f6f,0.6); }
     entry.error image,
     #XfceNotifyWindow entry.error image, #login_window entry.error image {
       color: #ffffff; }
     entry.error:focus,
     #XfceNotifyWindow entry.error:focus, #login_window entry.error:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#ce6f6f,0.3);
+      background-color: #ce6f6f;
       box-shadow: none; }
     entry.error selection,
     #XfceNotifyWindow entry.error selection, #login_window entry.error selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce6f6f; }
   entry.search-missing, popover.background entry.search-missing,
   #XfceNotifyWindow entry.search-missing, #login_window entry.search-missing {
     color: #ffffff;
-    border-color: #cc0000;
-    background-color: mix(#99bf9c,#ff0000,0.6); }
+    border-color: #bd4040;
+    background-color: mix(#99bf9c,#ce6f6f,0.6); }
     entry.search-missing image,
     #XfceNotifyWindow entry.search-missing image, #login_window entry.search-missing image {
       color: #ffffff; }
     entry.search-missing:focus,
     #XfceNotifyWindow entry.search-missing:focus, #login_window entry.search-missing:focus {
       color: #ffffff;
-      border-color: mix(#388c40,#ff0000,0.3);
-      background-color: #ff0000;
+      border-color: mix(#388c40,#ce6f6f,0.3);
+      background-color: #ce6f6f;
       box-shadow: none; }
     entry.search-missing selection,
     #XfceNotifyWindow entry.search-missing selection, #login_window entry.search-missing selection {
       background-color: #ffffff;
-      color: #ff0000; }
+      color: #ce6f6f; }
 
 /*********
  ! Menubar
@@ -5004,7 +5004,7 @@ notebook {
         padding: 0;
         color: mix(#b7ccb9,#0c190d,0.35); }
         notebook > header > tabs > tab button.flat:hover {
-          color: #ff4d4d; }
+          color: #e1a8a8; }
         notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #388c40; }
     notebook > header.top > tabs > tab:hover:not(:checked) {
@@ -7030,10 +7030,10 @@ levelbar block {
   border-color: transparent;
   border-radius: 10px; }
   levelbar block.low {
-    background-color: #ff0000;
+    background-color: #eeee47;
     border-color: transparent; }
   levelbar block.high, levelbar block:not(.empty) {
-    background-color: #388c40;
+    background-color: #90ff49;
     border-color: transparent; }
   levelbar block.full {
     background-color: #2d7033;
@@ -8227,7 +8227,7 @@ GeditViewFrame .gedit-search-slider {
   border-color: #6fa473;
   background-color: #99bf9c; }
   GeditViewFrame .gedit-search-slider .not-found {
-    background-color: #ff0000;
+    background-color: #ce6f6f;
     background-image: none;
     color: #ffffff; }
 
@@ -8301,10 +8301,10 @@ paned.titlebar {
 
 .conflict-row.activatable, .conflict-row.activatable:active {
   color: #ffffff;
-  background-color: #ff0000; }
+  background-color: #ce6f6f; }
 
 .conflict-row.activatable:hover {
-  background-color: #ff1a1a; }
+  background-color: #d68787; }
 
 .conflict-row.activatable:selected {
   color: #ffffff;
@@ -8947,11 +8947,11 @@ SheetStyleDialog.unity-force-quit {
 
 /* shutdown button */
 #shutdown_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #ce6f6f;
+  background-image: linear-gradient(to bottom, #e2aaaa, #b13c3c);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   #shutdown_button button:focus, #shutdown_button button:hover {
     border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
   #shutdown_button button:active, #shutdown_button button:active:hover, #shutdown_button button:active:focus, #shutdown_button button:active:hover:focus, #shutdown_button button:checked, #shutdown_button button:checked:hover, #shutdown_button button:checked:focus, #shutdown_button button:checked:hover:focus {
@@ -9003,7 +9003,7 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(206, 111, 111, 0);
     background-image: none;
     box-shadow: none; }
     #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
@@ -9015,11 +9015,11 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   #shutdown_button button:hover, #shutdown_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d27b7b;
+    background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
     #shutdown_button button:hover:focus, #shutdown_button button:hover:hover, #shutdown_button button.flat:hover:focus, #shutdown_button button.flat:hover:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
     #shutdown_button button:hover:active, #shutdown_button button:hover:active:hover, #shutdown_button button:hover:active:focus, #shutdown_button button:hover:active:hover:focus, #shutdown_button button:hover:checked, #shutdown_button button:hover:checked:hover, #shutdown_button button:hover:checked:focus, #shutdown_button button:hover:checked:hover:focus, #shutdown_button button.flat:hover:active, #shutdown_button button.flat:hover:active:hover, #shutdown_button button.flat:hover:active:focus, #shutdown_button button.flat:hover:active:hover:focus, #shutdown_button button.flat:hover:checked, #shutdown_button button.flat:hover:checked:hover, #shutdown_button button.flat:hover:checked:focus, #shutdown_button button.flat:hover:checked:hover:focus {
@@ -9029,20 +9029,20 @@ SheetStyleDialog.unity-force-quit {
     #shutdown_button button:hover:active:disabled, #shutdown_button button:hover:checked:disabled, #shutdown_button button.flat:hover:active:disabled, #shutdown_button button.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   #shutdown_button button:focus, #shutdown_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #d27b7b;
+    background-image: linear-gradient(to bottom, #e7b9b9, #ba3f3f);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 140, 64, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     #shutdown_button button:focus:hover, #shutdown_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #d68787;
+      background-image: linear-gradient(to bottom, #ecc8c8, #c04646);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
       #shutdown_button button:focus:hover:focus, #shutdown_button button:focus:hover:hover, #shutdown_button button.flat:focus:hover:focus, #shutdown_button button.flat:focus:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       #shutdown_button button:focus:hover:active, #shutdown_button button:focus:hover:active:hover, #shutdown_button button:focus:hover:active:focus, #shutdown_button button:focus:hover:active:hover:focus, #shutdown_button button:focus:hover:checked, #shutdown_button button:focus:hover:checked:hover, #shutdown_button button:focus:hover:checked:focus, #shutdown_button button:focus:hover:checked:hover:focus, #shutdown_button button.flat:focus:hover:active, #shutdown_button button.flat:focus:hover:active:hover, #shutdown_button button.flat:focus:hover:active:focus, #shutdown_button button.flat:focus:hover:active:hover:focus, #shutdown_button button.flat:focus:hover:checked, #shutdown_button button.flat:focus:hover:checked:hover, #shutdown_button button.flat:focus:hover:checked:focus, #shutdown_button button.flat:focus:hover:checked:hover:focus {
@@ -9074,14 +9074,14 @@ SheetStyleDialog.unity-force-quit {
   #shutdown_button button:focus, #shutdown_button button:hover, #shutdown_button button.flat:focus, #shutdown_button button.flat:hover {
     color: #ffffff; }
   #shutdown_button button:disabled:disabled, #shutdown_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#ce6f6f,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ce6f6f,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#ce6f6f,#ffffff,0.6);
     box-shadow: none; }
     #shutdown_button button:disabled:disabled :disabled, #shutdown_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#ce6f6f,#ffffff,0.6); }
   #shutdown_button button:active:disabled, #shutdown_button button:checked:disabled, #shutdown_button button.flat:active:disabled, #shutdown_button button.flat:checked:disabled {
     background-color: rgba(56, 140, 64, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -9091,17 +9091,17 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(255, 255, 255, 0.85); }
   #shutdown_button button.separator, #shutdown_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(206, 111, 111, 0.9); }
     #shutdown_button button.separator:disabled, #shutdown_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(206, 111, 111, 0.85); }
 
 /* restart button */
 #restart_button button {
-  background-color: #ff0000;
-  background-image: linear-gradient(to bottom, #ff4040, #bf0000);
+  background-color: #eeee47;
+  background-image: linear-gradient(to bottom, #f5f58e, #d4d414);
   border-color: rgba(204, 204, 204, 0.22);
   color: #ffffff;
-  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
+  box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.12); }
   #restart_button button:focus, #restart_button button:hover {
     border-color: mix(#388c40,rgba(255, 255, 255, 0.22),0.3); }
   #restart_button button:active, #restart_button button:active:hover, #restart_button button:active:focus, #restart_button button:active:hover:focus, #restart_button button:checked, #restart_button button:checked:hover, #restart_button button:checked:focus, #restart_button button:checked:hover:focus {
@@ -9153,7 +9153,7 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button.flat {
     border-color: rgba(204, 204, 204, 0.2);
     color: #ffffff;
-    background-color: rgba(255, 0, 0, 0);
+    background-color: rgba(238, 238, 71, 0);
     background-image: none;
     box-shadow: none; }
     #restart_button button.flat:focus, #restart_button button.flat:hover {
@@ -9165,11 +9165,11 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
       border-color: rgba(204, 204, 204, 0.2); }
   #restart_button button:hover, #restart_button button.flat:hover {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #efef55;
+    background-image: linear-gradient(to bottom, #f6f69f, #dfdf15);
     border-color: rgba(204, 204, 204, 0.3);
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.22); }
     #restart_button button:hover:focus, #restart_button button:hover:hover, #restart_button button.flat:hover:focus, #restart_button button.flat:hover:hover {
       border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
     #restart_button button:hover:active, #restart_button button:hover:active:hover, #restart_button button:hover:active:focus, #restart_button button:hover:active:hover:focus, #restart_button button:hover:checked, #restart_button button:hover:checked:hover, #restart_button button:hover:checked:focus, #restart_button button:hover:checked:hover:focus, #restart_button button.flat:hover:active, #restart_button button.flat:hover:active:hover, #restart_button button.flat:hover:active:focus, #restart_button button.flat:hover:active:hover:focus, #restart_button button.flat:hover:checked, #restart_button button.flat:hover:checked:hover, #restart_button button.flat:hover:checked:focus, #restart_button button.flat:hover:checked:hover:focus {
@@ -9179,20 +9179,20 @@ SheetStyleDialog.unity-force-quit {
     #restart_button button:hover:active:disabled, #restart_button button:hover:checked:disabled, #restart_button button.flat:hover:active:disabled, #restart_button button.flat:hover:checked:disabled {
       border-color: rgba(204, 204, 204, 0.3); }
   #restart_button button:focus, #restart_button button.flat:focus {
-    background-color: #ff0d0d;
-    background-image: linear-gradient(to bottom, #ff5050, #c90000);
+    background-color: #efef55;
+    background-image: linear-gradient(to bottom, #f6f69f, #dfdf15);
     border-color: rgba(255, 255, 255, 0.22);
     outline-color: rgba(56, 140, 64, 0.5);
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -3px;
     color: #ffffff;
-    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.42); }
+    box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.32); }
     #restart_button button:focus:hover, #restart_button button.flat:focus:hover {
-      background-color: #ff1a1a;
-      background-image: linear-gradient(to bottom, #ff6060, #d20000);
+      background-color: #f1f163;
+      background-image: linear-gradient(to bottom, #f8f8b1, #e9e916);
       border-color: rgba(204, 204, 204, 0.3);
-      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.48); }
+      box-shadow: 0 1px 2px -1px rgba(2, 5, 3, 0.38); }
       #restart_button button:focus:hover:focus, #restart_button button:focus:hover:hover, #restart_button button.flat:focus:hover:focus, #restart_button button.flat:focus:hover:hover {
         border-color: mix(#388c40,rgba(255, 255, 255, 0.3),0.3); }
       #restart_button button:focus:hover:active, #restart_button button:focus:hover:active:hover, #restart_button button:focus:hover:active:focus, #restart_button button:focus:hover:active:hover:focus, #restart_button button:focus:hover:checked, #restart_button button:focus:hover:checked:hover, #restart_button button:focus:hover:checked:focus, #restart_button button:focus:hover:checked:hover:focus, #restart_button button.flat:focus:hover:active, #restart_button button.flat:focus:hover:active:hover, #restart_button button.flat:focus:hover:active:focus, #restart_button button.flat:focus:hover:active:hover:focus, #restart_button button.flat:focus:hover:checked, #restart_button button.flat:focus:hover:checked:hover, #restart_button button.flat:focus:hover:checked:focus, #restart_button button.flat:focus:hover:checked:hover:focus {
@@ -9224,14 +9224,14 @@ SheetStyleDialog.unity-force-quit {
   #restart_button button:focus, #restart_button button:hover, #restart_button button.flat:focus, #restart_button button.flat:hover {
     color: #ffffff; }
   #restart_button button:disabled:disabled, #restart_button button.flat:disabled:disabled {
-    background-color: alpha(mix(#ff0000,#ffffff,0.2),0.4);
-    background-image: linear-gradient(to bottom, shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#ff0000,#ffffff,0.2),0.4),0.75));
+    background-color: alpha(mix(#eeee47,#ffffff,0.2),0.4);
+    background-image: linear-gradient(to bottom, shade(alpha(mix(#eeee47,#ffffff,0.2),0.4),1.25), shade(alpha(mix(#eeee47,#ffffff,0.2),0.4),0.75));
     /*border: 1px solid alpha($bg, .2);*/
     opacity: .6;
-    color: mix(#ff0000,#ffffff,0.6);
+    color: mix(#eeee47,#ffffff,0.6);
     box-shadow: none; }
     #restart_button button:disabled:disabled :disabled, #restart_button button.flat:disabled:disabled :disabled {
-      color: mix(#ff0000,#ffffff,0.6); }
+      color: mix(#eeee47,#ffffff,0.6); }
   #restart_button button:active:disabled, #restart_button button:checked:disabled, #restart_button button.flat:active:disabled, #restart_button button.flat:checked:disabled {
     background-color: rgba(56, 140, 64, 0.6);
     background-image: linear-gradient(to bottom, rgba(70, 175, 80, 0.6), rgba(42, 105, 48, 0.6));
@@ -9241,9 +9241,9 @@ SheetStyleDialog.unity-force-quit {
       color: rgba(255, 255, 255, 0.85); }
   #restart_button button.separator, #restart_button button .separator {
     border: 1px solid currentColor;
-    color: rgba(255, 0, 0, 0.9); }
+    color: rgba(238, 238, 71, 0.9); }
     #restart_button button.separator:disabled, #restart_button button .separator:disabled {
-      color: rgba(255, 0, 0, 0.85); }
+      color: rgba(238, 238, 71, 0.85); }
 
 /* password warning */
 #greeter_infobar {

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/info.json
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Zanah", 
-	"description": "Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/qt5ct/Cinnamox-Zanah.conf
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/qt5ct/Cinnamox-Zanah.conf
@@ -1,0 +1,10 @@
+#               FG              BTN_BG bright less brdark        less da     txt fg               br text              btn fg           txt bg     bg     shadow   sel bg     sel fg     link       visited           alt bg default          tooltip bg  tooltip_fg
+[ColorScheme]
+  active_colors=#0c190d,          #b7ccb9, #b7ccb9, #b7ccb9, #72bf78, #72bf78, #0c190d,           #0c190d,           #0c190d,           #99bf9c, #b7ccb9, #72bf78, #388c40, #ffffff, #388c40, #0c190d,            #b7ccb9, #0c190d,           72bf78,  #0c190d
+disabled_colors=#364538, #b7ccb9, #b7ccb9, #b7ccb9, #72bf78, #72bf78, #2f4230,  #2f4230,  #364538,  #99bf9c, #b7ccb9, #72bf78, #388c40, #ffffff, #388c40, #364538,   #b7ccb9, #364538,  #72bf78, #254227
+inactive_colors=#0c190d,          #b7ccb9, #b7ccb9, #b7ccb9, #72bf78, #72bf78, #0c190d,           #0c190d,           #0c190d,           #99bf9c, #b7ccb9, #72bf78, #388c40, #ffffff, #388c40, #0c190d,            #b7ccb9, #0c190d,           #72bf78, #0c190d
+
+#               FG              BTN_BG     bright   less br  dark     less da  txt fg               br text  btn fg     txt bg     bg     shadow   sel bg     sel fg     link       visite alt bg default  tooltip bg  tooltip_fg
+#  active_colors=#0c190d,          #99bf9c, #b7ccb9, #cbc7c4, #9f9d9a, #b8b5b2, #0c190d,           #ff0000, #0c190d, #99bf9c, #b7ccb9, #767472, #388c40, #ffffff, #388c40, #0c190d,            #b7ccb9, #0c190d,           72bf78, #0c190d
+#disabled_colors=#364538, #99bf9c, #b7ccb9, #cbc7c4, #9f9d9a, #b8b5b2, #2f4230,  #ffec17, #0c190d, #99bf9c, #b7ccb9, #767472, #388c40, #ffffff, #388c40, #364538,   #b7ccb9, #364538,  #72bf78, #254227
+#inactive_colors=#0c190d,          #99bf9c, #b7ccb9, #cbc7c4, #9f9d9a, #b8b5b2, #0c190d,           #ff9040, #0c190d, #99bf9c, #b7ccb9, #767472, #388c40, #ffffff, #388c40, #0c190d,            #b7ccb9, #0c190d,           #72bf78, #0c190d

--- a/Cinnamox-Zanah/files/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh
+++ b/Cinnamox-Zanah/files/Cinnamox-Zanah/qt5ct/cinnamox_enable_qt5ct.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#Description: Helper file to move Cinnamox-Zanah.conf to /$HOME/.config/qt5ct/colors folder
+THEMENAME=Cinnamox-Zanah;
+QTDIR="$HOME/.config/qt5ct/colors";
+if [ ! -f "$PWD/$THEMENAME.conf" ]; then
+	echo "Something is wrong. Cannot find $PWD/$THEMENAME.conf"
+    echo "";
+    read -p "Press enter to exit the script.";
+    cd;
+    exit 1;
+fi
+if [ ! -d "$QTDIR" ]; then
+    mkdir "$QTDIR";
+fi
+echo "Copying $PWD/$THEMENAME.conf to $QTDIR/$THEMENAME.conf"
+cp "$PWD/$THEMENAME.conf" "$QTDIR/$THEMENAME.conf";
+echo "";
+read -p "Press enter to exit the script.";
+cd;
+exit;

--- a/Cinnamox-Zanah/info.json
+++ b/Cinnamox-Zanah/info.json
@@ -1,5 +1,5 @@
 {
 	"author": "smurphos", 
 	"name": "Cinnamox-Zanah", 
-	"description": "Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.22 themes are included along with a script to adjust the transparency of the Cinnamon theme."
+	"description": "Cinnamox-Zanah features a pale blue colour scheme and dark text. Cinnamon, Metacity, GTK2, GTK3.18 and GTK3.20+ themes are included along with a script to adjust the transparency of the Cinnamon theme."
 }


### PR DESCRIPTION
* Cinnamon - Themes now have be-spoke error and warning colors that match error and warning colors in GTK

* GTK2 - Helper script added to easily toggle between HIDPI version and none HIDPI versions of theme. See readme for instructions

* GTK2, 3.18 and 3.20 - Reverted to Oomox-gtk-theme default code for link, info, warning, error and question colors. Updated individual theme templates for be-spoke theme colors.

* qt5ct - qt5ct configuration files included with helper script to install in correct location. See readme for instructions.

