### PR TITLE
[Faded-Dream] Set color for use in cinnamenu

### DIFF
--- a/Faded-Dream/files/Faded-Dream/cinnamon/cinnamon.css
+++ b/Faded-Dream/files/Faded-Dream/cinnamon/cinnamon.css
@@ -972,7 +972,7 @@ StScrollBar {
     background-color: #5b73c4;
     border: 1px solid #202020; }
   .menu-category-button-hover {
-    background-color: red;
+    background-color: rgba(255,255,255,0.25);
     border-radius: 2px; }
   .menu-category-button-greyed {
     padding: 7px;


### PR DESCRIPTION
Class is not used by any other applet. The previous color is copied unchanged from a base theme.