### PR TITLE
Cinnamox update 280827

### DIFF
--- a/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/README.md
@@ -6,15 +6,17 @@ Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
@@ -6,15 +6,17 @@ Cinnamox-Aubergine features a deep purple colour scheme and light text. Cinnamon
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(242, 217, 240, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(242, 217, 240, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #f2d9f0; }
+  color: #f2d9f0;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #E95420;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.0/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #77216F;
-    background-image: linear-gradient(to bottom, #95298b, #591953);
+    background-color: #5E2750;
+    background-image: linear-gradient(to bottom, #763164, #471d3c);
     border-color: rgba(219, 149, 213, 0.32);
     color: #f2d9f0;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(219, 149, 213, 0.3);
       color: #f2d9f0;
-      background-color: rgba(119, 33, 111, 0);
+      background-color: rgba(94, 39, 80, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(219, 149, 213, 0.4);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(242, 217, 240, 0.32);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #83247a;
-        background-image: linear-gradient(to bottom, #a42d99, #621b5c);
+        background-color: #672b58;
+        background-image: linear-gradient(to bottom, #81366e, #4e2042);
         border-color: rgba(219, 149, 213, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #f2d9f0; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#77216F,#f2d9f0,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),0.75));
+      background-color: alpha(mix(#5E2750,#f2d9f0,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#77216F,#f2d9f0,0.6);
+      color: mix(#5E2750,#f2d9f0,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#77216F,#f2d9f0,0.6); }
+        color: mix(#5E2750,#f2d9f0,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(119, 33, 111, 0.9); }
+      color: rgba(94, 39, 80, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(119, 33, 111, 0.85); }
+        color: rgba(94, 39, 80, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #77216F;
-    background-image: linear-gradient(to bottom, #95298b, #591953);
+    background-color: #5E2750;
+    background-image: linear-gradient(to bottom, #763164, #471d3c);
     border-color: rgba(219, 149, 213, 0.32);
     color: #f2d9f0;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(219, 149, 213, 0.3);
       color: #f2d9f0;
-      background-color: rgba(119, 33, 111, 0);
+      background-color: rgba(94, 39, 80, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(219, 149, 213, 0.4);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(242, 217, 240, 0.32);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #83247a;
-        background-image: linear-gradient(to bottom, #a42d99, #621b5c);
+        background-color: #672b58;
+        background-image: linear-gradient(to bottom, #81366e, #4e2042);
         border-color: rgba(219, 149, 213, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #f2d9f0; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#77216F,#f2d9f0,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),0.75));
+      background-color: alpha(mix(#5E2750,#f2d9f0,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#77216F,#f2d9f0,0.6);
+      color: mix(#5E2750,#f2d9f0,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#77216F,#f2d9f0,0.6); }
+        color: mix(#5E2750,#f2d9f0,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(119, 33, 111, 0.9); }
+      color: rgba(94, 39, 80, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(119, 33, 111, 0.85); }
+        color: rgba(94, 39, 80, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #77216F;
-    background-image: linear-gradient(to bottom, #95298b, #591953);
+    background-color: #5E2750;
+    background-image: linear-gradient(to bottom, #763164, #471d3c);
     border-color: rgba(219, 149, 213, 0.32);
     color: #f2d9f0;
     box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(219, 149, 213, 0.3);
       color: #f2d9f0;
-      background-color: rgba(119, 33, 111, 0);
+      background-color: rgba(94, 39, 80, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(219, 149, 213, 0.4);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(219, 149, 213, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #7d2375;
-      background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+      background-color: #632954;
+      background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
       border-color: rgba(242, 217, 240, 0.32);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #83247a;
-        background-image: linear-gradient(to bottom, #a42d99, #621b5c);
+        background-color: #672b58;
+        background-image: linear-gradient(to bottom, #81366e, #4e2042);
         border-color: rgba(219, 149, 213, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #f2d9f0; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#77216F,#f2d9f0,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),0.75));
+      background-color: alpha(mix(#5E2750,#f2d9f0,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#77216F,#f2d9f0,0.6);
+      color: mix(#5E2750,#f2d9f0,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#77216F,#f2d9f0,0.6); }
+        color: mix(#5E2750,#f2d9f0,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(233, 84, 32, 0.6);
       background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(119, 33, 111, 0.9); }
+      color: rgba(94, 39, 80, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(119, 33, 111, 0.85); }
+        color: rgba(94, 39, 80, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#77216F,mix(#77216F,mix(#77216F,#f2d9f0,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #77216F;
-      background-image: linear-gradient(to bottom, #95298b, #591953);
+      background-color: #5E2750;
+      background-image: linear-gradient(to bottom, #763164, #471d3c);
       border-color: rgba(219, 149, 213, 0.22);
       color: #f2d9f0;
       box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(219, 149, 213, 0.2);
         color: #f2d9f0;
-        background-color: rgba(119, 33, 111, 0);
+        background-color: rgba(94, 39, 80, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(219, 149, 213, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #7d2375;
-        background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+        background-color: #632954;
+        background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
         border-color: rgba(219, 149, 213, 0.3);
         color: #f2d9f0;
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(219, 149, 213, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #7d2375;
-        background-image: linear-gradient(to bottom, #9c2b92, #5e1a57);
+        background-color: #632954;
+        background-image: linear-gradient(to bottom, #7b3369, #4a1f3f);
         border-color: rgba(242, 217, 240, 0.22);
         outline-color: rgba(233, 84, 32, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #f2d9f0;
         box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #83247a;
-          background-image: linear-gradient(to bottom, #a42d99, #621b5c);
+          background-color: #672b58;
+          background-image: linear-gradient(to bottom, #81366e, #4e2042);
           border-color: rgba(219, 149, 213, 0.3);
           box-shadow: 0 1px 2px -1px rgba(68, 23, 65, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #f2d9f0; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#77216F,#f2d9f0,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#77216F,#f2d9f0,0.2),0.4),0.75));
+        background-color: alpha(mix(#5E2750,#f2d9f0,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),1.25), shade(alpha(mix(#5E2750,#f2d9f0,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#77216F,#f2d9f0,0.6);
+        color: mix(#5E2750,#f2d9f0,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#77216F,#f2d9f0,0.6); }
+          color: mix(#5E2750,#f2d9f0,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(233, 84, 32, 0.6);
         background-image: linear-gradient(to bottom, rgba(239, 130, 92, 0.6), rgba(181, 60, 18, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(119, 33, 111, 0.9); }
+        color: rgba(94, 39, 80, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(119, 33, 111, 0.85); }
+          color: rgba(94, 39, 80, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/README.md
@@ -6,15 +6,17 @@ Cinnamox-Gold-Spice features a brown and golden orange colour scheme and light t
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
@@ -6,15 +6,17 @@ Cinnamox-Gold-Spice features a brown and golden orange colour scheme and light t
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(242, 226, 218, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(242, 226, 218, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #f2e2da; }
+  color: #f2e2da;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #e54c00;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.0/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #99461e;
-    background-image: linear-gradient(to bottom, #bf5826, #733517);
+    background-color: #663d2b;
+    background-image: linear-gradient(to bottom, #804c36, #4d2e20);
     border-color: rgba(218, 173, 150, 0.32);
     color: #f2e2da;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(218, 173, 150, 0.3);
       color: #f2e2da;
-      background-color: rgba(153, 70, 30, 0);
+      background-color: rgba(102, 61, 43, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(218, 173, 150, 0.4);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(242, 226, 218, 0.32);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #a84d21;
-        background-image: linear-gradient(to bottom, #d26029, #7e3a19);
+        background-color: #70432f;
+        background-image: linear-gradient(to bottom, #8c543b, #543223);
         border-color: rgba(218, 173, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #f2e2da; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#99461e,#f2e2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#663d2b,#f2e2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#99461e,#f2e2da,0.6);
+      color: mix(#663d2b,#f2e2da,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#99461e,#f2e2da,0.6); }
+        color: mix(#663d2b,#f2e2da,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(153, 70, 30, 0.9); }
+      color: rgba(102, 61, 43, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(153, 70, 30, 0.85); }
+        color: rgba(102, 61, 43, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #99461e;
-    background-image: linear-gradient(to bottom, #bf5826, #733517);
+    background-color: #663d2b;
+    background-image: linear-gradient(to bottom, #804c36, #4d2e20);
     border-color: rgba(218, 173, 150, 0.32);
     color: #f2e2da;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(218, 173, 150, 0.3);
       color: #f2e2da;
-      background-color: rgba(153, 70, 30, 0);
+      background-color: rgba(102, 61, 43, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(218, 173, 150, 0.4);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(242, 226, 218, 0.32);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #a84d21;
-        background-image: linear-gradient(to bottom, #d26029, #7e3a19);
+        background-color: #70432f;
+        background-image: linear-gradient(to bottom, #8c543b, #543223);
         border-color: rgba(218, 173, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #f2e2da; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#99461e,#f2e2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#663d2b,#f2e2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#99461e,#f2e2da,0.6);
+      color: mix(#663d2b,#f2e2da,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#99461e,#f2e2da,0.6); }
+        color: mix(#663d2b,#f2e2da,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(153, 70, 30, 0.9); }
+      color: rgba(102, 61, 43, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(153, 70, 30, 0.85); }
+        color: rgba(102, 61, 43, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #99461e;
-    background-image: linear-gradient(to bottom, #bf5826, #733517);
+    background-color: #663d2b;
+    background-image: linear-gradient(to bottom, #804c36, #4d2e20);
     border-color: rgba(218, 173, 150, 0.32);
     color: #f2e2da;
     box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(218, 173, 150, 0.3);
       color: #f2e2da;
-      background-color: rgba(153, 70, 30, 0);
+      background-color: rgba(102, 61, 43, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(218, 173, 150, 0.4);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 173, 150, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #a14a20;
-      background-image: linear-gradient(to bottom, #c95c27, #783718);
+      background-color: #6b402d;
+      background-image: linear-gradient(to bottom, #865038, #503022);
       border-color: rgba(242, 226, 218, 0.32);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #a84d21;
-        background-image: linear-gradient(to bottom, #d26029, #7e3a19);
+        background-color: #70432f;
+        background-image: linear-gradient(to bottom, #8c543b, #543223);
         border-color: rgba(218, 173, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #f2e2da; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#99461e,#f2e2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#663d2b,#f2e2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#99461e,#f2e2da,0.6);
+      color: mix(#663d2b,#f2e2da,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#99461e,#f2e2da,0.6); }
+        color: mix(#663d2b,#f2e2da,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(229, 76, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(153, 70, 30, 0.9); }
+      color: rgba(102, 61, 43, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(153, 70, 30, 0.85); }
+        color: rgba(102, 61, 43, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#99461e,mix(#99461e,mix(#99461e,#f2e2da,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #99461e;
-      background-image: linear-gradient(to bottom, #bf5826, #733517);
+      background-color: #663d2b;
+      background-image: linear-gradient(to bottom, #804c36, #4d2e20);
       border-color: rgba(218, 173, 150, 0.22);
       color: #f2e2da;
       box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(218, 173, 150, 0.2);
         color: #f2e2da;
-        background-color: rgba(153, 70, 30, 0);
+        background-color: rgba(102, 61, 43, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(218, 173, 150, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #a14a20;
-        background-image: linear-gradient(to bottom, #c95c27, #783718);
+        background-color: #6b402d;
+        background-image: linear-gradient(to bottom, #865038, #503022);
         border-color: rgba(218, 173, 150, 0.3);
         color: #f2e2da;
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(218, 173, 150, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #a14a20;
-        background-image: linear-gradient(to bottom, #c95c27, #783718);
+        background-color: #6b402d;
+        background-image: linear-gradient(to bottom, #865038, #503022);
         border-color: rgba(242, 226, 218, 0.22);
         outline-color: rgba(229, 76, 0, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #f2e2da;
         box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #a84d21;
-          background-image: linear-gradient(to bottom, #d26029, #7e3a19);
+          background-color: #70432f;
+          background-image: linear-gradient(to bottom, #8c543b, #543223);
           border-color: rgba(218, 173, 150, 0.3);
           box-shadow: 0 1px 2px -1px rgba(68, 39, 24, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #f2e2da; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#99461e,#f2e2da,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#99461e,#f2e2da,0.2),0.4),0.75));
+        background-color: alpha(mix(#663d2b,#f2e2da,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),1.25), shade(alpha(mix(#663d2b,#f2e2da,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#99461e,#f2e2da,0.6);
+        color: mix(#663d2b,#f2e2da,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#99461e,#f2e2da,0.6); }
+          color: mix(#663d2b,#f2e2da,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(229, 76, 0, 0.6);
         background-image: linear-gradient(to bottom, rgba(255, 106, 31, 0.6), rgba(172, 57, 0, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(153, 70, 30, 0.9); }
+        color: rgba(102, 61, 43, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(153, 70, 30, 0.85); }
+          color: rgba(102, 61, 43, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/README.md
@@ -6,15 +6,17 @@ Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Met
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/README.md
@@ -6,15 +6,17 @@ Cinnamox-Heather features a pale blue colour scheme and dark text. Cinnamon, Met
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(12, 20, 25, 0.32); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #ffffff; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(12, 20, 25, 0.32);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #0c1419; }
+  color: #0c1419;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #386b8c;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.0/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #b7c4cc;
-    background-image: linear-gradient(to bottom, #f0f2f4, #7e96a4);
+    background-color: #99b0bf;
+    background-image: linear-gradient(to bottom, #ced9e0, #64879e);
     border-color: rgba(10, 16, 20, 0.22);
     color: #0c1419;
     box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(10, 16, 20, 0.2);
       color: #0c1419;
-      background-color: rgba(183, 196, 204, 0);
+      background-color: rgba(153, 176, 191, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.2); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(10, 16, 20, 0.3);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.3); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(12, 20, 25, 0.22);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #ced7dc;
-        background-image: linear-gradient(to bottom, white, #8fa4b0);
+        background-color: #aec0cc;
+        background-image: linear-gradient(to bottom, #e8edf1, #7493a8);
         border-color: rgba(10, 16, 20, 0.3);
         box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #0c1419; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#b7c4cc,#0c1419,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),0.75));
+      background-color: alpha(mix(#99b0bf,#0c1419,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#b7c4cc,#0c1419,0.6);
+      color: mix(#99b0bf,#0c1419,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#b7c4cc,#0c1419,0.6); }
+        color: mix(#99b0bf,#0c1419,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(255, 255, 255, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(183, 196, 204, 0.9); }
+      color: rgba(153, 176, 191, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(183, 196, 204, 0.85); }
+        color: rgba(153, 176, 191, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.22), 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #b7c4cc;
-    background-image: linear-gradient(to bottom, #f0f2f4, #7e96a4);
+    background-color: #99b0bf;
+    background-image: linear-gradient(to bottom, #ced9e0, #64879e);
     border-color: rgba(10, 16, 20, 0.22);
     color: #0c1419;
     box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(10, 16, 20, 0.2);
       color: #0c1419;
-      background-color: rgba(183, 196, 204, 0);
+      background-color: rgba(153, 176, 191, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.2); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(10, 16, 20, 0.3);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.3); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(12, 20, 25, 0.22);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #ced7dc;
-        background-image: linear-gradient(to bottom, white, #8fa4b0);
+        background-color: #aec0cc;
+        background-image: linear-gradient(to bottom, #e8edf1, #7493a8);
         border-color: rgba(10, 16, 20, 0.3);
         box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #0c1419; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#b7c4cc,#0c1419,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),0.75));
+      background-color: alpha(mix(#99b0bf,#0c1419,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#b7c4cc,#0c1419,0.6);
+      color: mix(#99b0bf,#0c1419,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#b7c4cc,#0c1419,0.6); }
+        color: mix(#99b0bf,#0c1419,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(255, 255, 255, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(183, 196, 204, 0.9); }
+      color: rgba(153, 176, 191, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(183, 196, 204, 0.85); }
+        color: rgba(153, 176, 191, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.22), 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #b7c4cc;
-    background-image: linear-gradient(to bottom, #f0f2f4, #7e96a4);
+    background-color: #99b0bf;
+    background-image: linear-gradient(to bottom, #ced9e0, #64879e);
     border-color: rgba(10, 16, 20, 0.22);
     color: #0c1419;
     box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(10, 16, 20, 0.2);
       color: #0c1419;
-      background-color: rgba(183, 196, 204, 0);
+      background-color: rgba(153, 176, 191, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.2); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(10, 16, 20, 0.3);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(10, 16, 20, 0.3); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #c2cdd4;
-      background-image: linear-gradient(to bottom, #fefefe, #879daa);
+      background-color: #a4b8c6;
+      background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
       border-color: rgba(12, 20, 25, 0.22);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #ced7dc;
-        background-image: linear-gradient(to bottom, white, #8fa4b0);
+        background-color: #aec0cc;
+        background-image: linear-gradient(to bottom, #e8edf1, #7493a8);
         border-color: rgba(10, 16, 20, 0.3);
         box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #0c1419; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#b7c4cc,#0c1419,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),0.75));
+      background-color: alpha(mix(#99b0bf,#0c1419,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#b7c4cc,#0c1419,0.6);
+      color: mix(#99b0bf,#0c1419,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#b7c4cc,#0c1419,0.6); }
+        color: mix(#99b0bf,#0c1419,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(56, 107, 140, 0.6);
       background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(255, 255, 255, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(183, 196, 204, 0.9); }
+      color: rgba(153, 176, 191, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(183, 196, 204, 0.85); }
+        color: rgba(153, 176, 191, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.22), 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#b7c4cc,mix(#b7c4cc,mix(#b7c4cc,#0c1419,0.1),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #b7c4cc;
-      background-image: linear-gradient(to bottom, #f0f2f4, #7e96a4);
+      background-color: #99b0bf;
+      background-image: linear-gradient(to bottom, #ced9e0, #64879e);
       border-color: rgba(10, 16, 20, 0.32);
       color: #0c1419;
       box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.12); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(10, 16, 20, 0.3);
         color: #0c1419;
-        background-color: rgba(183, 196, 204, 0);
+        background-color: rgba(153, 176, 191, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(10, 16, 20, 0.3); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #c2cdd4;
-        background-image: linear-gradient(to bottom, #fefefe, #879daa);
+        background-color: #a4b8c6;
+        background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
         border-color: rgba(10, 16, 20, 0.4);
         color: #0c1419;
         box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.22); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(10, 16, 20, 0.4); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #c2cdd4;
-        background-image: linear-gradient(to bottom, #fefefe, #879daa);
+        background-color: #a4b8c6;
+        background-image: linear-gradient(to bottom, #dbe3e8, #6c8da3);
         border-color: rgba(12, 20, 25, 0.32);
         outline-color: rgba(56, 107, 140, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #0c1419;
         box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.32); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #ced7dc;
-          background-image: linear-gradient(to bottom, white, #8fa4b0);
+          background-color: #aec0cc;
+          background-image: linear-gradient(to bottom, #e8edf1, #7493a8);
           border-color: rgba(10, 16, 20, 0.4);
           box-shadow: 0 1px 2px -1px rgba(2, 4, 5, 0.38); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #0c1419; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#b7c4cc,#0c1419,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#b7c4cc,#0c1419,0.2),0.4),0.75));
+        background-color: alpha(mix(#99b0bf,#0c1419,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),1.25), shade(alpha(mix(#99b0bf,#0c1419,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#b7c4cc,#0c1419,0.6);
+        color: mix(#99b0bf,#0c1419,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#b7c4cc,#0c1419,0.6); }
+          color: mix(#99b0bf,#0c1419,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(56, 107, 140, 0.6);
         background-image: linear-gradient(to bottom, rgba(70, 134, 175, 0.6), rgba(42, 80, 105, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(255, 255, 255, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(183, 196, 204, 0.9); }
+        color: rgba(153, 176, 191, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(183, 196, 204, 0.85); }
+          color: rgba(153, 176, 191, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/README.md
@@ -6,15 +6,17 @@ Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cin
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
@@ -6,15 +6,17 @@ Cinnamox-Kashmir-Blue features a soothing blue colour scheme and light text. Cin
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(218, 234, 242, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(218, 234, 242, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #daeaf2; }
+  color: #daeaf2;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #23b29a;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.0/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #577584;
-    background-image: linear-gradient(to bottom, #7191a1, #415863);
+    background-color: #29404c;
+    background-image: linear-gradient(to bottom, #33505f, #1f3039);
     border-color: rgba(150, 195, 218, 0.32);
     color: #daeaf2;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(150, 195, 218, 0.3);
       color: #daeaf2;
-      background-color: rgba(87, 117, 132, 0);
+      background-color: rgba(41, 64, 76, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(150, 195, 218, 0.4);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(218, 234, 242, 0.32);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #608191;
-        background-image: linear-gradient(to bottom, #819eac, #48616d);
+        background-color: #2d4654;
+        background-image: linear-gradient(to bottom, #385869, #22353f);
         border-color: rgba(150, 195, 218, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #daeaf2; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#577584,#daeaf2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#577584,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#577584,#daeaf2,0.2),0.4),0.75));
+      background-color: alpha(mix(#29404c,#daeaf2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#577584,#daeaf2,0.6);
+      color: mix(#29404c,#daeaf2,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#577584,#daeaf2,0.6); }
+        color: mix(#29404c,#daeaf2,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(87, 117, 132, 0.9); }
+      color: rgba(41, 64, 76, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(87, 117, 132, 0.85); }
+        color: rgba(41, 64, 76, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #577584;
-    background-image: linear-gradient(to bottom, #7191a1, #415863);
+    background-color: #29404c;
+    background-image: linear-gradient(to bottom, #33505f, #1f3039);
     border-color: rgba(150, 195, 218, 0.32);
     color: #daeaf2;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(150, 195, 218, 0.3);
       color: #daeaf2;
-      background-color: rgba(87, 117, 132, 0);
+      background-color: rgba(41, 64, 76, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(150, 195, 218, 0.4);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(218, 234, 242, 0.32);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #608191;
-        background-image: linear-gradient(to bottom, #819eac, #48616d);
+        background-color: #2d4654;
+        background-image: linear-gradient(to bottom, #385869, #22353f);
         border-color: rgba(150, 195, 218, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #daeaf2; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#577584,#daeaf2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#577584,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#577584,#daeaf2,0.2),0.4),0.75));
+      background-color: alpha(mix(#29404c,#daeaf2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#577584,#daeaf2,0.6);
+      color: mix(#29404c,#daeaf2,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#577584,#daeaf2,0.6); }
+        color: mix(#29404c,#daeaf2,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(87, 117, 132, 0.9); }
+      color: rgba(41, 64, 76, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(87, 117, 132, 0.85); }
+        color: rgba(41, 64, 76, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #577584;
-    background-image: linear-gradient(to bottom, #7191a1, #415863);
+    background-color: #29404c;
+    background-image: linear-gradient(to bottom, #33505f, #1f3039);
     border-color: rgba(150, 195, 218, 0.32);
     color: #daeaf2;
     box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(150, 195, 218, 0.3);
       color: #daeaf2;
-      background-color: rgba(87, 117, 132, 0);
+      background-color: rgba(41, 64, 76, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(150, 195, 218, 0.4);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(150, 195, 218, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #5b7b8b;
-      background-image: linear-gradient(to bottom, #7997a7, #455c68);
+      background-color: #2b4350;
+      background-image: linear-gradient(to bottom, #365464, #20323c);
       border-color: rgba(218, 234, 242, 0.32);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #608191;
-        background-image: linear-gradient(to bottom, #819eac, #48616d);
+        background-color: #2d4654;
+        background-image: linear-gradient(to bottom, #385869, #22353f);
         border-color: rgba(150, 195, 218, 0.4);
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #daeaf2; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#577584,#daeaf2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#577584,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#577584,#daeaf2,0.2),0.4),0.75));
+      background-color: alpha(mix(#29404c,#daeaf2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#577584,#daeaf2,0.6);
+      color: mix(#29404c,#daeaf2,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#577584,#daeaf2,0.6); }
+        color: mix(#29404c,#daeaf2,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(35, 178, 154, 0.6);
       background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(87, 117, 132, 0.9); }
+      color: rgba(41, 64, 76, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(87, 117, 132, 0.85); }
+        color: rgba(41, 64, 76, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#577584,mix(#577584,mix(#577584,#daeaf2,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #577584;
-      background-image: linear-gradient(to bottom, #7191a1, #415863);
+      background-color: #29404c;
+      background-image: linear-gradient(to bottom, #33505f, #1f3039);
       border-color: rgba(150, 195, 218, 0.22);
       color: #daeaf2;
       box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(150, 195, 218, 0.2);
         color: #daeaf2;
-        background-color: rgba(87, 117, 132, 0);
+        background-color: rgba(41, 64, 76, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(150, 195, 218, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #5b7b8b;
-        background-image: linear-gradient(to bottom, #7997a7, #455c68);
+        background-color: #2b4350;
+        background-image: linear-gradient(to bottom, #365464, #20323c);
         border-color: rgba(150, 195, 218, 0.3);
         color: #daeaf2;
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(150, 195, 218, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #5b7b8b;
-        background-image: linear-gradient(to bottom, #7997a7, #455c68);
+        background-color: #2b4350;
+        background-image: linear-gradient(to bottom, #365464, #20323c);
         border-color: rgba(218, 234, 242, 0.22);
         outline-color: rgba(35, 178, 154, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #daeaf2;
         box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #608191;
-          background-image: linear-gradient(to bottom, #819eac, #48616d);
+          background-color: #2d4654;
+          background-image: linear-gradient(to bottom, #385869, #22353f);
           border-color: rgba(150, 195, 218, 0.3);
           box-shadow: 0 1px 2px -1px rgba(24, 53, 68, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #daeaf2; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#577584,#daeaf2,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#577584,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#577584,#daeaf2,0.2),0.4),0.75));
+        background-color: alpha(mix(#29404c,#daeaf2,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),1.25), shade(alpha(mix(#29404c,#daeaf2,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#577584,#daeaf2,0.6);
+        color: mix(#29404c,#daeaf2,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#577584,#daeaf2,0.6); }
+          color: mix(#29404c,#daeaf2,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(35, 178, 154, 0.6);
         background-image: linear-gradient(to bottom, rgba(51, 215, 187, 0.6), rgba(26, 134, 116, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(87, 117, 132, 0.9); }
+        color: rgba(41, 64, 76, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(87, 117, 132, 0.85); }
+          color: rgba(41, 64, 76, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/README.md
@@ -6,15 +6,17 @@ Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Meta
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
@@ -6,15 +6,17 @@ Cinnamox-Rhino features a deep grey colour scheme and light text. Cinnamon, Meta
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(216, 229, 242, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(216, 229, 242, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #d8e5f2; }
+  color: #d8e5f2;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #3d80cc;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.0/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #434e5a;
-    background-image: linear-gradient(to bottom, #546271, #323b44);
+    background-color: #3b444c;
+    background-image: linear-gradient(to bottom, #4a555f, #2c3339);
     border-color: rgba(147, 183, 219, 0.32);
     color: #d8e5f2;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(147, 183, 219, 0.3);
       color: #d8e5f2;
-      background-color: rgba(67, 78, 90, 0);
+      background-color: rgba(59, 68, 76, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(147, 183, 219, 0.4);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(216, 229, 242, 0.32);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #4a5663;
-        background-image: linear-gradient(to bottom, #5c6b7c, #37404a);
+        background-color: #414b54;
+        background-image: linear-gradient(to bottom, #515e69, #31383f);
         border-color: rgba(147, 183, 219, 0.4);
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #d8e5f2; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#434e5a,#d8e5f2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),0.75));
+      background-color: alpha(mix(#3b444c,#d8e5f2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#434e5a,#d8e5f2,0.6);
+      color: mix(#3b444c,#d8e5f2,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#434e5a,#d8e5f2,0.6); }
+        color: mix(#3b444c,#d8e5f2,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(67, 78, 90, 0.9); }
+      color: rgba(59, 68, 76, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(67, 78, 90, 0.85); }
+        color: rgba(59, 68, 76, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #434e5a;
-    background-image: linear-gradient(to bottom, #546271, #323b44);
+    background-color: #3b444c;
+    background-image: linear-gradient(to bottom, #4a555f, #2c3339);
     border-color: rgba(147, 183, 219, 0.32);
     color: #d8e5f2;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(147, 183, 219, 0.3);
       color: #d8e5f2;
-      background-color: rgba(67, 78, 90, 0);
+      background-color: rgba(59, 68, 76, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(147, 183, 219, 0.4);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(216, 229, 242, 0.32);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #4a5663;
-        background-image: linear-gradient(to bottom, #5c6b7c, #37404a);
+        background-color: #414b54;
+        background-image: linear-gradient(to bottom, #515e69, #31383f);
         border-color: rgba(147, 183, 219, 0.4);
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #d8e5f2; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#434e5a,#d8e5f2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),0.75));
+      background-color: alpha(mix(#3b444c,#d8e5f2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#434e5a,#d8e5f2,0.6);
+      color: mix(#3b444c,#d8e5f2,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#434e5a,#d8e5f2,0.6); }
+        color: mix(#3b444c,#d8e5f2,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(67, 78, 90, 0.9); }
+      color: rgba(59, 68, 76, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(67, 78, 90, 0.85); }
+        color: rgba(59, 68, 76, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #434e5a;
-    background-image: linear-gradient(to bottom, #546271, #323b44);
+    background-color: #3b444c;
+    background-image: linear-gradient(to bottom, #4a555f, #2c3339);
     border-color: rgba(147, 183, 219, 0.32);
     color: #d8e5f2;
     box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(147, 183, 219, 0.3);
       color: #d8e5f2;
-      background-color: rgba(67, 78, 90, 0);
+      background-color: rgba(59, 68, 76, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(147, 183, 219, 0.4);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(147, 183, 219, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #46525f;
-      background-image: linear-gradient(to bottom, #586676, #353d47);
+      background-color: #3e4750;
+      background-image: linear-gradient(to bottom, #4d5964, #2e363c);
       border-color: rgba(216, 229, 242, 0.32);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #4a5663;
-        background-image: linear-gradient(to bottom, #5c6b7c, #37404a);
+        background-color: #414b54;
+        background-image: linear-gradient(to bottom, #515e69, #31383f);
         border-color: rgba(147, 183, 219, 0.4);
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #d8e5f2; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#434e5a,#d8e5f2,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),0.75));
+      background-color: alpha(mix(#3b444c,#d8e5f2,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#434e5a,#d8e5f2,0.6);
+      color: mix(#3b444c,#d8e5f2,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#434e5a,#d8e5f2,0.6); }
+        color: mix(#3b444c,#d8e5f2,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(61, 128, 204, 0.6);
       background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(67, 78, 90, 0.9); }
+      color: rgba(59, 68, 76, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(67, 78, 90, 0.85); }
+        color: rgba(59, 68, 76, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#434e5a,mix(#434e5a,mix(#434e5a,#d8e5f2,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #434e5a;
-      background-image: linear-gradient(to bottom, #546271, #323b44);
+      background-color: #3b444c;
+      background-image: linear-gradient(to bottom, #4a555f, #2c3339);
       border-color: rgba(147, 183, 219, 0.22);
       color: #d8e5f2;
       box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(147, 183, 219, 0.2);
         color: #d8e5f2;
-        background-color: rgba(67, 78, 90, 0);
+        background-color: rgba(59, 68, 76, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(147, 183, 219, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #46525f;
-        background-image: linear-gradient(to bottom, #586676, #353d47);
+        background-color: #3e4750;
+        background-image: linear-gradient(to bottom, #4d5964, #2e363c);
         border-color: rgba(147, 183, 219, 0.3);
         color: #d8e5f2;
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(147, 183, 219, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #46525f;
-        background-image: linear-gradient(to bottom, #586676, #353d47);
+        background-color: #3e4750;
+        background-image: linear-gradient(to bottom, #4d5964, #2e363c);
         border-color: rgba(216, 229, 242, 0.22);
         outline-color: rgba(61, 128, 204, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #d8e5f2;
         box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #4a5663;
-          background-image: linear-gradient(to bottom, #5c6b7c, #37404a);
+          background-color: #414b54;
+          background-image: linear-gradient(to bottom, #515e69, #31383f);
           border-color: rgba(147, 183, 219, 0.3);
           box-shadow: 0 1px 2px -1px rgba(23, 46, 69, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #d8e5f2; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#434e5a,#d8e5f2,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#434e5a,#d8e5f2,0.2),0.4),0.75));
+        background-color: alpha(mix(#3b444c,#d8e5f2,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),1.25), shade(alpha(mix(#3b444c,#d8e5f2,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#434e5a,#d8e5f2,0.6);
+        color: mix(#3b444c,#d8e5f2,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#434e5a,#d8e5f2,0.6); }
+          color: mix(#3b444c,#d8e5f2,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(61, 128, 204, 0.6);
         background-image: linear-gradient(to bottom, rgba(113, 162, 218, 0.6), rgba(41, 96, 157, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(67, 78, 90, 0.9); }
+        color: rgba(59, 68, 76, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(67, 78, 90, 0.85); }
+          color: rgba(59, 68, 76, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/README.md
@@ -6,15 +6,17 @@ Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinn
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
@@ -6,15 +6,17 @@ Cinnamox-Rosso-Cursa features an exciting red colour scheme and light text. Cinn
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(242, 218, 218, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(242, 218, 218, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #f2dada; }
+  color: #f2dada;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #CC6600;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.0/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #CC0000;
-    background-image: linear-gradient(to bottom, red, #990000);
+    background-color: #800000;
+    background-image: linear-gradient(to bottom, #a00000, #600000);
     border-color: rgba(218, 150, 150, 0.32);
     color: #f2dada;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(218, 150, 150, 0.3);
       color: #f2dada;
-      background-color: rgba(204, 0, 0, 0);
+      background-color: rgba(128, 0, 0, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(218, 150, 150, 0.4);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(242, 218, 218, 0.32);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #e00000;
-        background-image: linear-gradient(to bottom, #ff1a1a, #a80000);
+        background-color: #8d0000;
+        background-image: linear-gradient(to bottom, #b00000, #6a0000);
         border-color: rgba(218, 150, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #f2dada; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#CC0000,#f2dada,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),0.75));
+      background-color: alpha(mix(#800000,#f2dada,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#800000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#800000,#f2dada,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#CC0000,#f2dada,0.6);
+      color: mix(#800000,#f2dada,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#CC0000,#f2dada,0.6); }
+        color: mix(#800000,#f2dada,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(204, 0, 0, 0.9); }
+      color: rgba(128, 0, 0, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(204, 0, 0, 0.85); }
+        color: rgba(128, 0, 0, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #CC0000;
-    background-image: linear-gradient(to bottom, red, #990000);
+    background-color: #800000;
+    background-image: linear-gradient(to bottom, #a00000, #600000);
     border-color: rgba(218, 150, 150, 0.32);
     color: #f2dada;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(218, 150, 150, 0.3);
       color: #f2dada;
-      background-color: rgba(204, 0, 0, 0);
+      background-color: rgba(128, 0, 0, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(218, 150, 150, 0.4);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(242, 218, 218, 0.32);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #e00000;
-        background-image: linear-gradient(to bottom, #ff1a1a, #a80000);
+        background-color: #8d0000;
+        background-image: linear-gradient(to bottom, #b00000, #6a0000);
         border-color: rgba(218, 150, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #f2dada; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#CC0000,#f2dada,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),0.75));
+      background-color: alpha(mix(#800000,#f2dada,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#800000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#800000,#f2dada,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#CC0000,#f2dada,0.6);
+      color: mix(#800000,#f2dada,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#CC0000,#f2dada,0.6); }
+        color: mix(#800000,#f2dada,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(204, 0, 0, 0.9); }
+      color: rgba(128, 0, 0, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(204, 0, 0, 0.85); }
+        color: rgba(128, 0, 0, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #CC0000;
-    background-image: linear-gradient(to bottom, red, #990000);
+    background-color: #800000;
+    background-image: linear-gradient(to bottom, #a00000, #600000);
     border-color: rgba(218, 150, 150, 0.32);
     color: #f2dada;
     box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(218, 150, 150, 0.3);
       color: #f2dada;
-      background-color: rgba(204, 0, 0, 0);
+      background-color: rgba(128, 0, 0, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(218, 150, 150, 0.4);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(218, 150, 150, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #d60000;
-      background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+      background-color: #860000;
+      background-image: linear-gradient(to bottom, #a80000, #650000);
       border-color: rgba(242, 218, 218, 0.32);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #e00000;
-        background-image: linear-gradient(to bottom, #ff1a1a, #a80000);
+        background-color: #8d0000;
+        background-image: linear-gradient(to bottom, #b00000, #6a0000);
         border-color: rgba(218, 150, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #f2dada; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#CC0000,#f2dada,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),0.75));
+      background-color: alpha(mix(#800000,#f2dada,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#800000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#800000,#f2dada,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#CC0000,#f2dada,0.6);
+      color: mix(#800000,#f2dada,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#CC0000,#f2dada,0.6); }
+        color: mix(#800000,#f2dada,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(204, 102, 0, 0.6);
       background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(204, 0, 0, 0.9); }
+      color: rgba(128, 0, 0, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(204, 0, 0, 0.85); }
+        color: rgba(128, 0, 0, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#CC0000,mix(#CC0000,mix(#CC0000,#f2dada,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #CC0000;
-      background-image: linear-gradient(to bottom, red, #990000);
+      background-color: #800000;
+      background-image: linear-gradient(to bottom, #a00000, #600000);
       border-color: rgba(218, 150, 150, 0.22);
       color: #f2dada;
       box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(218, 150, 150, 0.2);
         color: #f2dada;
-        background-color: rgba(204, 0, 0, 0);
+        background-color: rgba(128, 0, 0, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(218, 150, 150, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #d60000;
-        background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+        background-color: #860000;
+        background-image: linear-gradient(to bottom, #a80000, #650000);
         border-color: rgba(218, 150, 150, 0.3);
         color: #f2dada;
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(218, 150, 150, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #d60000;
-        background-image: linear-gradient(to bottom, #ff0d0d, #a10000);
+        background-color: #860000;
+        background-image: linear-gradient(to bottom, #a80000, #650000);
         border-color: rgba(242, 218, 218, 0.22);
         outline-color: rgba(204, 102, 0, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #f2dada;
         box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #e00000;
-          background-image: linear-gradient(to bottom, #ff1a1a, #a80000);
+          background-color: #8d0000;
+          background-image: linear-gradient(to bottom, #b00000, #6a0000);
           border-color: rgba(218, 150, 150, 0.3);
           box-shadow: 0 1px 2px -1px rgba(68, 24, 24, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #f2dada; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#CC0000,#f2dada,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#CC0000,#f2dada,0.2),0.4),0.75));
+        background-color: alpha(mix(#800000,#f2dada,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#800000,#f2dada,0.2),0.4),1.25), shade(alpha(mix(#800000,#f2dada,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#CC0000,#f2dada,0.6);
+        color: mix(#800000,#f2dada,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#CC0000,#f2dada,0.6); }
+          color: mix(#800000,#f2dada,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(204, 102, 0, 0.6);
         background-image: linear-gradient(to bottom, rgba(255, 128, 0, 0.6), rgba(153, 77, 0, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(204, 0, 0, 0.9); }
+        color: rgba(128, 0, 0, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(204, 0, 0, 0.85); }
+          color: rgba(128, 0, 0, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;

--- a/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/README.md
@@ -6,15 +6,17 @@ Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Ci
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
@@ -6,15 +6,17 @@ Cinnamox-Willow-Grove features a soothing green colour scheme and light text. Ci
 
 Build tools are at [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme).
 
-[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme).
+[Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) is a fork of [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme).
 
-The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
+The Cinnamon themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@smurphos](https://github.com/smurphos).
 
-GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme) are authored by [@Actionless and others](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/CREDITS) with contributions from [@smurphos](https://github.com/smurphos)
+GTK2, GTK3, GTK3.20 and Metacity themes in both [Cinnamox-gtk-theme](https://github.com/smurphos/cinnamox-gtk-theme) & [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme) are authored by [@actionless and contributors](https://github.com/themix-project/oomox-gtk-theme/graphs/contributors).
 
 Menu in screenshots is the excellent [CinnVIIStarkMenu](https://cinnamon-spices.linuxmint.com/applets/view/281).
 
 Icons in screenshots are from [Vibrancy Colours](http://www.ravefinity.com/p/vibrancy-colors-gtk-icon-theme.html).
+
+[Licensed under GPL-3.0](https://github.com/smurphos/cinnamox-gtk-theme/blob/master/LICENSE)
 
 ## Installation
 
@@ -62,17 +64,19 @@ To run the script open a terminal window (Ctrl-Alt-T) and use the following comm
 
 This theme is compatible with Cinnamon versions `3.2.x`, `3.4.x`, `3.6.x` & `3.8.x`
 
-The GTK3 themes require GTK `3.18.x`, `3.20.x` or `3.22.x`
+The GTK3 themes require GTK `3.18.x` or `3.22.x`
 
 The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrine` to be installed. The former is a default package in Linux Mint.
 
-Tested on Linux Mint `18.2` & `18.3` 64bit with Cinnamon `3.4.x`, `3.6.x`, Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` and Ubuntu `17.10` with Cinnamon nightly builds.
+Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x` & `3.8.x`; Also tested ion Manjaro `17.0.6` 64Bit with Cinnamon `3.6.x` & `3.8.x`.
 
 ### Firefox fix
 
-If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a userContent.css file to your Firefox default profile including the line `input, textarea { color: #222; background: #eee; }`
+If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-The theme includes a helper script that creates the userContent.css file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
+This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+
+The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_firefox_fix.sh`
 
@@ -80,7 +84,7 @@ The theme includes a helper script that creates the userContent.css file with th
 
 The repository at [Cinnamox_theme_master](https://github.com/smurphos/cinnamox_theme_master) includes instructions to utilise the tools provided to make your own unique Cinnamox based theme.
 
-The [Oomox app](https://github.com/actionless/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/actionless/oomox-gtk-theme). From [version 1.60+](https://github.com/actionless/oomox/releases/) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
+The [Oomox app](https://github.com/themix-project/oomox) is a GUI app to design and build themes using the [Oomox-gtk-theme](https://github.com/themix-project/oomox-gtk-theme). From [version 1.60+](https://github.com/themix-project/oomox/releases) this app included a Cinnamon theme based on Cinnamox and has an option to export a Cinnamon theme. 
 
 ## Changelog & Previous Releases
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -202,13 +202,8 @@
 
 .menu-applications-inner-box StScrollView, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu {
   padding: 8px;
-  margin: 8px 0;
   border-radius: 10px;
   border: 1px solid rgba(230, 242, 218, 0.22); }
-  .menu-applications-inner-box StScrollView StIcon:ltr, .menu-context-menu StIcon:ltr {
-    padding-right: 4px; }
-  .menu-applications-inner-box StScrollView StIcon:rtl, .menu-context-menu StIcon:rtl {
-    padding-left: 4px; }
 
 .panel-top .window-list-item-box:active, .panel-top .window-list-item-box:checked, .panel-top .window-list-item-box:focus {
   color: #000000; }
@@ -325,14 +320,14 @@ StScrollView StScrollBar {
 .popup-sub-menu {
   border: 1px solid rgba(230, 242, 218, 0.22);
   border-radius: 10px;
-  padding: 8px;
-  margin: 8px 0; }
+  padding: 8px; }
 
 .popup-menu-content {
   padding: 0; }
 
 .popup-menu-item {
-  color: #e6f2da; }
+  color: #e6f2da;
+  spacing: .5em; }
   .popup-menu-item:active {
     background-color: #6ccc3d;
     border-radius: 10px;
@@ -355,8 +350,7 @@ StScrollView StScrollBar {
   font-size: 1em; }
 
 .popup-menu-icon {
-  icon-size: 1.14em;
-  padding: 0px 4px; }
+  icon-size: 1.14em; }
 
 .popup-alternating-menu-item:alternate {
   font-weight: bold; }

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
-#Description: Helper file to write userContent.css to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
-cd ~/.mozilla/firefox/
-if [[ $(grep '\[Profile[^0]\]' profiles.ini) ]]; then 
-    PROFPATH=$(grep -E '^\[Profile|^Path|^Default' profiles.ini | grep -1 '^Default=1' | grep '^Path' | cut -c6-);
+#Description: Helper file to write user.js to /$HOME/.mozilla/firefox/usersprofile.default folder in order to fix issues with text visibility in input fields with some themes
+if find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1; then 
+    TARGETPATH=$(find "$HOME"/.mozilla/firefox/ -maxdepth 1 -type d -name '*.default' | head -1)
+    TARGETFILE="$TARGETPATH/user.js"
+	TARGETSTRING="user_pref(\"widget.content.gtk-theme-override\", \"Adwaita\");"
+	if [ ! -f "$TARGETFILE" ]; then
+		touch "$TARGETFILE"
+		echo "creating file $TARGETFILE"
+		echo ""
+	fi
+	if ! grep -q "widget.content.gtk-theme-override" "$TARGETFILE"; then
+		echo "$TARGETSTRING" >> "$TARGETFILE"
+		echo "writing  string '$TARGETSTRING' to $TARGETFILE"
+		echo ""
+		echo "please restart Firefox for fix to take effect"
+	else
+		echo "$TARGETFILE already contains a widget.content.gtk-theme-override"
+	fi
 else
-    PROFPATH=$(grep 'Path=' profiles.ini | sed 's/^Path=//');
+    echo "could not locate your .default firefox profile"
 fi
-TARGETPATH="$HOME/.mozilla/firefox/$PROFPATH/chrome";
-TARGETFILE="$HOME/.mozilla/firefox/$PROFPATH/chrome/userContent.css";
-TARGETSTRING="input, textarea { color: #222; background: #eee; }";
-if [ ! -d "$TARGETPATH" ]; then
-    mkdir "$TARGETPATH";
-    echo "creating folder $TARGETPATH";
-    echo "";
-fi
-if [ ! -f "$TARGETFILE" ]; then
-    touch "$TARGETFILE";
-    echo "creating file $TARGETFILE";
-    echo "";
-fi
-echo "$TARGETSTRING" >> "$TARGETFILE";
-echo "writing  string '$TARGETSTRING' to $TARGETFILE";
-echo "";
-echo "please restart Firefox for fix to take effect";
-echo "";
-read -p "Press enter to exit the script.";
-cd;
-exit;
+echo ""
+read -rp "Press enter to exit the script."
+exit

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.0/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.0/gtk.css
@@ -632,8 +632,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .toolbar .button {
-    background-color: #6f7f5f;
-    background-image: linear-gradient(to bottom, #8b9c7a, #535f47);
+    background-color: #4f5947;
+    background-image: linear-gradient(to bottom, #636f59, #3b4335);
     border-color: rgba(184, 218, 150, 0.32);
     color: #e6f2da;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -648,7 +648,7 @@ GtkComboBox .separator {
     .toolbar .button.flat {
       border-color: rgba(184, 218, 150, 0.3);
       color: #e6f2da;
-      background-color: rgba(111, 127, 95, 0);
+      background-color: rgba(79, 89, 71, 0);
       background-image: none;
       box-shadow: none; }
       .toolbar .button.flat:focus, .toolbar .button.flat:hover {
@@ -660,8 +660,8 @@ GtkComboBox .separator {
       .toolbar .button.flat:active:insensitive, .toolbar .button.flat:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.3); }
     .toolbar .button:hover, .toolbar .button.flat:hover {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(184, 218, 150, 0.4);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -674,14 +674,14 @@ GtkComboBox .separator {
       .toolbar .button:hover:active:insensitive, .toolbar .button:hover:checked:insensitive, .toolbar .button.flat:hover:active:insensitive, .toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.4); }
     .toolbar .button:focus, .toolbar .button.flat:focus {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(230, 242, 218, 0.32);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       .toolbar .button:focus:hover, .toolbar .button.flat:focus:hover {
-        background-color: #7a8c69;
-        background-image: linear-gradient(to bottom, #99a78a, #5c694e);
+        background-color: #57624e;
+        background-image: linear-gradient(to bottom, #6d7a62, #41493b);
         border-color: rgba(184, 218, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
         .toolbar .button:focus:hover:focus, .toolbar .button:focus:hover:hover, .toolbar .button.flat:focus:hover:focus, .toolbar .button.flat:focus:hover:hover {
@@ -713,13 +713,13 @@ GtkComboBox .separator {
     .toolbar .button:focus, .toolbar .button:hover, .toolbar .button.flat:focus, .toolbar .button.flat:hover {
       color: #e6f2da; }
     .toolbar .button:insensitive:insensitive, .toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#6f7f5f,#e6f2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#4f5947,#e6f2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#6f7f5f,#e6f2da,0.6);
+      color: mix(#4f5947,#e6f2da,0.6);
       box-shadow: none; }
       .toolbar .button:insensitive:insensitive :insensitive, .toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#6f7f5f,#e6f2da,0.6); }
+        color: mix(#4f5947,#e6f2da,0.6); }
     .toolbar .button:active:insensitive, .toolbar .button:checked:insensitive {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -729,9 +729,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .toolbar .button.separator, .toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(111, 127, 95, 0.9); }
+      color: rgba(79, 89, 71, 0.9); }
       .toolbar .button.separator:insensitive, .toolbar .button .separator:insensitive {
-        color: rgba(111, 127, 95, 0.85); }
+        color: rgba(79, 89, 71, 0.85); }
   .toolbar .button.linked, .toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
     .toolbar .button.linked:focus, .toolbar .button.linked:hover, .toolbar .linked .button:focus, .toolbar .linked .button:hover {
@@ -797,8 +797,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .header-bar .button {
-    background-color: #6f7f5f;
-    background-image: linear-gradient(to bottom, #8b9c7a, #535f47);
+    background-color: #4f5947;
+    background-image: linear-gradient(to bottom, #636f59, #3b4335);
     border-color: rgba(184, 218, 150, 0.32);
     color: #e6f2da;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -813,7 +813,7 @@ GtkComboBox .separator {
     .header-bar .button.flat {
       border-color: rgba(184, 218, 150, 0.3);
       color: #e6f2da;
-      background-color: rgba(111, 127, 95, 0);
+      background-color: rgba(79, 89, 71, 0);
       background-image: none;
       box-shadow: none; }
       .header-bar .button.flat:focus, .header-bar .button.flat:hover {
@@ -825,8 +825,8 @@ GtkComboBox .separator {
       .header-bar .button.flat:active:insensitive, .header-bar .button.flat:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.3); }
     .header-bar .button:hover, .header-bar .button.flat:hover {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(184, 218, 150, 0.4);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -839,14 +839,14 @@ GtkComboBox .separator {
       .header-bar .button:hover:active:insensitive, .header-bar .button:hover:checked:insensitive, .header-bar .button.flat:hover:active:insensitive, .header-bar .button.flat:hover:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.4); }
     .header-bar .button:focus, .header-bar .button.flat:focus {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(230, 242, 218, 0.32);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       .header-bar .button:focus:hover, .header-bar .button.flat:focus:hover {
-        background-color: #7a8c69;
-        background-image: linear-gradient(to bottom, #99a78a, #5c694e);
+        background-color: #57624e;
+        background-image: linear-gradient(to bottom, #6d7a62, #41493b);
         border-color: rgba(184, 218, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
         .header-bar .button:focus:hover:focus, .header-bar .button:focus:hover:hover, .header-bar .button.flat:focus:hover:focus, .header-bar .button.flat:focus:hover:hover {
@@ -878,13 +878,13 @@ GtkComboBox .separator {
     .header-bar .button:focus, .header-bar .button:hover, .header-bar .button.flat:focus, .header-bar .button.flat:hover {
       color: #e6f2da; }
     .header-bar .button:insensitive:insensitive, .header-bar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#6f7f5f,#e6f2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#4f5947,#e6f2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#6f7f5f,#e6f2da,0.6);
+      color: mix(#4f5947,#e6f2da,0.6);
       box-shadow: none; }
       .header-bar .button:insensitive:insensitive :insensitive, .header-bar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#6f7f5f,#e6f2da,0.6); }
+        color: mix(#4f5947,#e6f2da,0.6); }
     .header-bar .button:active:insensitive, .header-bar .button:checked:insensitive {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -894,9 +894,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .header-bar .button.separator, .header-bar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(111, 127, 95, 0.9); }
+      color: rgba(79, 89, 71, 0.9); }
       .header-bar .button.separator:insensitive, .header-bar .button .separator:insensitive {
-        color: rgba(111, 127, 95, 0.85); }
+        color: rgba(79, 89, 71, 0.85); }
   .header-bar .button.linked, .header-bar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
     .header-bar .button.linked:focus, .header-bar .button.linked:hover, .header-bar .linked .button:focus, .header-bar .linked .button:hover {
@@ -1239,8 +1239,8 @@ GtkComboBox .separator {
     font: smaller;
     padding: 0 6px; }
   .selection-mode.header-bar .button, .selection-mode.toolbar .button {
-    background-color: #6f7f5f;
-    background-image: linear-gradient(to bottom, #8b9c7a, #535f47);
+    background-color: #4f5947;
+    background-image: linear-gradient(to bottom, #636f59, #3b4335);
     border-color: rgba(184, 218, 150, 0.32);
     color: #e6f2da;
     box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -1255,7 +1255,7 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button.flat, .selection-mode.toolbar .button.flat {
       border-color: rgba(184, 218, 150, 0.3);
       color: #e6f2da;
-      background-color: rgba(111, 127, 95, 0);
+      background-color: rgba(79, 89, 71, 0);
       background-image: none;
       box-shadow: none; }
       .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
@@ -1267,8 +1267,8 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button.flat:active:insensitive, .selection-mode.header-bar .button.flat:checked:insensitive, .selection-mode.toolbar .button.flat:active:insensitive, .selection-mode.toolbar .button.flat:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.3); }
     .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:hover {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(184, 218, 150, 0.4);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -1281,14 +1281,14 @@ GtkComboBox .separator {
       .selection-mode.header-bar .button:hover:active:insensitive, .selection-mode.header-bar .button:hover:checked:insensitive, .selection-mode.header-bar .button.flat:hover:active:insensitive, .selection-mode.header-bar .button.flat:hover:checked:insensitive, .selection-mode.toolbar .button:hover:active:insensitive, .selection-mode.toolbar .button:hover:checked:insensitive, .selection-mode.toolbar .button.flat:hover:active:insensitive, .selection-mode.toolbar .button.flat:hover:checked:insensitive {
         border-color: rgba(184, 218, 150, 0.4); }
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button.flat:focus, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button.flat:focus {
-      background-color: #758564;
-      background-image: linear-gradient(to bottom, #92a182, #57644b);
+      background-color: #535d4b;
+      background-image: linear-gradient(to bottom, #68755d, #3e4638);
       border-color: rgba(230, 242, 218, 0.32);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
       .selection-mode.header-bar .button:focus:hover, .selection-mode.header-bar .button.flat:focus:hover, .selection-mode.toolbar .button:focus:hover, .selection-mode.toolbar .button.flat:focus:hover {
-        background-color: #7a8c69;
-        background-image: linear-gradient(to bottom, #99a78a, #5c694e);
+        background-color: #57624e;
+        background-image: linear-gradient(to bottom, #6d7a62, #41493b);
         border-color: rgba(184, 218, 150, 0.4);
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
         .selection-mode.header-bar .button:focus:hover:focus, .selection-mode.header-bar .button:focus:hover:hover, .selection-mode.header-bar .button.flat:focus:hover:focus, .selection-mode.header-bar .button.flat:focus:hover:hover, .selection-mode.toolbar .button:focus:hover:focus, .selection-mode.toolbar .button:focus:hover:hover, .selection-mode.toolbar .button.flat:focus:hover:focus, .selection-mode.toolbar .button.flat:focus:hover:hover {
@@ -1320,13 +1320,13 @@ GtkComboBox .separator {
     .selection-mode.header-bar .button:focus, .selection-mode.header-bar .button:hover, .selection-mode.header-bar .button.flat:focus, .selection-mode.header-bar .button.flat:hover, .selection-mode.toolbar .button:focus, .selection-mode.toolbar .button:hover, .selection-mode.toolbar .button.flat:focus, .selection-mode.toolbar .button.flat:hover {
       color: #e6f2da; }
     .selection-mode.header-bar .button:insensitive:insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive, .selection-mode.toolbar .button:insensitive:insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive {
-      background-color: alpha(mix(#6f7f5f,#e6f2da,0.2),0.4);
-      background-image: linear-gradient(to bottom, shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),0.75));
+      background-color: alpha(mix(#4f5947,#e6f2da,0.2),0.4);
+      background-image: linear-gradient(to bottom, shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),0.75));
       opacity: .6;
-      color: mix(#6f7f5f,#e6f2da,0.6);
+      color: mix(#4f5947,#e6f2da,0.6);
       box-shadow: none; }
       .selection-mode.header-bar .button:insensitive:insensitive :insensitive, .selection-mode.header-bar .button.flat:insensitive:insensitive :insensitive, .selection-mode.toolbar .button:insensitive:insensitive :insensitive, .selection-mode.toolbar .button.flat:insensitive:insensitive :insensitive {
-        color: mix(#6f7f5f,#e6f2da,0.6); }
+        color: mix(#4f5947,#e6f2da,0.6); }
     .selection-mode.header-bar .button:active:insensitive, .selection-mode.header-bar .button:checked:insensitive, .selection-mode.toolbar .button:active:insensitive, .selection-mode.toolbar .button:checked:insensitive {
       background-color: rgba(108, 204, 61, 0.6);
       background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -1336,9 +1336,9 @@ GtkComboBox .separator {
         color: rgba(0, 0, 0, 0.85); }
     .selection-mode.header-bar .button.separator, .selection-mode.header-bar .button .separator, .selection-mode.toolbar .button.separator, .selection-mode.toolbar .button .separator {
       border: 1px solid currentColor;
-      color: rgba(111, 127, 95, 0.9); }
+      color: rgba(79, 89, 71, 0.9); }
       .selection-mode.header-bar .button.separator:insensitive, .selection-mode.header-bar .button .separator:insensitive, .selection-mode.toolbar .button.separator:insensitive, .selection-mode.toolbar .button .separator:insensitive {
-        color: rgba(111, 127, 95, 0.85); }
+        color: rgba(79, 89, 71, 0.85); }
   .selection-mode.header-bar .button.linked, .selection-mode.header-bar .linked .button, .selection-mode.toolbar .button.linked, .selection-mode.toolbar .linked .button {
     box-shadow: inset -1px 0 rgba(0, 0, 0, 0.32), 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
     .selection-mode.header-bar .button.linked:focus, .selection-mode.header-bar .button.linked:hover, .selection-mode.header-bar .linked .button:focus, .selection-mode.header-bar .linked .button:hover, .selection-mode.toolbar .button.linked:focus, .selection-mode.toolbar .button.linked:hover, .selection-mode.toolbar .linked .button:focus, .selection-mode.toolbar .linked .button:hover {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
@@ -1533,8 +1533,8 @@ toolbar {
       background-color: mix(#6f7f5f,mix(#6f7f5f,mix(#6f7f5f,#e6f2da,0.18),0.9),0.35);
       transition: 200ms ease-out; }
     toolbar.inline-toolbar button {
-      background-color: #6f7f5f;
-      background-image: linear-gradient(to bottom, #8b9c7a, #535f47);
+      background-color: #4f5947;
+      background-image: linear-gradient(to bottom, #636f59, #3b4335);
       border-color: rgba(184, 218, 150, 0.22);
       color: #e6f2da;
       box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.22); }
@@ -1589,7 +1589,7 @@ toolbar {
       toolbar.inline-toolbar button.flat {
         border-color: rgba(184, 218, 150, 0.2);
         color: #e6f2da;
-        background-color: rgba(111, 127, 95, 0);
+        background-color: rgba(79, 89, 71, 0);
         background-image: none;
         box-shadow: none; }
         toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
@@ -1601,8 +1601,8 @@ toolbar {
         toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
           border-color: rgba(184, 218, 150, 0.2); }
       toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:hover {
-        background-color: #758564;
-        background-image: linear-gradient(to bottom, #92a182, #57644b);
+        background-color: #535d4b;
+        background-image: linear-gradient(to bottom, #68755d, #3e4638);
         border-color: rgba(184, 218, 150, 0.3);
         color: #e6f2da;
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.32); }
@@ -1615,8 +1615,8 @@ toolbar {
         toolbar.inline-toolbar button:hover:active:disabled, toolbar.inline-toolbar button:hover:checked:disabled, toolbar.inline-toolbar button.flat:hover:active:disabled, toolbar.inline-toolbar button.flat:hover:checked:disabled {
           border-color: rgba(184, 218, 150, 0.3); }
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button.flat:focus {
-        background-color: #758564;
-        background-image: linear-gradient(to bottom, #92a182, #57644b);
+        background-color: #535d4b;
+        background-image: linear-gradient(to bottom, #68755d, #3e4638);
         border-color: rgba(230, 242, 218, 0.22);
         outline-color: rgba(108, 204, 61, 0.5);
         outline-width: 1px;
@@ -1625,8 +1625,8 @@ toolbar {
         color: #e6f2da;
         box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.42); }
         toolbar.inline-toolbar button:focus:hover, toolbar.inline-toolbar button.flat:focus:hover {
-          background-color: #7a8c69;
-          background-image: linear-gradient(to bottom, #99a78a, #5c694e);
+          background-color: #57624e;
+          background-image: linear-gradient(to bottom, #6d7a62, #41493b);
           border-color: rgba(184, 218, 150, 0.3);
           box-shadow: 0 1px 2px -1px rgba(46, 68, 24, 0.48); }
           toolbar.inline-toolbar button:focus:hover:focus, toolbar.inline-toolbar button:focus:hover:hover, toolbar.inline-toolbar button.flat:focus:hover:focus, toolbar.inline-toolbar button.flat:focus:hover:hover {
@@ -1660,14 +1660,14 @@ toolbar {
       toolbar.inline-toolbar button:focus, toolbar.inline-toolbar button:hover, toolbar.inline-toolbar button.flat:focus, toolbar.inline-toolbar button.flat:hover {
         color: #e6f2da; }
       toolbar.inline-toolbar button:disabled:disabled, toolbar.inline-toolbar button.flat:disabled:disabled {
-        background-color: alpha(mix(#6f7f5f,#e6f2da,0.2),0.4);
-        background-image: linear-gradient(to bottom, shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#6f7f5f,#e6f2da,0.2),0.4),0.75));
+        background-color: alpha(mix(#4f5947,#e6f2da,0.2),0.4);
+        background-image: linear-gradient(to bottom, shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),1.25), shade(alpha(mix(#4f5947,#e6f2da,0.2),0.4),0.75));
         /*border: 1px solid alpha($bg, .2);*/
         opacity: .6;
-        color: mix(#6f7f5f,#e6f2da,0.6);
+        color: mix(#4f5947,#e6f2da,0.6);
         box-shadow: none; }
         toolbar.inline-toolbar button:disabled:disabled :disabled, toolbar.inline-toolbar button.flat:disabled:disabled :disabled {
-          color: mix(#6f7f5f,#e6f2da,0.6); }
+          color: mix(#4f5947,#e6f2da,0.6); }
       toolbar.inline-toolbar button:active:disabled, toolbar.inline-toolbar button:checked:disabled, toolbar.inline-toolbar button.flat:active:disabled, toolbar.inline-toolbar button.flat:checked:disabled {
         background-color: rgba(108, 204, 61, 0.6);
         background-image: linear-gradient(to bottom, rgba(148, 218, 113, 0.6), rgba(80, 157, 41, 0.6));
@@ -1677,9 +1677,9 @@ toolbar {
           color: rgba(0, 0, 0, 0.85); }
       toolbar.inline-toolbar button.separator, toolbar.inline-toolbar button .separator {
         border: 1px solid currentColor;
-        color: rgba(111, 127, 95, 0.9); }
+        color: rgba(79, 89, 71, 0.9); }
         toolbar.inline-toolbar button.separator:disabled, toolbar.inline-toolbar button .separator:disabled {
-          color: rgba(111, 127, 95, 0.85); }
+          color: rgba(79, 89, 71, 0.85); }
 
 window.csd > .titlebar:not(headerbar) {
   padding: 0;


### PR DESCRIPTION
* cinnamox_firefox_fix.sh - Revamped to use user.js method to force Firefox to render themeable web content using Adwaita.

* Cinnamon theme - fixes to drop-down menu item spacing primarily to ensure Cinnamenu context menu displays correctly.

* GTK 3.18 and 3.20 - header bar buttons in CSD apps use regular button colours.