### PR TITLE
Cinnamox - 20200705 update

### DIFF
--- a/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Aubergine /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Aubergine /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #77216F; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(119, 33, 111, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #fbf4fb; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #fbf4fb; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #2C001E;
   color: #f2d9f0;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #2C001E;
-    border-radius: 0; }
+    background-color: #2C001E; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#2C001E,#f2d9f0,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#2C001E,#f2d9f0,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #E95420;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(137, 47, 130, 0.2), 0 0 0 1px rgba(94, 39, 80, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(137, 47, 130, 0.2), 0 0 0 1px rgba(94, 39, 80, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Aubergine";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Gold-Spice /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Gold-Spice /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #99461e; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(153, 70, 30, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #fcf7f5; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #fcf7f5; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #382218;
   color: #f2e2da;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #382218;
-    border-radius: 0; }
+    background-color: #382218; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#382218,#f2e2da,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#382218,#f2e2da,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #e54c00;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(136, 77, 48, 0.2), 0 0 0 1px rgba(102, 61, 43, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(136, 77, 48, 0.2), 0 0 0 1px rgba(102, 61, 43, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Gold-Spice";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Heather /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/README.md
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Heather /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #ffffff; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #ffffff; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #b7c4cc; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(183, 196, 204, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #0d161b; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #0d161b; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #72a0bf;
   color: #0c1419;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #72a0bf;
-    border-radius: 0; }
+    background-color: #72a0bf; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#72a0bf,#0c1419,0.1);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#72a0bf,#0c1419,0.1);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #386b8c;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(5, 8, 10, 0.2), 0 0 0 1px rgba(153, 176, 191, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(5, 8, 10, 0.2), 0 0 0 1px rgba(153, 176, 191, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Heather/files/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Heather";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Kashmir-Blue /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Kashmir-Blue /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #577584; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(87, 117, 132, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #f5f9fc; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #f5f9fc; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #28343a;
   color: #daeaf2;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #28343a;
-    border-radius: 0; }
+    background-color: #28343a; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#28343a,#daeaf2,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#28343a,#daeaf2,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #23b29a;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(48, 107, 136, 0.2), 0 0 0 1px rgba(41, 64, 76, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(48, 107, 136, 0.2), 0 0 0 1px rgba(41, 64, 76, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Kashmir-Blue";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Rhino /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Rhino /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #434e5a; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(67, 78, 90, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #f3f7fb; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #f3f7fb; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #1c2126;
   color: #d8e5f2;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #1c2126;
-    border-radius: 0; }
+    background-color: #1c2126; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#1c2126,#d8e5f2,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#1c2126,#d8e5f2,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #3d80cc;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(46, 92, 137, 0.2), 0 0 0 1px rgba(59, 68, 76, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(46, 92, 137, 0.2), 0 0 0 1px rgba(59, 68, 76, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Rhino";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Rosso-Cursa /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Rosso-Cursa /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #CC0000; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(204, 0, 0, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #fcf5f5; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #fcf5f5; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #4C0000;
   color: #f2dada;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #4C0000;
-    border-radius: 0; }
+    background-color: #4C0000; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#4C0000,#f2dada,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#4C0000,#f2dada,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #CC6600;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(136, 48, 48, 0.2), 0 0 0 1px rgba(128, 0, 0, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(136, 48, 48, 0.2), 0 0 0 1px rgba(128, 0, 0, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Rosso-Cursa";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit

