### PR TITLE
Cinnamox theme update 010820

### DIFF
--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #3e0d35;
   background-gradient-end: #671559; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #210017;
   background-gradient-end: #370026; }
@@ -32,7 +32,7 @@
   background-gradient-start: #671559;
   background-gradient-end: #3e0d35; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #b53c12;
   background-gradient-end: #ef825c; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(233, 84, 32, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(233, 84, 32, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2d9f0;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #E95420;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #ce4827; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 217, 240, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 217, 240, 0.22); }
+    border: 1px solid #ce4827; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #3e0d35;
   background-gradient-end: #671559; }
@@ -17,7 +17,7 @@
   background-gradient-start: #410d38;
   background-gradient-end: #6c165d; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #210017;
   background-gradient-end: #370026; }
@@ -42,7 +42,7 @@
   background-gradient-start: #6c165d;
   background-gradient-end: #410d38; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #b53c12;
   background-gradient-end: #ef825c; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #E95420; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #E95420;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2d9f0;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #E95420;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #ce4827; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 217, 240, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 217, 240, 0.22); }
+    border: 1px solid #ce4827; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #f2d9f0;
   background-color: #2C001E;
   background-image: linear-gradient(to bottom, #370026, #210017);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #f2d9f0;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #4f2714;
   background-gradient-end: #834122; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #2a1a12;
   background-gradient-end: #462b1e; }
@@ -32,7 +32,7 @@
   background-gradient-start: #834122;
   background-gradient-end: #4f2714; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #ac3900;
   background-gradient-end: #ff6a1f; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(229, 76, 0, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(229, 76, 0, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2e2da;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #e54c00;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #cf4805; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 226, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 226, 218, 0.22); }
+    border: 1px solid #cf4805; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #4f2714;
   background-gradient-end: #834122; }
@@ -17,7 +17,7 @@
   background-gradient-start: #532915;
   background-gradient-end: #8a4423; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #2a1a12;
   background-gradient-end: #462b1e; }
@@ -42,7 +42,7 @@
   background-gradient-start: #8a4423;
   background-gradient-end: #532915; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #ac3900;
   background-gradient-end: #ff6a1f; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #e54c00; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #e54c00;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2e2da;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #e54c00;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #cf4805; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 226, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 226, 218, 0.22); }
+    border: 1px solid #cf4805; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #f2e2da;
   background-color: #382218;
   background-image: linear-gradient(to bottom, #462b1e, #2a1a12);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #f2e2da;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #5d89a8;
   background-gradient-end: #cddbe4; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #477b9d;
   background-gradient-end: #a6c3d7; }
@@ -32,7 +32,7 @@
   background-gradient-start: #cddbe4;
   background-gradient-end: #5d89a8; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #2a5069;
   background-gradient-end: #4686af; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(56, 107, 140, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(56, 107, 140, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #0c1419;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #386b8c;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #ffffff;
     border-color: #417292; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(12, 20, 25, 0.32); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(12, 20, 25, 0.32); }
+    border: 1px solid #417292; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #5d89a8;
   background-gradient-end: #cddbe4; }
@@ -17,7 +17,7 @@
   background-gradient-start: #658fac;
   background-gradient-end: #dce5ec; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #477b9d;
   background-gradient-end: #a6c3d7; }
@@ -42,7 +42,7 @@
   background-gradient-start: #dce5ec;
   background-gradient-end: #658fac; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #2a5069;
   background-gradient-end: #4686af; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #386b8c; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #386b8c;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #0c1419;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #386b8c;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #ffffff;
     border-color: #417292; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(12, 20, 25, 0.32); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(12, 20, 25, 0.32); }
+    border: 1px solid #417292; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #0c1419;
   background-color: #72a0bf;
   background-image: linear-gradient(to bottom, #a6c3d7, #477b9d);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #0c1419;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #304047;
   background-gradient-end: #506a77; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #1e272c;
   background-gradient-end: #324149; }
@@ -32,7 +32,7 @@
   background-gradient-start: #506a77;
   background-gradient-end: #304047; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #1a8674;
   background-gradient-end: #33d7bb; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(35, 178, 154, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(35, 178, 154, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #daeaf2;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #23b29a;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #28a18f; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(218, 234, 242, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(218, 234, 242, 0.22); }
+    border: 1px solid #28a18f; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #304047;
   background-gradient-end: #506a77; }
@@ -17,7 +17,7 @@
   background-gradient-start: #32434b;
   background-gradient-end: #54707d; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #1e272c;
   background-gradient-end: #324149; }
@@ -42,7 +42,7 @@
   background-gradient-start: #54707d;
   background-gradient-end: #32434b; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #1a8674;
   background-gradient-end: #33d7bb; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #23b29a; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #23b29a;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #daeaf2;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #23b29a;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #28a18f; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(218, 234, 242, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(218, 234, 242, 0.22); }
+    border: 1px solid #28a18f; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #daeaf2;
   background-color: #28343a;
   background-image: linear-gradient(to bottom, #324149, #1e272c);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #daeaf2;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #242a30;
   background-gradient-end: #3c4650; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #15191d;
   background-gradient-end: #232930; }
@@ -32,7 +32,7 @@
   background-gradient-start: #3c4650;
   background-gradient-end: #242a30; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #29609d;
   background-gradient-end: #71a2da; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(61, 128, 204, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(61, 128, 204, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #d8e5f2;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #3d80cc;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #3b73b3; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(216, 229, 242, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(216, 229, 242, 0.22); }
+    border: 1px solid #3b73b3; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #242a30;
   background-gradient-end: #3c4650; }
@@ -17,7 +17,7 @@
   background-gradient-start: #262c32;
   background-gradient-end: #3f4a54; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #15191d;
   background-gradient-end: #232930; }
@@ -42,7 +42,7 @@
   background-gradient-start: #3f4a54;
   background-gradient-end: #262c32; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #29609d;
   background-gradient-end: #71a2da; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #3d80cc; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #3d80cc;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #d8e5f2;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #3d80cc;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #3b73b3; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(216, 229, 242, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(216, 229, 242, 0.22); }
+    border: 1px solid #3b73b3; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #d8e5f2;
   background-color: #1c2126;
   background-image: linear-gradient(to bottom, #232930, #15191d);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #d8e5f2;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #690000;
   background-gradient-end: #af0000; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #390000;
   background-gradient-end: #5f0000; }
@@ -32,7 +32,7 @@
   background-gradient-start: #af0000;
   background-gradient-end: #690000; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #994d00;
   background-gradient-end: #ff8000; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(204, 102, 0, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(204, 102, 0, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2dada;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #CC6600;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #c05400; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 218, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 218, 218, 0.22); }
+    border: 1px solid #c05400; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #690000;
   background-gradient-end: #af0000; }
@@ -17,7 +17,7 @@
   background-gradient-start: #6e0000;
   background-gradient-end: #b80000; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #390000;
   background-gradient-end: #5f0000; }
@@ -42,7 +42,7 @@
   background-gradient-start: #b80000;
   background-gradient-end: #6e0000; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #994d00;
   background-gradient-end: #ff8000; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #CC6600; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #CC6600;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #f2dada;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #CC6600;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #c05400; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(242, 218, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(242, 218, 218, 0.22); }
+    border: 1px solid #c05400; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #f2dada;
   background-color: #4C0000;
   background-image: linear-gradient(to bottom, #5f0000, #390000);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #f2dada;
   padding: 0 6px;
   min-height: 42px; }

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -7,12 +7,12 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #444d3b;
   background-gradient-end: #718062; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #33392e;
   background-gradient-end: #555f4c; }
@@ -32,7 +32,7 @@
   background-gradient-start: #718062;
   background-gradient-end: #444d3b; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #509d29;
   background-gradient-end: #94da71; }
@@ -544,6 +544,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: rgba(108, 204, 61, 0.2); }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: rgba(108, 204, 61, 0.2);
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #e6f2da;
   transition-duration: 150;
@@ -755,24 +765,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #6ccc3d;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #69ba40; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(230, 242, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(230, 242, 218, 0.22); }
+    border: 1px solid #69ba40; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
@@ -7,7 +7,7 @@
 /* The source code, tools and instructions to make your own cinnamox theme */
 /* can be found at https://github.com/smurphos/cinnamox-gtk-theme */
 /* -------------------------------------------------------------------------- */
-.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-graph .workspace, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
+.expo-workspaces-name-entry, .expo-background, .window-caption, .switcher-list, #LookingGlassDialog, .workspace-button, .sound-player-overlay, .panel-bottom .window-list-item-box, .panel-top, .popup-sub-menu, .starkmenu-favorites-box .menu-context-menu, .menu-context-menu, .menu-applications-inner-box StScrollView, .info-osd, .workspace-osd, .overview-empty-placeholder, .osd-window {
   background-gradient-direction: vertical;
   background-gradient-start: #444d3b;
   background-gradient-end: #718062; }
@@ -17,7 +17,7 @@
   background-gradient-start: #47503d;
   background-gradient-end: #768666; }
 
-.run-dialog-entry, #notification StEntry, #menu-search-entry {
+.workspace-graph .workspace, .workspace-button:shaded, .run-dialog-entry, #notification StEntry, #menu-search-entry {
   background-gradient-direction: vertical;
   background-gradient-start: #33392e;
   background-gradient-end: #555f4c; }
@@ -42,7 +42,7 @@
   background-gradient-start: #768666;
   background-gradient-end: #47503d; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #509d29;
   background-gradient-end: #94da71; }
@@ -593,6 +593,16 @@ StScrollView StScrollBar {
 .applet-spacer:highlight {
   background-color: #6ccc3d; }
 
+.spacer-box {
+  border-radius: 10px;
+  border: 1px solid transparent; }
+  .spacer-box:highlight {
+    background-color: #6ccc3d;
+    border: 1px symbolic; }
+  .spacer-box.edit-mode {
+    border-radius: 10px;
+    border: 1px symbolic; }
+
 .applet-box {
   color: #e6f2da;
   transition-duration: 150;
@@ -800,24 +810,24 @@ StScrollView StScrollBar {
   transition-duration: 150; }
   .workspace-button.vertical {
     height: 1.5em; }
-  .workspace-button:outlined {
-    background-color: #6ccc3d;
+  .workspace-button:outlined, .workspace-button:outlined:shaded {
     color: #000000;
     border-color: #69ba40; }
 
 .workspace-graph .workspace {
+  margin: 2px;
   border: 1px solid rgba(230, 242, 218, 0.22); }
   .workspace-graph .workspace:active {
-    border: 1px solid rgba(230, 242, 218, 0.22); }
+    border: 1px solid #69ba40; }
     .workspace-graph .workspace:active .windows {
-      -active-window-background: rgba(255, 255, 255, 0.8);
+      -active-window-background: rgba(255, 255, 255, 0.6);
       -active-window-border: rgba(0, 0, 0, 0.9);
-      -inactive-window-background: rgba(140, 140, 140, 0.8);
+      -inactive-window-background: rgba(140, 140, 140, 0.4);
       -inactive-window-border: rgba(0, 0, 0, 0.7); }
   .workspace-graph .workspace .windows {
-    -active-window-background: rgba(140, 140, 140, 0.8);
+    -active-window-background: rgba(140, 140, 140, 0.6);
     -active-window-border: rgba(0, 0, 0, 0.7);
-    -inactive-window-background: rgba(140, 140, 140, 0.8);
+    -inactive-window-background: rgba(140, 140, 140, 0.4);
     -inactive-window-border: rgba(0, 0, 0, 0.7); }
 
 .panel-launchers {

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
@@ -842,7 +842,7 @@ headerbar {
   color: #e6f2da;
   background-color: #444c3d;
   background-image: linear-gradient(to bottom, #555f4c, #33392e);
-  border-radius: 10px 10px 0 0;
+  border-radius: 0;
   color: #e6f2da;
   padding: 0 6px;
   min-height: 42px; }


### PR DESCRIPTION
* Cinnamon Panel - add support for spacer applet styling  .spacer-box
* Cinnamon Panel - add support for :shade state in simple workspace switcher applet
* Cinnamon Panel - rework graph view for workspace switcher applet
* GTK3.20 - don't apply border-radius to headerbars - looks wrong with apps with split headerbars like gnome-disks.