### PR TITLE
Divo: Remove shadow of system status icons

### DIFF
--- a/Divo/files/Divo/cinnamon/cinnamon.css
+++ b/Divo/files/Divo/cinnamon/cinnamon.css
@@ -370,7 +370,6 @@ spacing: 0px;
     padding-right: 0px;
     spacing: 0px;
     margin: 0px;
-    icon-shadow: 0px 2px 2px rgba(0,0,0, 0.6);
 }
 
 .system-status-icon.warning {


### PR DESCRIPTION
I've removed the shadow from system status icons - I find the wifi and battery icons look "muddy" otherwise.

Before:
![divo-orig](https://user-images.githubusercontent.com/4016213/67044638-9ad0c280-f124-11e9-88fb-2c5c40fede97.png)

After:
![divo-modified](https://user-images.githubusercontent.com/4016213/67044640-9ad0c280-f124-11e9-85fe-76d30772da43.png)