--- a/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Willow-Grove /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/README.md
@@ -22,9 +22,9 @@ The themes are also available via [openDesktop.org](https://www.opendesktop.org/
 
 Select the Cinnamox theme as your Desktop, Controls and Window Borders in the Cinnamon Themes module.
 
-To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the system theme directory.
+To allow the GTK2, GTK3 and Metacity1 themes to apply to GUI apps running as root run this command in your terminal after installation to create symlinks to user themes in the local system theme directory.
 
-`sudo ln -s ~/.themes/* /usr/share/themes/`
+`sudo mkdir -p /usr/local/share/themes; sudo ln -s ~/.themes/Cinnamox-Willow-Grove /usr/local/share/themes/`
 
 ## Tweaking
 
@@ -39,6 +39,18 @@ To access the tool open a terminal window (Ctrl-Alt-T) and use the following com
 `chmod +x ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh && ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh`
 
 If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_fontsize.sh` again to chose another option including the default
+
+### Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
+
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+
+The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
+
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+
+`chmod +x ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh && ~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh`
+
+If you are not happy with the end result simply run `~/.themes/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh` again to revert.
 
 ### Titlebar Button-Size
 
@@ -104,7 +116,7 @@ The GTK2 theme requires the package `gtk2-engines-murrine` or `gtk-engine-murrin
 
 If you have problems seeing text on input fields in Firefox with any particular theme this problem can be solved by adding a `~/.mozilla/firefox/********.default/user.js` file to your Firefox default profile including the line `user_pref("widget.content.gtk-theme-override", "Adwaita");` and restarting Firefox.
 
-This forces firefox to use the GTK default Adwaita theme for rendering all website content.
+This forces Firefox to use the GTK default Adwaita theme for rendering all website content.
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -355,16 +355,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1341,3 +1341,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
@@ -422,16 +422,16 @@ StScrollView StScrollBar {
   color: #000000; }
 
 .menu-selected-app-box {
-  padding: 0 8px;
-  margin-bottom: 0.9em;
+  padding: 0 4px;
+  margin-top: 6px;
+  height: 1.8em;
   text-align: right; }
   .menu-selected-app-box:rtl {
     text-align: left; }
 
 .menu-selected-app-title {
   font-weight: bold;
-  font-size: 0.9em;
-  margin-top: 6px; }
+  font-size: 0.9em; }
 
 .menu-selected-app-description {
   max-width: 150px;
@@ -1383,3 +1383,4 @@ StScrollView StScrollBar {
   border-right-width: 0;
   border-radius: 10px 0 0 0; }
 stage {}
+.menu-selected-app-box {}

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
@@ -137,6 +137,8 @@
     -gtk-icon-shadow: none; }
   .background.csd {
     background-color: #6f7f5f; }
+  .background.csd.popup {
+    background-color: transparent; }
 
 .gtkstyle-fallback {
   background-color: rgba(111, 127, 95, 0.5);
@@ -3966,6 +3968,10 @@ menubar, .menubar {
       color: #f8fcf5; }
     menubar > menuitem *:hover, .menubar > menuitem *:hover {
       color: #f8fcf5; }
+    menubar > menuitem > window.background.csd.popup > decoration,
+    menubar > menuitem > window.background.csd.popup > menu, .menubar > menuitem > window.background.csd.popup > decoration,
+    .menubar > menuitem > window.background.csd.popup > menu {
+      border-radius: 0 0 10px 10px; }
 
 /******
  ! Menu
@@ -3973,7 +3979,7 @@ menubar, .menubar {
 menu,
 .menu,
 .context-menu {
-  border-radius: 0;
+  border-radius: 10px;
   padding: 3px;
   background-color: #444c3d;
   color: #e6f2da;
@@ -4140,20 +4146,20 @@ menu,
     min-height: 16px;
     min-width: 16px;
     padding: 3px;
-    background-color: #444c3d;
-    border-radius: 0; }
+    background-color: #444c3d; }
     menu > arrow.top,
     .menu > arrow.top,
     .context-menu > arrow.top {
-      margin-top: -6px;
       border-bottom: 1px solid mix(#444c3d,#e6f2da,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+      border-radius: 10px 10px 0 0; }
     menu > arrow.bottom,
     .menu > arrow.bottom,
     .context-menu > arrow.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix(#444c3d,#e6f2da,0.18);
-      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+      border-radius: 0 0 10px 10px; }
     menu > arrow:hover,
     .menu > arrow:hover,
     .context-menu > arrow:hover {
@@ -4464,7 +4470,8 @@ modelbutton.flat,
 menuitem.button.flat {
   padding: 5px;
   outline-color: transparent;
-  transition: none; }
+  transition: none;
+  border-radius: 10px; }
   modelbutton.flat:hover,
   menuitem.button.flat:hover {
     background-color: #6ccc3d;
@@ -7855,7 +7862,10 @@ decoration {
     border-radius: 0;
     box-shadow: none; }
   .csd.popup decoration {
-    border-radius: 0;
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 1px 2px rgba(92, 136, 48, 0.2), 0 0 0 1px rgba(79, 89, 71, 0.13); }
+  .background.csd.popup decoration {
+    border-radius: 10px;
     box-shadow: 0 1px 2px rgba(92, 136, 48, 0.2), 0 0 0 1px rgba(79, 89, 71, 0.13); }
   tooltip.csd decoration {
     border-radius: 10px;

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/scripts/cinnamox_toggle_menufix.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ ! -t 1 ]; then
+    exit
+fi
+THEMENAME="Cinnamox-Willow-Grove";
+DIRECTORY="/home/$USER/.themes/$THEMENAME/cinnamon/";
+MENUDEFAULT=".menu-selected-app-box {}"
+MENUFIX=".menu-selected-app-box {margin-bottom: 0.6em;}"
+cd "$DIRECTORY" || exit;
+if ! grep -q "$THEMENAME" cinnamon.css; then
+    echo "There is a problem. Cannot find the cinnamon.css file for $THEMENAME in $DIRECTORY.";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+if grep -Fq "$MENUDEFAULT" cinnamon.css; then
+    sed -i "s|$MENUDEFAULT|$MENUFIX|g" cinnamon.css;
+    MESSAGE="Menu app description fix applied."
+elif grep -q "$MENUFIX" cinnamon.css; then
+    sed -i "s|$MENUFIX|$MENUDEFAULT|g" cinnamon.css;
+    MESSAGE="Menu app description fix reverted."
+else 
+    echo "There is a problem. No string $MENUDEFAULT or $MENUFIX in cinnamon.css";
+    echo "The script should only be used with $THEMENAME.";
+    echo "";
+    read -rp "Press enter to exit script.";
+    exit 1;
+fi
+gsettings reset org.cinnamon.theme name;
+sleep 1;
+gsettings set org.cinnamon.theme name "$THEMENAME";
+if [ -t 1 ]; then
+    echo "";
+    echo "$MESSAGE";
+    echo "";
+    read -rp "Press enter to exit the script.";
+fi
+exit


### PR DESCRIPTION
* Cinnamon 4.6.6 - use height declaration for app description box as this is now honoured by the menu - https://github.com/linuxmint/cinnamon/commit/af9d3da81c1755519173a36fb33085566ea18e4e
* Scripts - add a helper script to add some margin to app description box for users on 4.4.8 and earlier
* GTK3.20 - add some roundness to the corners of application menus
* GTK3.20 - add some roundness to menu buttons for CSD apps