### PR TITLE
[Pragmatic-Darker-Blue]Set reasonable color for use in cinnamenu

### DIFF
--- a/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/cinnamon/cinnamon.css
+++ b/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/cinnamon/cinnamon.css
@@ -976,7 +976,7 @@ StScrollBar {
   .menu-category-button-selected {
     padding: 7px; }
   .menu-category-button-hover {
-    background-color: red;
+    background-color: #383838;
     border-radius: 2px; }
   .menu-category-button-greyed {
     padding: 7px;


### PR DESCRIPTION
This class is not currently used by any other applet and the background-color (red) was copied from a base theme although it was unused.