### PR TITLE
Graphite-One: hard coded icon size, menu tidy up, thumbnail title scale

### DIFF
--- a/Graphite-One/files/Graphite-One/cinnamon/cinnamon.css
+++ b/Graphite-One/files/Graphite-One/cinnamon/cinnamon.css
@@ -123,7 +123,7 @@ StScrollBar StButton#vhandle:hover {
  * PopupMenu (popupMenu.js)
  * ===================================================================*/
 .menu {
-    font-size: 1.2em;
+    font-size: 1.1em;
     border-radius: 16px 16px 16px 16px;
     background-gradient-start: rgba(120,120,120,1);
     background-gradient-end: rgba(20,20,20,1);
@@ -133,7 +133,7 @@ StScrollBar StButton#vhandle:hover {
     margin: 5px;
 }
 .popup-menu-arrow {
-    icon-size: 1.14em;
+    icon-size: 1.1em;
 }
 .popup-submenu-menu-item:open {
     background-gradient-start: rgba(20,20,20,1);
@@ -240,7 +240,7 @@ StScrollBar StButton#vhandle:hover {
     font-weight: normal;
 }
 .popup-menu-icon {
-    icon-size: 1.14em;
+    icon-size: 1em;
 }
 /* Switches (to be used in menus) */
 .toggle-switch {
@@ -792,7 +792,7 @@ color: #fb5858;
     padding: 4px;
 }
 .notification-icon-button > StIcon {
-    icon-size: 36px;
+    icon-size: 1.5em;
 }
 #notification StEntry {
     padding: 4px;
@@ -983,7 +983,7 @@ color: #fb5858;
 
 /* CinnamonMountOperation Dialogs */
 .cinnamon-mount-operation-icon {
-    icon-size: 48px;
+    icon-size: 2em;
 }
 .mount-password-reask {
     color: red;
@@ -1168,19 +1168,19 @@ color: #fb5858;
     padding-bottom: 4px;
 }
 .menu-applications-box {
-    padding-top: 29px;
+    padding-top: 4px;
     padding-left: 4px;
     padding-right: 4px;
     padding-bottom: 4px;
 }
 .menu-applications-inner-box {
-    padding-top: 10px;
+    padding-top: 4px;
     padding-left: 10px;
     padding-right: 10px;
     padding-bottom: 0px;
 }
 .menu-applications-outer-box {
-    padding-top: 10px;
+    padding-top: 0px;
     padding-left: 10px;
     padding-right: 10px;
     padding-bottom: 0px;
@@ -1193,6 +1193,7 @@ color: #fb5858;
     max-width: 10px;
     border: 1px solid rgba(0,0,0,0);
     border-radius: 6px 6px 6px 6px;
+    min-width: 16em;
 }
 .menu-application-button:highlighted {
     /* This style is used in menu application buttons for applications which were newly installed */
@@ -1291,10 +1292,10 @@ color: #fb5858;
     max-width: 150px;
 }
 .menu-search-box {
-   padding-top: 3px;
+   padding-top: 0px;
     padding-left: 4px;
     padding-right: 15px;
-    padding-bottom: 9px;
+    padding-bottom: 6px;
 }
 
 #menu-search-entry {
@@ -1309,7 +1310,7 @@ color: #fb5858;
     selected-color: black;
     caret-color: #D9D9D9;
     caret-size: 1px;
-    width: 435px;
+    width: 22em;
     transition-duration: 0;
 }
 #menu-search-entry:focus,
@@ -1342,7 +1343,7 @@ color: #fb5858;
     border: 1px;
     border-gradient-end: rgba(120,120,120,1);
     border-gradient-start: rgba(20,20,20,1);
-        border-radius: 14px 14px 14px 14px;
+        border-radius: 0px 0px 0px 0px;
     background-gradient-end: rgba(20,20,20,1);
     background-gradient-start: rgba(120,120,120,1);
     background-gradient-direction: horizontal;
@@ -1545,7 +1546,7 @@ color: #fb5858;
 }
 
 .grouped-window-list-thumbnail-menu { /* neutralise anything inherited from .menu so it disappears */
-    font-size: 0.8em;
+    font-size: 1em;
     border: 1px transparent rgba(255,255,255,0);
     background: transparent rgba(255,255,255,0);
     background-gradient-start: rgba(20,20,20,0);
@@ -1643,7 +1644,7 @@ color: #fb5858;
 }
 
 .sound-player-overlay StButton > StIcon {
-    icon-size: 16px;
+    icon-size: 1em;
 }
 
 .sound-player-overlay StBoxLayout {


### PR DESCRIPTION
Remove hard coded icon size, tidy up the menus, make the thumbnail title more legible