### PR TITLE
Spider-Void: adapt for Cinnamon 3.8

### DIFF
--- a/Spider-Void/files/Spider-Void/cinnamon/cinnamon.css
+++ b/Spider-Void/files/Spider-Void/cinnamon/cinnamon.css
@@ -1735,6 +1735,13 @@ color: #444;
     background-gradient-start:  rgba(84,255,02,1);
     background-gradient-end:  rgba(184,255,102,1);
 }
+.window-list-preview {
+    color: white;
+    font-size: 9pt;
+    border-image:url("background.svg");
+    box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.75);
+    padding: 14px 25px 25px 25px;
+}
 
 /* ===================================================================
  * Sound Applet (status/volume.js)


### PR DESCRIPTION
Minimal adaptation, reuse the menu layout for the window list preview.  Mis-spelt commit message, should be spider-void of course.