### PR TITLE
Adapta-Nokto and Adapta-Nokto-Eta - use correct GTK thumbnail.png

### DIFF
--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.0/thumbnail.png
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.0/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.20/thumbnail.png
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.20/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.22/thumbnail.png
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.22/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-3.0/thumbnail.png
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-3.0/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-3.20/thumbnail.png
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-3.20/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/thumbnail.png
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/thumbnail.png
@@ -1,1 +1,1 @@
-../assets/thumbnail.png
+../assets/thumbnail-dark.png


### PR DESCRIPTION
Correcting the symbolic links to use the dark GTK thumbnail.png for the Nokto variants.