### PR TITLE
[Windows-10] Fix for menu applet label being covered up

### DIFF
--- a/Windows-10/files/Windows-10/cinnamon/cinnamon.css
+++ b/Windows-10/files/Windows-10/cinnamon/cinnamon.css
@@ -180,7 +180,6 @@ StScrollBar StButton#hhandle:focus {
   padding-top: 0px;
   padding-bottom: 0px;
   min-width: 200px;
-  min-height: 80px;
   border: rgba(50, 50, 50, 0.9);
   border-radius: 0 0 0 0;
   background-color: rgba(25, 25, 25, 0.85);
@@ -381,7 +380,6 @@ StScrollBar StButton#hhandle:focus {
 #panelLeft .applet-box:first-child {
   transition-duration: 300;
   background-size: cover;
-  width: 35px;
   height: 40px;
   color: #ffffff;
 }


### PR DESCRIPTION
Remove fixed width property from panelLeft first-child in cinnamon.css to prevent menu applet label from being covered up by adjoining applets/icons etc.

+ Remove min-height property from .menu class which seems to serve no purpose but which does however cause a problem for cinnamenu's context menu.