### PR TITLE
Adapta update 120119

### DIFF
--- a/Adapta-Eta/README.md
+++ b/Adapta-Eta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Eta/files/Adapta-Eta/README.md
+++ b/Adapta-Eta/files/Adapta-Eta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Eta/files/Adapta-Eta/cinnamon/cinnamon.css
+++ b/Adapta-Eta/files/Adapta-Eta/cinnamon/cinnamon.css
@@ -173,7 +173,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .panel-dummy:entered { background-color: rgba(77, 182, 172, 0.25); }
 
-.panel-status-button { height: 22px; -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
+.panel-status-button { -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
 
 .panel-status-button:hover { color: #FFFFFF; }
 
@@ -447,7 +447,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu .menu-favorites-button:hover { border-color: transparent; color: #263238; background-color: rgba(38, 50, 56, 0.12); box-shadow: 0 0 transparent; text-shadow: none; icon-shadow: none; }
 
-.menu-favorites-box { padding: 7px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.09); background-color: transparent; }
+.menu-favorites-box { padding: 7px; spacing: 20px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.09); background-color: transparent; }
 
 .menu-favorites-box:ltr { border-right-width: 1px; }
 
@@ -525,11 +525,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu-search-entry-icon { icon-size: 16px; color: #263238; }
 
-.menu-context-menu { padding: 0.5em; }
+.menu-context-menu { padding: 0.5em 1px; }
 
 .info-osd { spacing: 1em; padding: 16px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; text-align: center; font-weight: 700; }
 
-.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; margin: 32px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
+.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
 
 .osd-window .osd-monitor-label { font-size: 30pt; }
 

--- a/Adapta-Nokto-Eta/README.md
+++ b/Adapta-Nokto-Eta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/README.md
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/cinnamon/cinnamon.css
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/cinnamon/cinnamon.css
@@ -173,7 +173,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .panel-dummy:entered { background-color: rgba(77, 182, 172, 0.25); }
 
-.panel-status-button { height: 22px; -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
+.panel-status-button { -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
 
 .panel-status-button:hover { color: #FFFFFF; }
 
@@ -447,7 +447,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu .menu-favorites-button:hover { border-color: transparent; color: #CFD8DC; background-color: rgba(207, 216, 220, 0.12); box-shadow: 0 0 transparent; text-shadow: none; icon-shadow: none; }
 
-.menu-favorites-box { padding: 7px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.13); background-color: transparent; }
+.menu-favorites-box { padding: 7px; spacing: 20px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.13); background-color: transparent; }
 
 .menu-favorites-box:ltr { border-right-width: 1px; }
 
@@ -525,11 +525,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu-search-entry-icon { icon-size: 16px; color: #CFD8DC; }
 
-.menu-context-menu { padding: 0.5em; }
+.menu-context-menu { padding: 0.5em 1px; }
 
 .info-osd { spacing: 1em; padding: 16px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; text-align: center; font-weight: 700; }
 
-.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; margin: 32px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
+.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
 
 .osd-window .osd-monitor-label { font-size: 30pt; }
 

--- a/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Nokto/files/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/files/Adapta-Nokto/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
@@ -173,7 +173,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .panel-dummy:entered { background-color: rgba(77, 182, 172, 0.25); }
 
-.panel-status-button { height: 22px; -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
+.panel-status-button { -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
 
 .panel-status-button:hover { color: #FFFFFF; }
 
@@ -447,7 +447,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu .menu-favorites-button:hover { border-color: transparent; color: #CFD8DC; background-color: rgba(207, 216, 220, 0.12); box-shadow: 0 0 transparent; text-shadow: none; icon-shadow: none; }
 
-.menu-favorites-box { padding: 7px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.13); background-color: transparent; }
+.menu-favorites-box { padding: 7px; spacing: 20px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.13); background-color: transparent; }
 
 .menu-favorites-box:ltr { border-right-width: 1px; }
 
@@ -525,11 +525,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu-search-entry-icon { icon-size: 16px; color: #CFD8DC; }
 
-.menu-context-menu { padding: 0.5em; }
+.menu-context-menu { padding: 0.5em 1px; }
 
 .info-osd { spacing: 1em; padding: 16px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; text-align: center; font-weight: 700; }
 
-.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; margin: 32px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
+.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
 
 .osd-window .osd-monitor-label { font-size: 30pt; }
 

--- a/Adapta/README.md
+++ b/Adapta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta/files/Adapta/README.md
+++ b/Adapta/files/Adapta/README.md
@@ -24,6 +24,9 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed to menu theming for Cinnamenu compatibility
 * Cinnamon - Cinnamon 4.0 Grouped Window Applet theming by @jaszhix & @smurphos
 * Cinnamon - support for Cinnamon 4.0 windows overview theming
+* Cinnamon - fixed keyboard applet on vertical panels
+* Cinnamon - fixed off-centre media-key osd
+* Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
 
 ## License
 
@@ -64,7 +67,7 @@ Tested on Linux Mint `18.2`, `18.3` & `19` 64bit with Cinnamon `3.4.x`, `3.6.x`,
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Adapta/files/Adapta/cinnamon/cinnamon.css
+++ b/Adapta/files/Adapta/cinnamon/cinnamon.css
@@ -173,7 +173,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .panel-dummy:entered { background-color: rgba(77, 182, 172, 0.25); }
 
-.panel-status-button { height: 22px; -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
+.panel-status-button { -natural-hpadding: 3px; -minimum-hpadding: 3px; border-width: 0; font-weight: 700; color: #CFD8DC; }
 
 .panel-status-button:hover { color: #FFFFFF; }
 
@@ -447,7 +447,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu .menu-favorites-button:hover { border-color: transparent; color: #263238; background-color: rgba(38, 50, 56, 0.12); box-shadow: 0 0 transparent; text-shadow: none; icon-shadow: none; }
 
-.menu-favorites-box { padding: 7px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.09); background-color: transparent; }
+.menu-favorites-box { padding: 7px; spacing: 20px; border-radius: 0; border: 0 solid rgba(0, 0, 0, 0.09); background-color: transparent; }
 
 .menu-favorites-box:ltr { border-right-width: 1px; }
 
@@ -525,11 +525,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu-search-entry-icon { icon-size: 16px; color: #263238; }
 
-.menu-context-menu { padding: 0.5em; }
+.menu-context-menu { padding: 0.5em 1px; }
 
 .info-osd { spacing: 1em; padding: 16px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; text-align: center; font-weight: 700; }
 
-.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; margin: 32px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
+.osd-window { min-width: 64px; min-height: 64px; spacing: 1em; padding: 20px; border: none; border-radius: 5px; border-image: url("assets/misc/osd.svg") 9 9 9 9; color: #CFD8DC; background: none; font-weight: 700; text-align: center; }
 
 .osd-window .osd-monitor-label { font-size: 30pt; }
 


### PR DESCRIPTION
* Cinnamon - fix keyboard applet in vertical panel
* Cinnamon - remove weird margin on Media-Keys OSD that was pushing it down and right
* Cinnamon4 - menu - add a little spacing between the favorites-scrollbox and system-buttons
* Cinnamon - reduce horizontal padding on cinnamenu right-click context menu to match other popup menus

Closes #546 
