### PR TITLE
Remove height property from #menu-search-entry ...

### DIFF
--- a/Vivaldi/files/Vivaldi/cinnamon/cinnamon.css
+++ b/Vivaldi/files/Vivaldi/cinnamon/cinnamon.css
@@ -149,7 +149,6 @@ StScrollBar StButton#vhandle:hover
     padding-top: 0px;
     padding-bottom: 0px;
     min-width: 250px;
-    min-height: 80px;
     border-radius: 0px 0px 0px 0px;
     box-shadow: none;
     background-color: rgba(23,23,23,1);
@@ -1695,7 +1694,6 @@ border-radius: 1px;
 padding: 5px 6px;
 color: #FFF;
 font: 0.9em;
-height: 18px;
 width: 220px;
 border-image: url("search-entry.png") 6 6 6 6 stretch;
 selected-color: #2DAF01;


### PR DESCRIPTION
...to allow for different font sizes in menu applet search box

+ Remove min-height property from .menu class as it seems to serve no purpose but it does however cause a problem in the context menu of Cinnamenu applet.