### PR TITLE
Thunderbolt: Update cinnamon.css

### DIFF
--- a/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
+++ b/Thunderbolt/files/Thunderbolt/cinnamon/cinnamon.css
@@ -341,7 +341,15 @@ StScrollBar StButton#vhandle:hover
 
 .popup-menu-item {
     padding: .4em 1.75em;
-	spacing: 1em;
+    spacing: 1em;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    box-shadow: inset  0px 1px 1px transparent;
+    color: #fff;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 22px;
+    padding-right: 22px;
 }
 
 .popup-menu-item:active {
@@ -352,10 +360,7 @@ StScrollBar StButton#vhandle:hover
     border-radius: 3px;
     box-shadow: inset  0px 1px 1px rgba(255,255,255,0.1);
     color: #fff;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    padding-left: 22px;
-    padding-right: 22px;
+
 }
 
 .popup-menu-item:insensitive {


### PR DESCRIPTION
This update solves problem: popmenu cause a slight resizing if an active item is selected (#312)