### PR TITLE
Reduce use of text shadow in a couple of themes

### DIFF
--- a/Photocopy/files/Photocopy/cinnamon/cinnamon.css
+++ b/Photocopy/files/Photocopy/cinnamon/cinnamon.css
@@ -1227,7 +1227,6 @@ border-image: url("button-focus.svg") 3;
     padding-left: 28px;
     text-align: right;
     height: 30px;
-    text-shadow: 0px 1px 1px #000000;
 }
 
 .menu-selected-app-box:rtl {

--- a/SimpleDock/files/SimpleDock/cinnamon/cinnamon.css
+++ b/SimpleDock/files/SimpleDock/cinnamon/cinnamon.css
@@ -1302,7 +1302,6 @@ color: #fb5858;
     padding-left: 28px;
     text-align: center;
     color: #ffffff;
-    text-shadow: 0px 2px 2px #000000;
 }
 
 .menu-selected-app-title {


### PR DESCRIPTION
when in menu-selected-app-box in particular it slows the menu down