### PR TITLE
Graphite: make thumbnail box disappear if code permits

### DIFF
--- a/Graphite-One/files/Graphite-One/cinnamon/cinnamon.css
+++ b/Graphite-One/files/Graphite-One/cinnamon/cinnamon.css
@@ -1567,12 +1567,21 @@ color: #fb5858;
     text-shadow: 1px 1px 1px #00ff00;
 }
 
-.grouped-window-list-thumbnail-menu {
-    font-size: 0.8em;
+.grouped-window-list-thumbnail-menu { /* neutralise anything inherited from .menu so it disappears */
+    font-size: 1em;
+    border: 1px transparent rgba(255,255,255,0);
+    background: transparent rgba(255,255,255,0);
+    background-gradient-start: rgba(20,20,20,0);
+    background-gradient-end: rgba(90,90,90,0);
+    background-gradient-direction: horizontal;
+    box-shadow: inset 0px 0px 0px 0px rgba(217,217,217,0);
 }
 .grouped-window-list-thumbnail-menu .item-box {
     padding: 24px;
     border-radius: 24px;
+    background-gradient-start: rgba(120,120,120,1);
+    background-gradient-end: rgba(20,20,20,1);
+    background-gradient-direction: horizontal;
 }
 .grouped-window-list-thumbnail-menu .item-box:outlined {
     padding: 6px;

--- a/Graphite-Zero/files/Graphite-Zero/cinnamon/cinnamon.css
+++ b/Graphite-Zero/files/Graphite-Zero/cinnamon/cinnamon.css
@@ -1572,12 +1572,21 @@ color: #fb5858;
     text-shadow: 1px 1px 1px #00ff00;
 }
 
-.grouped-window-list-thumbnail-menu {
-    font-size: 0.8em;
+.grouped-window-list-thumbnail-menu { /* neutralise anything inherited from .menu so it disappears */
+    font-size: 1em;
+    border: 1px transparent rgba(255,255,255,0);
+    background: transparent rgba(255,255,255,0);
+    background-gradient-start: rgba(20,20,20,0);
+    background-gradient-end: rgba(90,90,90,0);
+    background-gradient-direction: horizontal;
+    box-shadow: inset 0px 0px 0px 0px rgba(217,217,217,0);
 }
 .grouped-window-list-thumbnail-menu .item-box {
     padding: 24px;
     border-radius: 24px;
+    background-gradient-start: rgba(120,120,120,1);
+    background-gradient-end: rgba(20,20,20,1);
+    background-gradient-direction: horizontal;
 }
 .grouped-window-list-thumbnail-menu .item-box:outlined {
     padding: 6px;


### PR DESCRIPTION
if Cinnamon pr 8096 gets pulled then the surrounding menu box around thumbnail boxes will be made to vanish, makes more efficient use of screen real estate.  Has no effect with the current code.