### PR TITLE
[Adapta] Fix hover color in .menu-category-button-hover..

### DIFF
--- a/Adapta/files/Adapta/cinnamon/cinnamon.css
+++ b/Adapta/files/Adapta/cinnamon/cinnamon.css
@@ -505,7 +505,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 
 .menu-category-button { padding: 0 7px; border: 1px solid transparent; color: rgba(38, 50, 56, 0.87); }
 
-.menu-category-button-hover, .menu-category-button-selected { padding: 0 7px; border-radius: 2px; border: 1px solid transparent; background-color: rgba(0, 188, 212, 0.12); color: #00BCD4; }
+.menu-category-button-selected { padding: 0 7px; border-radius: 2px; border: 1px solid transparent; background-color: rgba(0, 188, 212, 0.12); color: #00BCD4; }
+
+.menu-category-button-hover { color: #263238; background-color: rgba(38, 50, 56, 0.12); }
 
 .menu-category-button-greyed { padding: 0 7px; border: 1px solid transparent; color: rgba(38, 50, 56, 0.28); }
 


### PR DESCRIPTION
class to match hover color for app buttons and fav buttons. This class is not currently used by any other applet.

@smurphos 