### PR TITLE
Cinnamox update 211018

### DIFF
--- a/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Aubergine/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(242, 217, 240, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/index.theme
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Aubergine
 GtkTheme=Cinnamox-Aubergine
-IconTheme=Cinnamox-Aubergine
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Aubergine

--- a/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Gold-Spice/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(242, 226, 218, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/index.theme
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Gold-Spice
 GtkTheme=Cinnamox-Gold-Spice
-IconTheme=Cinnamox-Gold-Spice
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Gold-Spice

--- a/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Heather/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(12, 20, 25, 0.32);
   border-radius: 10px;

--- a/Cinnamox-Heather/files/Cinnamox-Heather/index.theme
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Heather
 GtkTheme=Cinnamox-Heather
-IconTheme=Cinnamox-Heather
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Heather

--- a/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Kashmir-Blue/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(218, 234, 242, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/index.theme
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Kashmir-Blue
 GtkTheme=Cinnamox-Kashmir-Blue
-IconTheme=Cinnamox-Kashmir-Blue
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Kashmir-Blue

--- a/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rhino/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(216, 229, 242, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/index.theme
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Rhino
 GtkTheme=Cinnamox-Rhino
-IconTheme=Cinnamox-Rhino
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Rhino

--- a/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Rosso-Cursa/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(242, 218, 218, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/index.theme
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Rosso-Cursa
 GtkTheme=Cinnamox-Rosso-Cursa
-IconTheme=Cinnamox-Rosso-Cursa
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Rosso-Cursa

--- a/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh && ~/.themes/Cinnamox-Willow-Grove/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -623,6 +623,9 @@ StScrollView StScrollBar {
     spacing: 3px;
     padding: 3px 1px; }
 
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px; }
+
 .window-list-item-box {
   border: 1px solid rgba(230, 242, 218, 0.22);
   border-radius: 10px;

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/index.theme
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=Cinnamox-Willow-Grove
 GtkTheme=Cinnamox-Willow-Grove
-IconTheme=Cinnamox-Willow-Grove
+IconTheme=Adwaita
 MetacityTheme=Cinnamox-Willow-Grove


### PR DESCRIPTION
* Fix to the firefox_fix instructions in the readme.

* Fix to the index.theme to not reference a non-existent icon theme

* Cinnamon - added a little padding between label and icon for the stock windows-list applet