### PR TITLE
Carta: fix windows-list progress and preview

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1574,10 +1574,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
     background-color: rgb(207, 216, 220);
 }
 
+.window-list-item-box .progress {
+    border-top-width: 4px;
+    border-top-color: rgb(207, 216, 220);
+}
+
 .window-list-item-demands-attention {
     background-color: rgb(211, 47, 47);
 }
 
+.window-list-preview {
+    /* background-color: rgb(66, 89, 100); */
+    background-color: rgb(38, 50, 56);
+    color: rgb(207, 216, 220);
+    spacing: 12px;
+    border-radius: 4px;
+    font-size: 9pt;
+    padding: 12px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+}
+  
 .sound-button {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
Fix styles of windows-list progress and preview tiles ("broken" in new cinnamon version).