### PR TITLE
[Carta] Fix for menu applet

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1374,7 +1374,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .menu-application-button {
     padding: 7px;
-    border: 1px solid transparent;
 }
 
 .menu-application-button:highlighted {
@@ -1399,7 +1398,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .menu-category-button {
     padding: 7px;
-    border: 1px solid transparent;
 }
 
 .menu-category-button-selected {


### PR DESCRIPTION
Remove unnecessary border property that is causing the menu category list and menu application list to jump up and down when hovering with the mouse.