### PR TITLE
[Vivaldi-ZorinOS] Remove height property from #menu-search-entry ...

### DIFF
--- a/Vivaldi-ZorinOS/files/Vivaldi-ZorinOS/cinnamon/cinnamon.css
+++ b/Vivaldi-ZorinOS/files/Vivaldi-ZorinOS/cinnamon/cinnamon.css
@@ -149,7 +149,6 @@ StScrollBar StButton#vhandle:hover
     padding-top: 0px;
     padding-bottom: 0px;
     min-width: 250px;
-    min-height: 80px;
     border-radius: 0px 0px 0px 0px;
     box-shadow: none;
     background-color: rgba(0,0,0,0.9);
@@ -1695,7 +1694,6 @@ border-radius: 1px;
 padding: 5px 6px;
 color: #FFF;
 font: 0.9em;
-height: 18px;
 width: 220px;
 border-image: url("search-entry.png") 6 6 6 6 stretch;
 selected-color: #2DAF01;


### PR DESCRIPTION
to allow for different font sizes.

and remove min-height property from .menu because as far as I can tell, it doesn't serve any purpose? but it does however cause a problem for cinnamenu's context menu.

@freemangilgamesh 