### PR TITLE
Faience theme: Fix display problem in cinnamenu grid view.

### DIFF
--- a/Faience/files/Faience/cinnamon/cinnamon.css
+++ b/Faience/files/Faience/cinnamon/cinnamon.css
@@ -922,13 +922,11 @@ border-width: 0px;
     padding-bottom: 0px;
 }
 .menu-application-button {
-    min-height: 36px;
-    padding: 0px 7px;
+    padding: 7px 7px;
 }
 .menu-application-button:hover,
 .menu-application-button-selected {
-    min-height: 36px;
-    padding: 0px 7px;
+    padding: 7px 7px;
     background-gradient-start: #5990e1;
     background-gradient-end: #3478db;
     background-gradient-direction: vertical;
@@ -943,17 +941,14 @@ border-width: 0px;
     padding-right: 5px;
 }
 .menu-category-button {
-    min-height: 36px;
-    padding: 0px 7px;
+    padding: 7px 7px;
 }
 .menu-category-button-greyed {
-    min-height: 36px;
-    padding: 0px 7px;
+    padding: 7px 7px;
     color: #aaa;
 }
 .menu-category-button-selected {
-    min-height: 36px;
-    padding: 0px 7px;
+    padding: 7px 7px;
     background-gradient-start: #5990e1;
     background-gradient-end: #3478db;
     background-gradient-direction: vertical;


### PR DESCRIPTION
This fix replaces min-height with vertical padding. It fixes an overlapping icons problem in cinnamenu's grid view.
![Screenshot from 2020-12-03 08-28-56](https://user-images.githubusercontent.com/58893963/100984103-292f2000-3542-11eb-91e5-73d29a25e7c4.png)
