### PR TITLE
Adapta: Issue #456

### DIFF
--- a/Adapta/README.md
+++ b/Adapta/README.md
@@ -64,6 +64,4 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Adapta/firefox_fix.sh && ~/.themes/Adapta/cinnamon/firefox_fix.sh`
-
-
+`chmod +x ~/.themes/Adapta/firefox_fix.sh && ~/.themes/Adapta/firefox_fix.sh`


### PR DESCRIPTION
@smurphos - I installed this theme (Adapta) with the built in theme manager on Linux Mint 18.3. Even after creating the symlink with the following the issue remained.
```sh
sudo ln -s ~/.themes/* /usr/share/themes/
```

The `README.me` file contains a broken path to the script `firefox_fix.sh`. I've corrected it by by removing `cinnamon/` from line [#67](https://github.com/linuxmint/cinnamon-spices-themes/blame/master/Adapta/README.md#L67).

```sh
# Broken
chmod +x ~/.themes/Adapta/firefox_fix.sh && ~/.themes/Adapta/cinnamon/firefox_fix.sh
# Fixed
chmod +x ~/.themes/Adapta/firefox_fix.sh && ~/.themes/Adapta/firefox_fix.sh
```
Fixes #456 