### PR TITLE
Adapta bugfix update 190319

### DIFF
--- a/Adapta-Eta/README.md
+++ b/Adapta-Eta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Eta/files/Adapta-Eta/README.md
+++ b/Adapta-Eta/files/Adapta-Eta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Eta/files/Adapta-Eta/gtk-3.22/gtk.css
+++ b/Adapta-Eta/files/Adapta-Eta/gtk-3.22/gtk.css
@@ -756,7 +756,7 @@ actionbar box:not(.linked) > button.toggle.text-button, actionbar .linked > butt
 
 actionbar .linked > button.popup.toggle { -gtk-outline-radius: 2px; }
 
-.titlebar, headerbar { background-color: #222d32; background-clip: border-box; color: rgba(207, 216, 220, 0.87); }
+.titlebar, headerbar { background-color: #222d32; background-clip: border-box; min-height: 42px; color: rgba(207, 216, 220, 0.87); }
 
 .titlebar *, headerbar * { outline-style: none; outline-width: 0; outline-color: transparent; }
 

--- a/Adapta-Nokto-Eta/README.md
+++ b/Adapta-Nokto-Eta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/README.md
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.22/gtk.css
+++ b/Adapta-Nokto-Eta/files/Adapta-Nokto-Eta/gtk-3.22/gtk.css
@@ -756,7 +756,7 @@ actionbar box:not(.linked) > button.toggle.text-button, actionbar .linked > butt
 
 actionbar .linked > button.popup.toggle { -gtk-outline-radius: 2px; }
 
-.titlebar, headerbar { background-color: #222d32; background-clip: border-box; color: rgba(207, 216, 220, 0.87); }
+.titlebar, headerbar { background-color: #222d32; background-clip: border-box; min-height: 42px; color: rgba(207, 216, 220, 0.87); }
 
 .titlebar *, headerbar * { outline-style: none; outline-width: 0; outline-color: transparent; }
 

--- a/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Nokto/files/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/files/Adapta-Nokto/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/gtk.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/gtk.css
@@ -756,7 +756,7 @@ actionbar box:not(.linked) > button.toggle.text-button, actionbar .linked > butt
 
 actionbar .linked > button.popup.toggle { -gtk-outline-radius: 2px; }
 
-.titlebar, headerbar { background-color: #222d32; background-clip: border-box; color: rgba(207, 216, 220, 0.87); }
+.titlebar, headerbar { background-color: #222d32; background-clip: border-box; min-height: 42px; color: rgba(207, 216, 220, 0.87); }
 
 .titlebar *, headerbar * { outline-style: none; outline-width: 0; outline-color: transparent; }
 

--- a/Adapta/README.md
+++ b/Adapta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta/files/Adapta/README.md
+++ b/Adapta/files/Adapta/README.md
@@ -27,6 +27,7 @@ This build is based on [Adapta version 3.95.0.11](https://github.com/adapta-proj
 * Cinnamon - fixed keyboard applet on vertical panels
 * Cinnamon - fixed off-centre media-key osd
 * Cinnamon - added spacing to menu-favorites-box to distinguish scrollbox from system-buttons
+* GTK 3.22 - Add a minimum height to headerbars.
 
 ## License
 

--- a/Adapta/files/Adapta/gtk-3.22/gtk.css
+++ b/Adapta/files/Adapta/gtk-3.22/gtk.css
@@ -756,7 +756,7 @@ actionbar box:not(.linked) > button.toggle.text-button, actionbar .linked > butt
 
 actionbar .linked > button.popup.toggle { -gtk-outline-radius: 2px; }
 
-.titlebar, headerbar { background-color: #222d32; background-clip: border-box; color: rgba(207, 216, 220, 0.87); }
+.titlebar, headerbar { background-color: #222d32; background-clip: border-box; min-height: 42px; color: rgba(207, 216, 220, 0.87); }
 
 .titlebar *, headerbar * { outline-style: none; outline-width: 0; outline-color: transparent; }
 


### PR DESCRIPTION
* GTK 3.22 - add a minimum height to headerbars.

Closes #565 