### PR TITLE
Numix-Cinnamon-Transparent: Adjust height value in .menu-selected-app-box 

### DIFF
--- a/Numix-Cinnamon-Transparent/files/Numix-Cinnamon-Transparent/cinnamon/cinnamon.css
+++ b/Numix-Cinnamon-Transparent/files/Numix-Cinnamon-Transparent/cinnamon/cinnamon.css
@@ -2020,7 +2020,7 @@ StScrollBar StButton#hhandle:active {
   padding-right: 30px;
   padding-left: 30px;
   text-align: right;
-  height: 1.2em;
+  height: 2.8em;
 }
 
 .menu-selected-app-title {


### PR DESCRIPTION
The current value of height attribute is 1.2em. This is far to small and pushes the text off the bottom of the menu. A new value of 2.8em looks perfectly fine and also matches the same value in the theme Numix-Cinnamon-Semi-Transparent. Changing this value will have no effect on versions of cinnamon prior to 4.6 as the Menu applet previously ignored this value (and set it to 30px regardless) which is probably why it was overlooked.