### PR TITLE
[Pragmatic-Darker-Blue] ported gtk-dark from gtk-3.0 to gtk-3.22

### DIFF
--- a/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk-dark.css
+++ b/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk-dark.css
@@ -1,0 +1,3907 @@
+* {
+  background-clip: padding-box;
+  -GtkToolButton-icon-spacing: 4;
+  -GtkTextView-error-underline-color: #FC4138;
+  -GtkScrolledWindow-scrollbar-spacing: 0;
+  -GtkToolItemGroup-expander-size: 11;
+  -GtkWidget-text-handle-width: 20;
+  -GtkWidget-text-handle-height: 20;
+  -GtkDialog-button-spacing: 4;
+  -GtkDialog-action-area-border: 6;
+  outline-color: rgba(218, 218, 218, 0.3);
+  outline-style: dashed;
+  outline-offset: -3px;
+  outline-width: 1px;
+  -gtk-outline-radius: 2px; }
+
+.background {
+  color: #DADADA;
+  background-color: rgba(56, 56, 56, 0.999); }
+
+*:disabled {
+  -gtk-icon-effect: dim; }
+
+.gtkstyle-fallback {
+  background-color: #383838;
+  color: #DADADA; }
+  .gtkstyle-fallback:hover {
+    background-color: #525252;
+    color: #DADADA; }
+  .gtkstyle-fallback:active {
+    background-color: #1f1f1f;
+    color: #DADADA; }
+  .gtkstyle-fallback:disabled {
+    background-color: #3d3d3d;
+    color: rgba(218, 218, 218, 0.55); }
+  .gtkstyle-fallback:selected {
+    background-color: #3770AA;
+    color: #ffffff; }
+
+.view, iconview,
+.view text,
+iconview text,
+textview text {
+  color: #DADADA;
+  background-color: #404040; }
+  .view:selected, iconview:selected, .view:selected:focus, iconview:selected:focus,
+  .view text:selected,
+  iconview text:selected,
+  textview text:selected,
+  .view text:selected:focus,
+  iconview text:selected:focus,
+  textview text:selected:focus {
+    border-radius: 2px; }
+
+textview border {
+  background-color: #3c3c3c; }
+
+rubberband, flowbox rubberband, treeview.view rubberband, .content-view rubberband,
+.rubberband {
+  border: 1px solid #76905b;
+  background-color: rgba(118, 144, 91, 0.2); }
+
+flowbox flowboxchild {
+  padding: 3px;
+  border-radius: 2px; }
+  flowbox flowboxchild:selected {
+    outline-offset: -2px; }
+
+label.separator, popover label.separator,
+popover.background label.separator {
+  color: #DADADA; }
+label selection {
+  color: #ffffff;
+  background-color: #3770AA; }
+label:disabled {
+  color: rgba(218, 218, 218, 0.55); }
+
+.dim-label, label.separator, popover label.separator,
+popover.background label.separator, headerbar .subtitle,
+.titlebar:not(headerbar) .subtitle {
+  opacity: 0.55; }
+
+assistant .sidebar {
+  background-color: #404040;
+  border-top: 1px solid #292929; }
+  assistant .sidebar:dir(ltr) {
+    border-right: 1px solid #292929; }
+  assistant .sidebar:dir(rtl) {
+    border-left: 1px solid #292929; }
+assistant.csd .sidebar {
+  border-top-style: none; }
+assistant .sidebar label {
+  padding: 6px 12px; }
+assistant .sidebar label.highlight {
+  background-color: #3770AA;
+  color: #ffffff; }
+
+textview {
+  background-color: #3c3c3c;
+  color: #DADADA; }
+
+popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
+popover.background.osd,
+popover.background.magnifier, .csd
+popover.background.osd, .csd
+popover.background.magnifier, .osd .scale-popup, .osd {
+  color: #C3C3C3;
+  border: none;
+  background-color: #353535;
+  background-clip: padding-box;
+  box-shadow: none; }
+
+@keyframes spin {
+  to {
+        -gtk-icon-transform: rotate(1turn); } }
+spinner {
+  background-image: none;
+  opacity: 0;
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic"); }
+  spinner:checked {
+    opacity: 1;
+    animation: spin 1s linear infinite; }
+    spinner:checked:disabled {
+      opacity: 0.5; }
+
+entry {
+  border: 1px solid;
+  padding: 5px 8px;
+  caret-color: currentColor;
+  border-radius: 3px;
+  transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  color: #DADADA;
+  border-color: #292929;
+  background-color: #404040; }
+  entry.search {
+    border-radius: 4px; }
+  entry image {
+    color: #bbbbbb; }
+    entry image.left {
+      padding-left: 0;
+      padding-right: 5px; }
+    entry image.right {
+      padding-right: 0;
+      padding-left: 5px; }
+  entry.flat, entry.flat:focus {
+    padding: 2px;
+    color: #DADADA;
+    border-color: #292929;
+    background-color: #404040;
+    border: none;
+    border-radius: 0; }
+  entry:focus {
+    background-clip: padding-box;
+    color: #DADADA;
+    border-color: #3770AA;
+    background-color: #404040; }
+  entry:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    border-color: rgba(41, 41, 41, 0.55);
+    background-color: rgba(64, 64, 64, 0.55); }
+  entry.warning {
+    color: white;
+    border-color: #292929;
+    background-color: #f7ae86; }
+    entry.warning image {
+      color: white; }
+    entry.warning:focus {
+      color: white;
+      background-color: #f27835;
+      box-shadow: none; }
+    entry.warning selection, entry.warning selection:focus {
+      background-color: #525252;
+      color: #f27835; }
+  entry.error {
+    color: white;
+    border-color: #292929;
+    background-color: #fd8d88; }
+    entry.error image {
+      color: white; }
+    entry.error:focus {
+      color: white;
+      background-color: #FC4138;
+      box-shadow: none; }
+    entry.error selection, entry.error selection:focus {
+      background-color: #525252;
+      color: #FC4138; }
+  entry.search-missing {
+    color: white;
+    border-color: #292929;
+    background-color: #fd8d88; }
+    entry.search-missing image {
+      color: white; }
+    entry.search-missing:focus {
+      color: white;
+      background-color: #FC4138;
+      box-shadow: none; }
+    entry.search-missing selection, entry.search-missing selection:focus {
+      background-color: #525252;
+      color: #FC4138; }
+  entry:drop(active):focus, entry:drop(active) {
+    border-color: #f08437;
+    box-shadow: none; }
+  .osd entry {
+    color: #C3C3C3;
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: rgba(109, 109, 109, 0.4); }
+    .osd entry image, .osd entry image:hover {
+      color: inherit; }
+    .osd entry:focus {
+      color: #ffffff;
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: #3770AA; }
+    .osd entry:disabled {
+      color: rgba(195, 195, 195, 0.55);
+      background-color: rgba(109, 109, 109, 0.25); }
+    .osd entry selection:focus, .osd entry selection {
+      color: #3770AA;
+      background-color: #404040; }
+  entry progress {
+    margin: 0 -6px;
+    border-radius: 0;
+    border-width: 0 0 2px;
+    border-color: #3770AA;
+    border-style: solid;
+    background-image: none;
+    background-color: transparent;
+    box-shadow: none; }
+
+treeview entry.flat, treeview entry {
+  border-radius: 0;
+  background-image: none;
+  background-color: #404040; }
+  treeview entry.flat:focus, treeview entry:focus {
+    border-color: #3770AA; }
+
+@keyframes needs_attention {
+  from {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.01, to(#3770AA), to(transparent)); }
+  to {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#3770AA), to(transparent)); } }
+button {
+  min-height: 22px;
+  min-width: 20px;
+  transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  border: 1px solid;
+  border-radius: 3px;
+  padding: 5px 8px;
+  color: #DADADA;
+  outline-color: rgba(218, 218, 218, 0.3);
+  border-color: #292929;
+  background-color: #353535; }
+  button separator {
+    margin: 4px 1px; }
+  button.flat, button.sidebar-button {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none;
+    transition: none; }
+    button.flat:hover, button.sidebar-button:hover {
+      transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+      transition-duration: 350ms; }
+      button.flat:hover:active, button.sidebar-button:hover:active {
+        transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+  button:hover {
+    color: #DADADA;
+    outline-color: rgba(218, 218, 218, 0.3);
+    border-color: #292929;
+    background-color: #525252;
+    -gtk-icon-effect: highlight; }
+  button:active, button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: #292929;
+    background-color: #3770AA;
+    background-clip: padding-box;
+    transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
+  button:active {
+    color: #DADADA; }
+  button:active:hover, button:checked {
+    color: #ffffff; }
+  button.flat:disabled, button.sidebar-button:disabled {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none; }
+  button:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    border-color: rgba(41, 41, 41, 0.55);
+    background-color: rgba(69, 69, 69, 0.55); }
+    button:disabled label {
+      color: inherit; }
+    button:disabled:active, button:disabled:checked {
+      color: rgba(255, 255, 255, 0.8);
+      border-color: rgba(143, 168, 118, 0.75);
+      background-color: rgba(143, 168, 118, 0.75);
+      opacity: 0.6; }
+      button:disabled:active label, button:disabled:checked label {
+        color: inherit; }
+  button.image-button, headerbar button.titlebutton,
+  .titlebar button.titlebutton {
+    min-width: 24px;
+    padding-left: 5px;
+    padding-right: 5px; }
+  button.text-button {
+    padding-left: 12px;
+    padding-right: 12px; }
+  button.text-button.image-button, headerbar button.text-button.titlebutton,
+  .titlebar button.text-button.titlebutton {
+    padding-left: 5px;
+    padding-right: 5px; }
+    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child,
+    .titlebar button.text-button.titlebutton label:first-child {
+      padding-left: 8px;
+      padding-right: 2px; }
+    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child,
+    .titlebar button.text-button.titlebutton label:last-child {
+      padding-right: 8px;
+      padding-left: 2px; }
+    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child,
+    .titlebar button.text-button.titlebutton label:only-child {
+      padding-left: 8px;
+      padding-right: 8px; }
+    button.text-button.image-button.popup, headerbar button.text-button.popup.titlebutton,
+    .titlebar button.text-button.popup.titlebutton {
+      padding-right: 8px;
+      padding-left: 8px; }
+  button:drop(active), combobox:drop(active) button.combo {
+    color: #f08437;
+    border-color: #f08437;
+    box-shadow: none; }
+  button.osd {
+    color: #C3C3C3;
+    outline-color: rgba(195, 195, 195, 0.3);
+    background-color: #353535;
+    border-color: #212121; }
+    button.osd.image-button, headerbar button.osd.titlebutton,
+    .titlebar button.osd.titlebutton {
+      padding: 0;
+      min-height: 36px;
+      min-width: 36px; }
+    button.osd:hover {
+      color: #3770AA; }
+    button.osd:active, button.osd:checked {
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: #3770AA; }
+    button.osd:disabled {
+      color: #606060;
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: rgba(109, 109, 109, 0.25); }
+  .osd button {
+    color: #C3C3C3;
+    outline-color: rgba(195, 195, 195, 0.3);
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: rgba(109, 109, 109, 0.4); }
+    .osd button:hover {
+      color: #C3C3C3;
+      outline-color: rgba(195, 195, 195, 0.3);
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: rgba(127, 127, 127, 0.5); }
+    .osd button:active, .osd button:checked {
+      background-clip: padding-box;
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: #3770AA; }
+    .osd button:disabled {
+      color: #606060;
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: rgba(109, 109, 109, 0.25); }
+    .osd button.flat, .osd button.sidebar-button {
+      border-color: transparent;
+      background-color: transparent;
+      background-image: none;
+      box-shadow: none; }
+      .osd button.flat:hover, .osd button.sidebar-button:hover {
+        color: #C3C3C3;
+        outline-color: rgba(195, 195, 195, 0.3);
+        border-color: rgba(22, 22, 22, 0.4);
+        background-color: rgba(127, 127, 127, 0.5); }
+      .osd button.flat:disabled, .osd button.sidebar-button:disabled {
+        color: #606060;
+        border-color: rgba(22, 22, 22, 0.4);
+        background-color: rgba(109, 109, 109, 0.25);
+        background-image: none; }
+      .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
+        color: #ffffff;
+        outline-color: rgba(255, 255, 255, 0.3);
+        border-color: rgba(22, 22, 22, 0.4);
+        background-color: #3770AA; }
+  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child), .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
+    box-shadow: none; }
+  button.suggested-action {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #6db442;
+    border-color: #6db442; }
+    button.suggested-action.flat, button.suggested-action.sidebar-button {
+      border-color: transparent;
+      background-color: transparent;
+      background-image: none;
+      color: #6db442;
+      outline-color: rgba(109, 180, 66, 0.3); }
+    button.suggested-action:hover {
+      background-clip: padding-box;
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      background-color: #88c663;
+      border-color: #88c663; }
+    button.suggested-action:active, button.suggested-action:checked {
+      background-clip: padding-box;
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      background-color: #568f34;
+      border-color: #568f34; }
+    button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
+      border-color: transparent;
+      background-color: transparent;
+      background-image: none;
+      color: rgba(218, 218, 218, 0.55); }
+    button.suggested-action:disabled {
+      color: rgba(218, 218, 218, 0.55);
+      border-color: rgba(41, 41, 41, 0.55);
+      background-color: rgba(69, 69, 69, 0.55); }
+      button.suggested-action:disabled label {
+        color: inherit; }
+  button.destructive-action {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #F04A50;
+    border-color: #F04A50; }
+    button.destructive-action.flat, button.destructive-action.sidebar-button {
+      border-color: transparent;
+      background-color: transparent;
+      background-image: none;
+      color: #F04A50;
+      outline-color: rgba(240, 74, 80, 0.3); }
+    button.destructive-action:hover {
+      background-clip: padding-box;
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      background-color: #f4797e;
+      border-color: #f4797e; }
+    button.destructive-action:active, button.destructive-action:checked {
+      background-clip: padding-box;
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      background-color: #ec1b22;
+      border-color: #ec1b22; }
+    button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
+      border-color: transparent;
+      background-color: transparent;
+      background-image: none;
+      color: rgba(218, 218, 218, 0.55); }
+    button.destructive-action:disabled {
+      color: rgba(218, 218, 218, 0.55);
+      border-color: rgba(41, 41, 41, 0.55);
+      background-color: rgba(69, 69, 69, 0.55); }
+      button.destructive-action:disabled label {
+        color: inherit; }
+  .stack-switcher > button {
+    outline-offset: -3px; }
+    .stack-switcher > button > label {
+      padding-left: 6px;
+      padding-right: 6px; }
+    .stack-switcher > button > image {
+      padding-left: 6px;
+      padding-right: 6px;
+      padding-top: 3px;
+      padding-bottom: 3px; }
+    .stack-switcher > button.text-button {
+      padding-left: 10px;
+      padding-right: 10px; }
+    .stack-switcher > button.image-button, headerbar .stack-switcher > button.titlebutton,
+    .titlebar .stack-switcher > button.titlebutton {
+      padding-left: 2px;
+      padding-right: 2px; }
+    .stack-switcher > button.needs-attention:active > label, .stack-switcher > button.needs-attention:active > image, .stack-switcher > button.needs-attention:checked > label, .stack-switcher > button.needs-attention:checked > image {
+      animation: none;
+      background-image: none; }
+  .stack-switcher > button.needs-attention > label, .stack-switcher > button.needs-attention > image, button stacksidebar row.needs-attention > label, stacksidebar button row.needs-attention > label {
+    animation: needs_attention 150ms ease-in;
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#3770AA), to(transparent));
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+    background-position: right 3px, right 2px; }
+    .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
+      background-position: left 3px, left 2px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
+  .inline-toolbar button, .inline-toolbar button:backdrop {
+    border-radius: 2px;
+    border-width: 1px; }
+
+.inline-toolbar toolbutton > button {
+  color: #DADADA;
+  outline-color: rgba(218, 218, 218, 0.3);
+  border-color: #292929;
+  background-color: #353535; }
+  .inline-toolbar toolbutton > button:hover {
+    color: #DADADA;
+    outline-color: rgba(218, 218, 218, 0.3);
+    border-color: #292929;
+    background-color: #525252; }
+  .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: #292929;
+    background-color: #3770AA; }
+  .inline-toolbar toolbutton > button:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    border-color: rgba(41, 41, 41, 0.55);
+    background-color: rgba(69, 69, 69, 0.55); }
+    .inline-toolbar toolbutton > button:disabled label {
+      color: inherit; }
+  .inline-toolbar toolbutton > button:disabled:active, .inline-toolbar toolbutton > button:disabled:checked {
+    color: rgba(255, 255, 255, 0.8);
+    border-color: rgba(143, 168, 118, 0.75);
+    background-color: rgba(143, 168, 118, 0.75);
+    opacity: 0.6; }
+    .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
+      color: inherit; }
+
+toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry, .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button, .linked:not(.vertical) > button:hover, .linked:not(.vertical) > button:active, .linked:not(.vertical) > button:checked, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
+.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
+.primary-toolbar .linked:not(.vertical).path-bar > button,
+headerbar .linked:not(.vertical).path-bar > button,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
+.primary-toolbar .linked:not(.vertical).path-bar > button:hover,
+headerbar .linked:not(.vertical).path-bar > button:hover,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
+.primary-toolbar .linked:not(.vertical).path-bar > button:active,
+headerbar .linked:not(.vertical).path-bar > button:active,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
+.primary-toolbar .linked:not(.vertical).path-bar > button:checked,
+headerbar .linked:not(.vertical).path-bar > button:checked,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
+.primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
+headerbar .linked:not(.vertical).path-bar > button:disabled,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl) {
+  border-radius: 0;
+  border-right-style: none; }
+
+.linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, toolbar.inline-toolbar toolbutton:first-child > button.sidebar-button, .inline-toolbar toolbutton:first-child > button.sidebar-button, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > combobox:first-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
+.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
+.primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
+headerbar .linked:not(.vertical).path-bar > button:first-child,
+headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
+headerbar .linked:not(.vertical).path-bar > button:first-child:active,
+headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
+headerbar .linked:not(.vertical).path-bar > button:first-child:disabled,
+.primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px; }
+.linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, toolbar.inline-toolbar toolbutton:last-child > button.sidebar-button, .inline-toolbar toolbutton:last-child > button.sidebar-button, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > combobox:last-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
+.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
+.primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
+headerbar .linked:not(.vertical).path-bar > button:last-child,
+headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
+headerbar .linked:not(.vertical).path-bar > button:last-child:active,
+headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
+headerbar .linked:not(.vertical).path-bar > button:last-child:disabled,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-right-style: solid; }
+.linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, toolbar.inline-toolbar toolbutton:only-child > button.sidebar-button, .inline-toolbar toolbutton:only-child > button.sidebar-button, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > combobox:only-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
+.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
+.primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
+headerbar .linked:not(.vertical).path-bar > button:only-child,
+headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
+headerbar .linked:not(.vertical).path-bar > button:only-child:active,
+headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
+headerbar .linked:not(.vertical).path-bar > button:only-child:disabled,
+.primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled {
+  border-radius: 3px;
+  border-style: solid; }
+
+.linked.vertical > entry, .linked.vertical > entry:focus, .linked.vertical > button, .linked.vertical > button:hover, .linked.vertical > button:active, .linked.vertical > button:checked, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > combobox > box > button.combo {
+  border-radius: 0;
+  border-bottom-style: none; }
+
+.linked.vertical > entry:first-child, .linked.vertical > button:first-child, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > combobox:first-child > box > button.combo {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px; }
+.linked.vertical > entry:last-child, .linked.vertical > button:last-child, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > combobox:last-child > box > button.combo {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-bottom-style: solid; }
+.linked.vertical > entry:only-child, .linked.vertical > button:only-child, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > combobox:only-child > box > button.combo {
+  border-radius: 3px;
+  border-style: solid; }
+
+menuitem.button.flat,
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+  border-color: transparent;
+  background-color: transparent;
+  background-image: none;
+  box-shadow: none; }
+
+menuitem.button.flat,
+modelbutton.flat {
+  transition: none;
+  min-height: 24px;
+  padding-left: 8px;
+  padding-right: 8px;
+  outline-offset: -3px;
+  border-radius: 2px; }
+  menuitem.button.flat:hover,
+  modelbutton.flat:hover {
+    background-color: #484848; }
+  menuitem.button.flat:checked,
+  modelbutton.flat:checked {
+    color: #DADADA; }
+  menuitem.button.flat check:last-child,
+  menuitem.button.flat radio:last-child,
+  modelbutton.flat check:last-child,
+  modelbutton.flat radio:last-child {
+    margin-left: 8px; }
+  menuitem.button.flat check:first-child,
+  menuitem.button.flat radio:first-child,
+  modelbutton.flat check:first-child,
+  modelbutton.flat radio:first-child {
+    margin-right: 8px; }
+
+modelbutton.flat arrow.left {
+  -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+modelbutton.flat arrow.right {
+  -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+
+*:link, button:link, button:visited {
+  color: #75a3d2; }
+  *:link:visited, button:visited {
+    color: #4e89c6; }
+    *:selected *:link:visited, *:selected button:visited:link, *:selected button:visited {
+      color: #afc6dd; }
+  *:link:hover, button:hover:link, button:hover:visited {
+    color: #9bbddf; }
+    *:selected *:link:hover, *:selected button:hover:link, *:selected button:hover:visited {
+      color: #ebf1f7; }
+  *:link:active, button:active:link, button:active:visited {
+    color: #75a3d2; }
+    *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
+      color: #d7e2ee; }
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, *:selected *:link, *:selected button:link, *:selected button:visited {
+    color: #d7e2ee; }
+
+button:link > label, button:visited > label {
+  text-decoration-line: underline; }
+
+spinbutton:drop(active) {
+  box-shadow: none; }
+spinbutton button:active {
+  color: #ffffff; }
+spinbutton:disabled {
+  color: rgba(218, 218, 218, 0.55); }
+spinbutton:not(.vertical) entry {
+  min-width: 28px; }
+spinbutton:not(.vertical):dir(ltr) entry, spinbutton:not(.vertical):dir(rtl) button.up {
+  border-radius: 3px 0 0 3px; }
+spinbutton:not(.vertical) > button + button {
+  border-left-style: none; }
+spinbutton:not(.vertical) > button + button,
+spinbutton:not(.vertical) > button:hover:not(:active),
+spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 #cfcfcf; }
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(207, 207, 207, 0.5); }
+spinbutton:not(.vertical) > button:first-child:hover:not(:active),
+spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
+spinbutton:not(.vertical) > entry + button:not(:active):hover {
+  box-shadow: none; }
+spinbutton:not(.vertical) > entry:focus + button {
+  border-left-color: #3770AA; }
+spinbutton:not(.vertical) > entry:drop(active) + button {
+  border-left-color: #f08437; }
+.osd spinbutton:not(.vertical) > button:hover:not(:active),
+.osd spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(38, 38, 38, 0.4); }
+.osd spinbutton:not(.vertical) > button:first-child:hover:not(:active),
+.osd spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
+.osd spinbutton:not(.vertical) > entry + button:not(:active):hover {
+  box-shadow: none; }
+.osd spinbutton:not(.vertical) > entry:focus + button {
+  border-left-color: rgba(38, 38, 38, 0.4); }
+spinbutton.vertical button, spinbutton.vertical entry {
+  padding-left: 4px;
+  padding-right: 4px;
+  min-width: 0; }
+spinbutton.vertical button.up {
+  border-radius: 3px 3px 0 0; }
+spinbutton.vertical > entry:focus + button {
+  border-top-color: #3770AA; }
+spinbutton.vertical > entry:drop(active) + button {
+  border-top-color: #f08437; }
+
+combobox button.combo {
+  padding-top: 3px;
+  padding-bottom: 3px; }
+combobox arrow {
+  -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+  min-height: 16px;
+  min-width: 16px; }
+
+toolbar, .inline-toolbar {
+  -GtkWidget-window-dragging: true;
+  padding: 4px;
+  background-color: #383838; }
+  toolbar separator, .inline-toolbar separator {
+    background: none; }
+  toolbar.horizontal separator, .horizontal.inline-toolbar separator {
+    margin: 0 6px; }
+  toolbar.vertical separator, .vertical.inline-toolbar separator {
+    margin: 6px 0; }
+  .osd toolbar, .osd .inline-toolbar {
+    background-color: transparent; }
+  toolbar.osd, .osd.inline-toolbar {
+    padding: 7px;
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    border-radius: 3px;
+    background-color: rgba(53, 53, 53, 0.9); }
+    toolbar.osd.left, .osd.left.inline-toolbar, toolbar.osd.right, .osd.right.inline-toolbar, toolbar.osd.top, .osd.top.inline-toolbar, toolbar.osd.bottom, .osd.bottom.inline-toolbar {
+      border-radius: 0; }
+    toolbar.osd.top, .osd.top.inline-toolbar {
+      border-width: 0 0 1px 0; }
+    toolbar.osd.bottom, .osd.bottom.inline-toolbar {
+      border-width: 1px 0 0 0; }
+    toolbar.osd.left, .osd.left.inline-toolbar {
+      border-width: 0 1px 0 0; }
+    toolbar.osd.right, .osd.right.inline-toolbar {
+      border-width: 0 0 0 1px; }
+  toolbar:not(.inline-toolbar) switch, .inline-toolbar:not(.inline-toolbar) switch,
+  toolbar:not(.inline-toolbar) scale,
+  .inline-toolbar:not(.inline-toolbar) scale,
+  toolbar:not(.inline-toolbar) entry,
+  .inline-toolbar:not(.inline-toolbar) entry,
+  toolbar:not(.inline-toolbar) spinbutton,
+  .inline-toolbar:not(.inline-toolbar) spinbutton,
+  toolbar:not(.inline-toolbar) button,
+  .inline-toolbar:not(.inline-toolbar) button {
+    margin-right: 1px;
+    margin-bottom: 1px; }
+  toolbar:not(.inline-toolbar) .linked > button, .inline-toolbar:not(.inline-toolbar) .linked > button,
+  toolbar:not(.inline-toolbar) .linked > entry,
+  .inline-toolbar:not(.inline-toolbar) .linked > entry {
+    margin-right: 0; }
+
+.primary-toolbar toolbar, .primary-toolbar .inline-toolbar,
+.primary-toolbar:not(.libreoffice-toolbar) {
+  color: #ded6d6;
+  background-color: #2f2f2f;
+  box-shadow: none;
+  border-width: 0 0 1px 0;
+  border-style: solid;
+  border-image: linear-gradient(to bottom, #2f2f2f, #1d1d1d) 1 0 1 0; }
+
+.inline-toolbar {
+  background-color: #303030;
+  border-style: solid;
+  border-color: #292929;
+  border-width: 0 1px 1px;
+  padding: 3px;
+  border-radius: 0  0 3px 3px; }
+
+searchbar {
+  background-color: #383838;
+  border-style: solid;
+  border-color: #292929;
+  border-width: 0 0 1px;
+  padding: 3px; }
+
+actionbar {
+  padding: 6px;
+  border-top: 1px solid #292929;
+  background-color: #303030; }
+
+headerbar,
+.titlebar:not(headerbar) {
+  min-height: 42px;
+  padding: 0 7px;
+  border-width: 0 0 1px;
+  border-style: solid;
+  border-radius: 0;
+  border-color: #252525;
+  color: #ded6d6;
+  background-color: #2f2f2f; }
+  .csd headerbar, .csd
+  .titlebar:not(headerbar) {
+    background-color: #2f2f2f;
+    border-color: #252525; }
+  headerbar:backdrop,
+  .titlebar:backdrop:not(headerbar) {
+    color: rgba(222, 214, 214, 0.7); }
+  headerbar .title,
+  .titlebar:not(headerbar) .title {
+    padding-left: 12px;
+    padding-right: 12px; }
+  headerbar .subtitle,
+  .titlebar:not(headerbar) .subtitle {
+    font-size: smaller;
+    padding-left: 12px;
+    padding-right: 12px; }
+  headerbar.selection-mode,
+  .selection-mode.titlebar:not(headerbar) {
+    color: #ffffff;
+    background-color: #3770AA;
+    border-color: #85a06a;
+    box-shadow: none; }
+    headerbar.selection-mode:backdrop,
+    .selection-mode.titlebar:backdrop:not(headerbar) {
+      background-color: #3770AA;
+      color: rgba(255, 255, 255, 0.6); }
+    headerbar.selection-mode button,
+    .selection-mode.titlebar:not(headerbar) button {
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      background-color: rgba(64, 64, 64, 0);
+      border-color: rgba(255, 255, 255, 0); }
+      headerbar.selection-mode button.flat, headerbar.selection-mode button.sidebar-button,
+      .selection-mode.titlebar:not(headerbar) button.flat,
+      .selection-mode.titlebar:not(headerbar) button.sidebar-button {
+        border-color: transparent;
+        background-color: transparent;
+        background-image: none;
+        color: #ffffff;
+        background-color: rgba(64, 64, 64, 0); }
+      headerbar.selection-mode button:hover,
+      .selection-mode.titlebar:not(headerbar) button:hover {
+        color: #ffffff;
+        outline-color: rgba(255, 255, 255, 0.3);
+        background-color: rgba(255, 255, 255, 0.05);
+        border-color: rgba(255, 255, 255, 0.5); }
+      headerbar.selection-mode button:active, headerbar.selection-mode button:checked,
+      .selection-mode.titlebar:not(headerbar) button:active,
+      .selection-mode.titlebar:not(headerbar) button:checked {
+        color: #3770AA;
+        outline-color: rgba(143, 168, 118, 0.3);
+        background-color: #404040;
+        border-color: #404040; }
+      headerbar.selection-mode button:disabled,
+      .selection-mode.titlebar:not(headerbar) button:disabled {
+        color: rgba(255, 255, 255, 0.4);
+        background-color: rgba(64, 64, 64, 0);
+        border-color: rgba(255, 255, 255, 0); }
+        headerbar.selection-mode button:disabled:active, headerbar.selection-mode button:disabled:checked,
+        .selection-mode.titlebar:not(headerbar) button:disabled:active,
+        .selection-mode.titlebar:not(headerbar) button:disabled:checked {
+          color: rgba(55, 112, 170, 0.4);
+          background-color: rgba(255, 255, 255, 0.15);
+          border-color: rgba(255, 255, 255, 0.15); }
+    headerbar.selection-mode .selection-menu,
+    .selection-mode.titlebar:not(headerbar) .selection-menu {
+      box-shadow: none;
+      padding-left: 10px;
+      padding-right: 10px; }
+      headerbar.selection-mode .selection-menu GtkArrow,
+      .selection-mode.titlebar:not(headerbar) .selection-menu GtkArrow {
+        -GtkArrow-arrow-scaling: 1; }
+      headerbar.selection-mode .selection-menu .arrow,
+      .selection-mode.titlebar:not(headerbar) .selection-menu .arrow {
+        -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+    .maximized headerbar.selection-mode, .maximized
+    .selection-mode.titlebar:not(headerbar) {
+      background-color: #3770aa; }
+  .tiled headerbar, .tiled headerbar:backdrop, .maximized headerbar, .maximized headerbar:backdrop, .tiled
+  .titlebar:not(headerbar), .tiled
+  .titlebar:backdrop:not(headerbar), .maximized
+  .titlebar:not(headerbar), .maximized
+  .titlebar:backdrop:not(headerbar) {
+    border-radius: 0; }
+  .maximized headerbar, .maximized
+  .titlebar:not(headerbar) {
+    background-color: #2f2f2f;
+    border-color: #252525; }
+  headerbar.default-decoration, .csd headerbar.default-decoration, headerbar.default-decoration:backdrop, .csd headerbar.default-decoration:backdrop,
+  .default-decoration.titlebar:not(headerbar), .csd
+  .default-decoration.titlebar:not(headerbar),
+  .default-decoration.titlebar:backdrop:not(headerbar), .csd
+  .default-decoration.titlebar:backdrop:not(headerbar) {
+    min-height: 28px;
+    padding: 0 3px;
+    background-color: #2f2f2f;
+    border-bottom-width: 0; }
+    .maximized headerbar.default-decoration, .maximized .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized .csd headerbar.default-decoration:backdrop, .maximized
+    .default-decoration.titlebar:not(headerbar), .maximized .csd
+    .default-decoration.titlebar:not(headerbar), .maximized
+    .default-decoration.titlebar:backdrop:not(headerbar), .maximized .csd
+    .default-decoration.titlebar:backdrop:not(headerbar) {
+      background-color: #2f2f2f; }
+
+.titlebar {
+  border-radius: 3px 3px 0 0; }
+
+headerbar entry, headerbar button, headerbar separator {
+  margin-top: 6px;
+  margin-bottom: 6px; }
+separator:first-child + headerbar, separator:first-child + headerbar:backdrop, headerbar:first-child, headerbar:first-child:backdrop {
+  border-top-left-radius: 3px; }
+  .maximized separator:first-child + headerbar, .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop, .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child, .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop, .tiled headerbar:first-child:backdrop {
+    border-radius: 0; }
+headerbar:last-child, headerbar:last-child:backdrop {
+  border-top-right-radius: 3px; }
+  .maximized headerbar:last-child, .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop, .tiled headerbar:last-child:backdrop {
+    border-radius: 0; }
+
+window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop, window.csd > .titlebar:not(headerbar), window.csd > .titlebar:not(headerbar):backdrop {
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none; }
+.titlebar:not(headerbar) > separator {
+  background-image: linear-gradient(to bottom, #252525, #252525); }
+
+.primary-toolbar toolbar separator, .primary-toolbar .inline-toolbar separator,
+.primary-toolbar:not(.libreoffice-toolbar) separator {
+  min-width: 1px;
+  min-height: 1px;
+  border-width: 0 1px;
+  border-image: linear-gradient(to bottom, rgba(222, 214, 214, 0) 25%, rgba(222, 214, 214, 0.35) 25%, rgba(222, 214, 214, 0.35) 75%, rgba(222, 214, 214, 0) 75%) 0 1/0 1px stretch; }
+  .primary-toolbar toolbar separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop,
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop {
+    opacity: 0.6; }
+
+.primary-toolbar entry, headerbar entry {
+  color: #ded6d6;
+  border-color: rgba(16, 16, 16, 0.4);
+  background-color: rgba(103, 103, 103, 0.4); }
+  .primary-toolbar entry image, headerbar entry image,
+  .primary-toolbar entry image:hover, headerbar entry image:hover {
+    color: inherit; }
+  .primary-toolbar entry:backdrop, headerbar entry:backdrop {
+    opacity: 0.85; }
+  .primary-toolbar entry:focus, headerbar entry:focus {
+    color: #ded6d6;
+    border-color: #3770AA;
+    background-color: rgba(103, 103, 103, 0.4);
+    background-clip: padding-box; }
+    .primary-toolbar entry:focus image, headerbar entry:focus image {
+      color: rgba(222, 214, 214, 0.85); }
+  .primary-toolbar entry:disabled, headerbar entry:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(103, 103, 103, 0.25); }
+  .primary-toolbar entry selection:focus, headerbar entry selection:focus {
+    background-color: #3770AA;
+    color: #ffffff; }
+  .primary-toolbar entry progress, headerbar entry progress {
+    border-color: #3770AA;
+    background-image: none;
+    background-color: transparent; }
+  .primary-toolbar entry.warning, headerbar entry.warning {
+    color: white;
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: #a45b33; }
+    .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
+      color: white;
+      background-color: #f27835; }
+    .primary-toolbar entry.warning selection, headerbar entry.warning selection,
+    .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
+      background-color: #525252;
+      color: #f27835; }
+  .primary-toolbar entry.error, headerbar entry.error {
+    color: white;
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: #aa3a34; }
+    .primary-toolbar entry.error:focus, headerbar entry.error:focus {
+      color: white;
+      background-color: #FC4138; }
+    .primary-toolbar entry.error selection, headerbar entry.error selection,
+    .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
+      background-color: #525252;
+      color: #FC4138; }
+.primary-toolbar button, headerbar button {
+  color: #ded6d6;
+  outline-color: rgba(222, 214, 214, 0.3);
+  outline-offset: -3px;
+  background-color: rgba(47, 47, 47, 0);
+  border-color: rgba(47, 47, 47, 0); }
+  .primary-toolbar button:backdrop, headerbar button:backdrop {
+    opacity: 0.7; }
+  .primary-toolbar button:hover, headerbar button:hover {
+    color: #ded6d6;
+    outline-color: rgba(222, 214, 214, 0.3);
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: rgba(103, 103, 103, 0.4); }
+  .primary-toolbar button:active, headerbar button:active,
+  .primary-toolbar button:checked, headerbar button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: transparent;
+    background-color: #3770AA;
+    background-clip: padding-box; }
+  .primary-toolbar button:disabled, headerbar button:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(47, 47, 47, 0);
+    border-color: rgba(47, 47, 47, 0); }
+    .primary-toolbar button:disabled label, headerbar button:disabled label {
+      color: inherit; }
+  .primary-toolbar button:disabled:active, headerbar button:disabled:active,
+  .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
+    color: rgba(255, 255, 255, 0.75);
+    border-color: rgba(143, 168, 118, 0.65);
+    background-color: rgba(143, 168, 118, 0.65); }
+.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button,
+.selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat,
+.selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat, .primary-toolbar toolbar.selection-mode button.sidebar-button, .primary-toolbar .selection-mode.inline-toolbar button.sidebar-button,
+.selection-mode.primary-toolbar button.sidebar-button, headerbar.selection-mode button.sidebar-button {
+  border-color: transparent;
+  background-color: transparent;
+  background-image: none;
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0); }
+.primary-toolbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child), headerbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child) {
+  margin-right: 1px; }
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:hover,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, headerbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:active,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:active, headerbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:checked,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, headerbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked:not(.vertical):not(.path-bar) > button:disabled {
+  border-radius: 3px;
+  border-style: solid; }
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: none; }
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
+.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
+.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
+.primary-toolbar .linked:not(.vertical).path-bar > button,
+headerbar .linked:not(.vertical).path-bar > button {
+  color: #ded6d6;
+  outline-color: rgba(222, 214, 214, 0.3);
+  border-color: rgba(16, 16, 16, 0.4);
+  background-color: rgba(103, 103, 103, 0.4); }
+  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
+  .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
+  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
+  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:hover,
+  .primary-toolbar .linked:not(.vertical).path-bar > button:hover,
+  headerbar .linked:not(.vertical).path-bar > button:hover {
+    background-color: rgba(141, 141, 141, 0.4); }
+  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active,
+  .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
+  .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
+  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
+  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:active,
+  .primary-toolbar .linked:not(.vertical).path-bar > button:active,
+  headerbar .linked:not(.vertical).path-bar > button:active,
+  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
+  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:checked,
+  .primary-toolbar .linked:not(.vertical).path-bar > button:checked,
+  headerbar .linked:not(.vertical).path-bar > button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: transparent;
+    background-color: #3770AA; }
+  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
+  .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
+  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
+  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:disabled,
+  .primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
+  headerbar .linked:not(.vertical).path-bar > button:disabled {
+    color: rgba(222, 214, 214, 0.6); }
+.primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
+  box-shadow: none; }
+  .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
+    color: #ded6d6;
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: rgba(103, 103, 103, 0.4);
+    background-clip: padding-box; }
+    .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image,
+    .primary-toolbar .linked:not(.vertical) entry:focus image:hover, headerbar .linked:not(.vertical) entry:focus image:hover {
+      color: inherit; }
+  .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
+    color: #ded6d6;
+    outline-color: rgba(222, 214, 214, 0.3);
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: rgba(103, 103, 103, 0.4); }
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover {
+      background-color: rgba(141, 141, 141, 0.4); }
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      border-color: transparent;
+      background-color: #3770AA; }
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
+      color: rgba(222, 214, 214, 0.6);
+      background-color: rgba(103, 103, 103, 0.2);
+      border-color: rgba(16, 16, 16, 0.4); }
+      .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled:checked, headerbar .linked:not(.vertical) entry + button:last-child:disabled:checked {
+        background-color: rgba(143, 168, 118, 0.65);
+        color: rgba(255, 255, 255, 0.75); }
+.primary-toolbar button.suggested-action, headerbar button.suggested-action {
+  background-clip: border-box;
+  color: #ffffff;
+  outline-color: rgba(255, 255, 255, 0.3);
+  background-color: #6db442;
+  border-color: #6db442; }
+  .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat,
+  .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none;
+    color: #6db442;
+    outline-color: rgba(109, 180, 66, 0.3); }
+  .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #88c663;
+    border-color: #88c663; }
+  .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active,
+  .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #568f34;
+    border-color: #568f34; }
+  .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled,
+  .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled,
+  .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(47, 47, 47, 0);
+    border-color: rgba(47, 47, 47, 0); }
+    .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label,
+    .primary-toolbar button.suggested-action.sidebar-button:disabled label, headerbar button.suggested-action.sidebar-button:disabled label,
+    .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+      color: inherit; }
+.primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop,
+.primary-toolbar button.suggested-action:backdrop,
+headerbar button.suggested-action:backdrop {
+  opacity: 0.8; }
+.primary-toolbar button.destructive-action, headerbar button.destructive-action {
+  background-clip: border-box;
+  color: #ffffff;
+  outline-color: rgba(255, 255, 255, 0.3);
+  background-color: #F04A50;
+  border-color: #F04A50; }
+  .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat,
+  .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none;
+    color: #F04A50;
+    outline-color: rgba(240, 74, 80, 0.3); }
+  .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #f4797e;
+    border-color: #f4797e; }
+  .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active,
+  .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #ec1b22;
+    border-color: #ec1b22; }
+  .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled,
+  .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled,
+  .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(47, 47, 47, 0);
+    border-color: rgba(47, 47, 47, 0); }
+    .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label,
+    .primary-toolbar button.destructive-action.sidebar-button:disabled label, headerbar button.destructive-action.sidebar-button:disabled label,
+    .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+      color: inherit; }
+.primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop,
+.primary-toolbar button.destructive-action:backdrop,
+headerbar button.destructive-action:backdrop {
+  opacity: 0.8; }
+.primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
+  color: #ffffff; }
+  .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: transparent; }
+  .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
+    color: rgba(255, 255, 255, 0.4); }
+.primary-toolbar spinbutton button, headerbar spinbutton button {
+  color: #ded6d6; }
+  .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
+    background-color: rgba(222, 214, 214, 0.25);
+    border-color: transparent; }
+  .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
+    color: rgba(222, 214, 214, 0.7); }
+  .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
+    background-color: rgba(0, 0, 0, 0.1); }
+.primary-toolbar combobox:disabled, headerbar combobox:disabled {
+  color: rgba(222, 214, 214, 0.4); }
+.primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
+  color: #ded6d6;
+  border-color: rgba(16, 16, 16, 0.4);
+  background-color: rgba(103, 103, 103, 0.4); }
+  .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image,
+  .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
+    color: inherit; }
+  .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
+    color: #ded6d6;
+    border-color: #3770AA;
+    background-color: rgba(103, 103, 103, 0.4);
+    box-shadow: none; }
+  .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(103, 103, 103, 0.25); }
+.primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
+  border-right-style: none; }
+  .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
+    box-shadow: none; }
+.primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
+  border-left-style: none; }
+  .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
+    box-shadow: none; }
+.primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr),
+.primary-toolbar combobox > .linked > button.combo:dir(ltr):hover, headerbar combobox > .linked > button.combo:dir(ltr):hover,
+.primary-toolbar combobox > .linked > button.combo:dir(ltr):active, headerbar combobox > .linked > button.combo:dir(ltr):active,
+.primary-toolbar combobox > .linked > button.combo:dir(ltr):checked, headerbar combobox > .linked > button.combo:dir(ltr):checked,
+.primary-toolbar combobox > .linked > button.combo:dir(ltr):disabled, headerbar combobox > .linked > button.combo:dir(ltr):disabled {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl),
+.primary-toolbar combobox > .linked > button.combo:dir(rtl):hover, headerbar combobox > .linked > button.combo:dir(rtl):hover,
+.primary-toolbar combobox > .linked > button.combo:dir(rtl):active, headerbar combobox > .linked > button.combo:dir(rtl):active,
+.primary-toolbar combobox > .linked > button.combo:dir(rtl):checked, headerbar combobox > .linked > button.combo:dir(rtl):checked,
+.primary-toolbar combobox > .linked > button.combo:dir(rtl):disabled, headerbar combobox > .linked > button.combo:dir(rtl):disabled {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.primary-toolbar switch:backdrop, headerbar switch:backdrop {
+  opacity: 0.75; }
+.primary-toolbar progressbar trough, headerbar progressbar trough {
+  background-color: rgba(16, 16, 16, 0.4); }
+.primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
+  opacity: 0.75; }
+.primary-toolbar scale:backdrop, headerbar scale:backdrop {
+  opacity: 0.75; }
+.primary-toolbar scale slider, headerbar scale slider {
+  background-color: #494949;
+  border-color: rgba(16, 16, 16, 0.7); }
+  .primary-toolbar scale slider:hover, headerbar scale slider:hover {
+    background-color: #555555;
+    border-color: rgba(16, 16, 16, 0.7); }
+  .primary-toolbar scale slider:active, headerbar scale slider:active {
+    background-color: #3770AA;
+    border-color: #3770AA; }
+  .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
+    background-color: #414141;
+    border-color: rgba(16, 16, 16, 0.7); }
+.primary-toolbar scale trough, headerbar scale trough {
+  background-color: rgba(16, 16, 16, 0.4); }
+  .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
+    background-color: rgba(16, 16, 16, 0.3); }
+
+.path-bar button.text-button, .path-bar button.image-button, .path-bar headerbar button.titlebutton, headerbar .path-bar button.titlebutton,
+.path-bar .titlebar button.titlebutton,
+.titlebar .path-bar button.titlebutton, .path-bar button {
+  padding-left: 6px;
+  padding-right: 6px; }
+.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label,
+.path-bar .titlebar button.text-button.titlebutton label,
+.titlebar .path-bar button.text-button.titlebutton label {
+  padding-left: 0;
+  padding-right: 0; }
+.path-bar button.text-button.image-button label:last-child, .path-bar headerbar button.text-button.titlebutton label:last-child, headerbar .path-bar button.text-button.titlebutton label:last-child,
+.path-bar .titlebar button.text-button.titlebutton label:last-child,
+.titlebar .path-bar button.text-button.titlebutton label:last-child, .path-bar button label:last-child {
+  padding-right: 10px; }
+.path-bar button.text-button.image-button label:first-child, .path-bar headerbar button.text-button.titlebutton label:first-child, headerbar .path-bar button.text-button.titlebutton label:first-child,
+.path-bar .titlebar button.text-button.titlebutton label:first-child,
+.titlebar .path-bar button.text-button.titlebutton label:first-child, .path-bar button label:first-child {
+  padding-left: 10px; }
+.path-bar button.slider-button, .path-bar button:not(.image-button):not(.text-button) {
+  padding-left: 1px;
+  padding-right: 1px; }
+.path-bar button image {
+  padding-left: 4px;
+  padding-right: 4px; }
+
+treeview.view {
+  border-left-color: rgba(218, 218, 218, 0.15);
+  border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
+  treeview.view acceleditor > label {
+    background-color: #3770AA; }
+  treeview.view:selected, treeview.view:selected:focus {
+    border-radius: 0;
+    border-left-color: #9bb8d5;
+    border-top-color: rgba(218, 218, 218, 0.1); }
+  treeview.view:disabled {
+    color: rgba(218, 218, 218, 0.55); }
+    treeview.view:disabled:selected {
+      color: #c2d4b0; }
+  treeview.view.separator {
+    min-height: 2px;
+    color: rgba(0, 0, 0, 0.1); }
+  treeview.view:drop(active) {
+    border-style: solid none;
+    border-width: 1px;
+    border-color: #728163; }
+    treeview.view:drop(active).after {
+      border-top-style: none; }
+    treeview.view:drop(active).before {
+      border-bottom-style: none; }
+  treeview.view.expander {
+    -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
+    color: #8d8d8d; }
+    treeview.view.expander:dir(rtl) {
+      -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+    treeview.view.expander:hover {
+      color: #DADADA; }
+    treeview.view.expander:selected {
+      color: #dde5d6; }
+      treeview.view.expander:selected:hover {
+        color: #ffffff; }
+    treeview.view.expander:checked {
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+  treeview.view.progressbar, treeview.view.progressbar:focus {
+    color: #ffffff;
+    border-radius: 3px;
+    background-color: #3770AA; }
+    treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
+      color: #3770AA;
+      box-shadow: none;
+      background-color: #404040; }
+  treeview.view.trough {
+    color: #DADADA;
+    background-color: #2b2b2b;
+    border-radius: 3px;
+    border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
+  treeview.view header button {
+    padding: 3px 6px;
+    font-weight: bold;
+    color: #bbbbbb;
+    background-color: #353535;
+    background-image: none;
+    border-style: none solid solid none;
+    border-radius: 0;
+    border-color: #292929; }
+    treeview.view header button:active, treeview.view header button:hover {
+      background-color: #353535; }
+    treeview.view header button:active:hover {
+      color: #DADADA; }
+    treeview.view header button:disabled {
+      border-color: #383838;
+      background-image: none; }
+    treeview.view header button:last-child {
+      border-right-style: none; }
+  treeview.view button.dnd, treeview.view button.dnd:selected, treeview.view button.dnd:hover, treeview.view button.dnd:active,
+  treeview.view header.button.dnd,
+  treeview.view header.button.dnd:selected,
+  treeview.view header.button.dnd:hover,
+  treeview.view header.button.dnd:active {
+    transition: none;
+    color: #3770AA;
+    box-shadow: inset 1px 1px 0 1px #3770AA, inset -1px 0 0 1px #3770AA, inset 1px 1px #ffffff, inset -1px 0 #ffffff; }
+
+menubar,
+.menubar {
+  -GtkWidget-window-dragging: true;
+  padding: 0px;
+  background-color: #2f2f2f;
+  color: #ded6d6; }
+  menubar:backdrop,
+  .menubar:backdrop {
+    color: rgba(222, 214, 214, 0.7); }
+  menubar > menuitem,
+  .menubar > menuitem {
+    padding: 6px 8px;
+    border: solid transparent;
+    border-width: 0; }
+    menubar > menuitem:hover,
+    .menubar > menuitem:hover {
+      background-color: #3770AA;
+      color: #ffffff; }
+    menubar > menuitem:disabled,
+    .menubar > menuitem:disabled {
+      color: rgba(222, 214, 214, 0.4);
+      border-color: transparent; }
+    menubar > menuitem > label:disabled,
+    .menubar > menuitem > label:disabled {
+      color: rgba(218, 218, 218, 0.55); }
+
+menu,
+.menu {
+  margin: 4px;
+  padding: 0;
+  border-radius: 0;
+  background-color: #404040;
+  border: 1px solid #292929; }
+  .csd menu, .csd
+  .menu {
+    padding: 4px 0px;
+    border-radius: 2px;
+    border: none; }
+  menu separator, .csd menu separator,
+  .menu separator, .csd
+  .menu separator {
+    margin: 2px 0;
+    background-color: #404040; }
+  menu .separator:not(label), .csd menu .separator:not(label),
+  .menu .separator:not(label), .csd
+  .menu .separator:not(label) {
+    color: #ffffff; }
+  menu menuitem,
+  .menu menuitem {
+    min-height: 16px;
+    min-width: 40px;
+    padding: 5px; }
+    menu menuitem:hover,
+    .menu menuitem:hover {
+      color: #ffffff;
+      background-color: #3770AA; }
+    menu menuitem:disabled,
+    .menu menuitem:disabled {
+      color: rgba(218, 218, 218, 0.55); }
+    menu menuitem arrow,
+    .menu menuitem arrow {
+      min-height: 16px;
+      min-width: 16px; }
+      menu menuitem arrow:dir(ltr),
+      .menu menuitem arrow:dir(ltr) {
+        -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
+        margin-left: 10px; }
+      menu menuitem arrow:dir(rtl),
+      .menu menuitem arrow:dir(rtl) {
+        -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl");
+        margin-right: 10px; }
+    menuitem accelerator {
+      color: alpha(currentColor,0.55); }
+    menuitem check, menuitem radio {
+      min-height: 16px;
+      min-width: 16px; }
+      menuitem check:dir(ltr), menuitem radio:dir(ltr) {
+        margin-right: 6px;
+        margin-left: 2px; }
+      menuitem check:dir(rtl), menuitem radio:dir(rtl) {
+        margin-left: 6px;
+        margin-right: 2px; }
+  menu > arrow,
+  .menu > arrow {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none;
+    min-width: 16px;
+    min-height: 16px;
+    padding: 4px;
+    background-color: #404040;
+    border-radius: 0; }
+    menu > arrow.top,
+    .menu > arrow.top {
+      margin-top: -6px;
+      border-bottom: 1px solid #4f4f4f;
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+    menu > arrow.bottom,
+    .menu > arrow.bottom {
+      margin-bottom: -6px;
+      border-top: 1px solid #4f4f4f;
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+    menu > arrow:hover,
+    .menu > arrow:hover {
+      background-color: #353535; }
+    menu > arrow:disabled,
+    .menu > arrow:disabled {
+      color: transparent;
+      background-color: transparent;
+      border-color: transparent; }
+
+.csd .popup {
+  border-radius: 2px; }
+
+popover,
+popover.background {
+  padding: 2px;
+  border-radius: 3px;
+  background-clip: border-box;
+  background-color: #404040;
+  box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.35); }
+  .csd popover, popover, .csd
+  popover.background,
+  popover.background {
+    border: 1px solid #1c1c1c; }
+  popover separator,
+  popover.background separator {
+    background-color: #404040; }
+  popover > list,
+  popover > .view,
+  popover > iconview,
+  popover > toolbar,
+  popover > .inline-toolbar,
+  popover.background > list,
+  popover.background > .view,
+  popover.background > iconview,
+  popover.background > toolbar,
+  popover.background > .inline-toolbar {
+    border-style: none;
+    background-color: transparent; }
+
+cursor-handle {
+  background-color: transparent;
+  background-image: none;
+  box-shadow: none;
+  border-style: none; }
+  cursor-handle.top {
+    -gtk-icon-source: -gtk-icontheme("selection-start-symbolic"); }
+  cursor-handle.bottom {
+    -gtk-icon-source: -gtk-icontheme("selection-end-symbolic"); }
+
+notebook {
+  padding: 0; }
+  notebook.frame {
+    border: 1px solid #292929; }
+    notebook.frame > header {
+      margin: -1px; }
+      notebook.frame > header.top {
+        margin-bottom: 0; }
+      notebook.frame > header.bottom {
+        margin-top: 0; }
+      notebook.frame > header.left {
+        margin-right: 0; }
+      notebook.frame > header.right {
+        margin-left: 0; }
+      notebook.frame > header.top, notebook.frame > header.bottom {
+        padding-left: 0;
+        padding-right: 0; }
+      notebook.frame > header.left, notebook.frame > header.right {
+        padding-top: 0;
+        padding-bottom: 0; }
+  notebook > stack:not(:only-child) {
+    background-color: #404040; }
+  notebook > header {
+    padding: 2px;
+    background-color: #383838;
+    /* button in headers */ }
+    notebook > header.top {
+      box-shadow: inset 0 -1px #292929; }
+    notebook > header.bottom {
+      box-shadow: inset 0 1px #292929; }
+    notebook > header.right {
+      box-shadow: inset 1px 0 #292929; }
+    notebook > header.left {
+      box-shadow: inset -1px 0 #292929; }
+    notebook > header.top {
+      padding-bottom: 0; }
+      notebook > header.top > tabs > tab {
+        padding: 2px 10px;
+        min-width: 20px;
+        min-height: 20px;
+        outline-offset: -4px;
+        border: 1px solid transparent;
+        border-bottom: none;
+        border-radius: 1px 1px 0 0; }
+        notebook > header.top > tabs > tab + tab {
+          margin-left: -1px; }
+    notebook > header.bottom {
+      padding-top: 0; }
+      notebook > header.bottom > tabs > tab {
+        padding: 2px 10px;
+        min-width: 20px;
+        min-height: 20px;
+        outline-offset: -4px;
+        border: 1px solid transparent;
+        border-top: none;
+        border-radius: 0 0 1px 1px; }
+        notebook > header.bottom > tabs > tab + tab {
+          margin-left: -1px; }
+    notebook > header.right {
+      padding-left: 0; }
+      notebook > header.right > tabs > tab {
+        padding: 2px 10px;
+        min-width: 20px;
+        min-height: 20px;
+        outline-offset: -4px;
+        border: 1px solid transparent;
+        border-left: none;
+        border-radius: 0 1px 1px 0; }
+        notebook > header.right > tabs > tab + tab {
+          margin-top: -1px; }
+    notebook > header.left {
+      padding-right: 0; }
+      notebook > header.left > tabs > tab {
+        padding: 2px 10px;
+        min-width: 20px;
+        min-height: 20px;
+        outline-offset: -4px;
+        border: 1px solid transparent;
+        border-right: none;
+        border-radius: 1px 0 0 1px; }
+        notebook > header.left > tabs > tab + tab {
+          margin-top: -1px; }
+    notebook > header.top > tabs > arrow.up, notebook > header.bottom > tabs > arrow.up {
+      -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+      notebook > header.top > tabs > arrow.up:last-child, notebook > header.bottom > tabs > arrow.up:last-child {
+        margin-left: 2px; }
+    notebook > header.top > tabs > arrow.down, notebook > header.bottom > tabs > arrow.down {
+      -gtk-icon-source: -gtk-icontheme("pan-start-symbolic"); }
+      notebook > header.top > tabs > arrow.down:first-child, notebook > header.bottom > tabs > arrow.down:first-child {
+        margin-right: 2px; }
+    notebook > header.left > tabs > arrow.up, notebook > header.right > tabs > arrow.up {
+      -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+      notebook > header.left > tabs > arrow.up:last-child, notebook > header.right > tabs > arrow.up:last-child {
+        margin-top: 2px; }
+    notebook > header.left > tabs > arrow.down, notebook > header.right > tabs > arrow.down {
+      -gtk-icon-source: -gtk-icontheme("pan-up-symbolic"); }
+      notebook > header.left > tabs > arrow.down:first-child, notebook > header.right > tabs > arrow.down:first-child {
+        margin-bottom: 2px; }
+    notebook > header > tabs > arrow {
+      color: rgba(218, 218, 218, 0.55); }
+      notebook > header > tabs > arrow:hover {
+        color: rgba(218, 218, 218, 0.775); }
+      notebook > header > tabs > arrow:active {
+        color: #DADADA; }
+      notebook > header > tabs > arrow:disabled {
+        color: rgba(218, 218, 218, 0.25); }
+    notebook > header.top > tabs > tab:hover:not(:checked) {
+      box-shadow: inset 0 -1px #292929; }
+    notebook > header.bottom > tabs > tab:hover:not(:checked) {
+      box-shadow: inset 0 1px #292929; }
+    notebook > header.left > tabs > tab:hover:not(:checked) {
+      box-shadow: inset -1px 0 #292929; }
+    notebook > header.right > tabs > tab:hover:not(:checked) {
+      box-shadow: inset 1px 0 #292929; }
+    notebook > header > tabs > tab {
+      color: rgba(218, 218, 218, 0.55);
+      background-color: rgba(64, 64, 64, 0); }
+      notebook > header > tabs > tab:hover:not(:checked) {
+        color: rgba(218, 218, 218, 0.775);
+        background-color: rgba(64, 64, 64, 0.5);
+        border-color: #292929; }
+      notebook > header > tabs > tab:checked {
+        color: #DADADA;
+        background-color: #404040;
+        border-color: #292929; }
+      notebook > header > tabs > tab button.flat, notebook > header > tabs > tab button.sidebar-button {
+        min-height: 22px;
+        min-width: 16px;
+        padding: 0;
+        color: #a1a1a1; }
+        notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover {
+          color: #ff4d4d; }
+        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover {
+          color: #3770AA; }
+    notebook > header button.flat, notebook > header button.sidebar-button {
+      padding: 2px; }
+
+scrollbar {
+  background-color: #3d3d3d;
+  transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+  * {
+    -GtkScrollbar-has-backward-stepper: false;
+    -GtkScrollbar-has-forward-stepper: false; }
+  scrollbar.top {
+    border-bottom: 1px solid #292929; }
+  scrollbar.bottom {
+    border-top: 1px solid #292929; }
+  scrollbar.left {
+    border-right: 1px solid #292929; }
+  scrollbar.right {
+    border-left: 1px solid #292929; }
+  scrollbar button {
+    border: none; }
+  scrollbar slider {
+    min-width: 6px;
+    min-height: 6px;
+    margin: -1px;
+    border: 4px solid transparent;
+    border-radius: 8px;
+    background-clip: padding-box;
+    background-color: #797979; }
+    scrollbar slider:hover {
+      background-color: dimgray; }
+    scrollbar slider:hover:active {
+      background-color: #3770AA; }
+    scrollbar slider:disabled {
+      background-color: transparent; }
+  scrollbar.fine-tune slider {
+    min-width: 4px;
+    min-height: 4px; }
+  scrollbar.fine-tune.horizontal slider {
+    border-width: 5px 4px; }
+  scrollbar.fine-tune.vertical slider {
+    border-width: 4px 5px; }
+  scrollbar.overlay-indicator:not(.dragging):not(.hovering) {
+    opacity: 0.4;
+    border-color: transparent;
+    background-color: transparent; }
+    scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
+      margin: 0;
+      min-width: 4px;
+      min-height: 4px;
+      background-color: darkgray;
+      border: 1px solid rgba(0, 0, 0, 0.3); }
+    scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider {
+      margin: 2px 0;
+      min-height: 40px; }
+    scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider {
+      margin: 0 2px;
+      min-width: 40px; }
+  scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering {
+    opacity: 0.99; }
+  scrollbar.horizontal slider {
+    min-width: 40px; }
+  scrollbar.vertical slider {
+    min-height: 40px; }
+
+switch {
+  font-size: 1px;
+  min-width: 52px;
+  min-height: 24px;
+  background-size: 52px 24px;
+  background-repeat: no-repeat;
+  background-position: center center; }
+  switch slider {
+    min-width: 1px;
+    min-height: 1px; }
+  switch, switch slider {
+    outline-color: transparent;
+    color: transparent;
+    border: none;
+    box-shadow: none; }
+
+switch {
+  background-image: -gtk-scaled(url("assets/switch-dark.png"), url("assets/switch-dark@2.png")); }
+
+menuitem:hover switch,
+row:selected switch,
+infobar switch {
+  background-image: -gtk-scaled(url("assets/switch-selected.png"), url("assets/switch-selected@2.png")); }
+
+headerbar switch,
+.primary-toolbar switch,
+.primary-toolbar toolbar switch,
+.primary-toolbar .inline-toolbar switch {
+  background-image: -gtk-scaled(url("assets/switch-header-dark.png"), url("assets/switch-header-dark@2.png")); }
+
+switch:checked {
+  background-image: -gtk-scaled(url("assets/switch-active-dark.png"), url("assets/switch-active-dark@2.png")); }
+
+menuitem:hover switch:checked,
+row:selected switch:checked,
+infobar switch:checked {
+  background-image: -gtk-scaled(url("assets/switch-active-selected.png"), url("assets/switch-active-selected@2.png")); }
+
+headerbar switch:checked,
+.primary-toolbar switch:checked,
+.primary-toolbar toolbar switch:checked,
+.primary-toolbar .inline-toolbar switch:checked {
+  background-image: -gtk-scaled(url("assets/switch-active-header-dark.png"), url("assets/switch-active-header-dark@2.png")); }
+
+switch:disabled {
+  background-image: -gtk-scaled(url("assets/switch-insensitive-dark.png"), url("assets/switch-insensitive-dark@2.png")); }
+
+menuitem:hover switch:disabled,
+row:selected switch:disabled,
+infobar switch:disabled {
+  background-image: -gtk-scaled(url("assets/switch-insensitive-selected.png"), url("assets/switch-insensitive-selected@2.png")); }
+
+headerbar switch:disabled,
+.primary-toolbar switch:disabled,
+.primary-toolbar toolbar switch:disabled,
+.primary-toolbar .inline-toolbar switch:disabled {
+  background-image: -gtk-scaled(url("assets/switch-insensitive-header-dark.png"), url("assets/switch-insensitive-header-dark@2.png")); }
+
+switch:checked:disabled {
+  background-image: -gtk-scaled(url("assets/switch-active-insensitive-dark.png"), url("assets/switch-active-insensitive-dark@2.png")); }
+
+menuitem:hover switch:checked:disabled,
+row:selected switch:checked:disabled,
+infobar switch:checked:disabled {
+  background-image: -gtk-scaled(url("assets/switch-active-insensitive-selected.png"), url("assets/switch-active-insensitive-selected@2.png")); }
+
+headerbar switch:checked:disabled,
+.primary-toolbar switch:checked:disabled,
+.primary-toolbar toolbar switch:checked:disabled,
+.primary-toolbar .inline-toolbar switch:checked:disabled {
+  background-image: -gtk-scaled(url("assets/switch-active-insensitive-header-dark.png"), url("assets/switch-active-insensitive-header-dark@2.png")); }
+
+.check,
+check,
+treeview.check {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-dark.png"), url("assets/checkbox-unchecked-dark@2.png")); }
+
+.osd check {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-dark.png"), url("assets/checkbox-unchecked-dark@2.png")); }
+
+menuitem check:hover,
+.view check:selected,
+iconview check:selected,
+treeview.check:selected,
+row:selected check,
+infobar check {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-selected.png"), url("assets/checkbox-unchecked-selected@2.png")); }
+
+.check:disabled,
+check:disabled,
+treeview.check:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive-dark.png"), url("assets/checkbox-unchecked-insensitive-dark@2.png")); }
+
+.osd check:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive-dark.png"), url("assets/checkbox-unchecked-insensitive-dark@2.png")); }
+
+menuitem check:disabled:hover,
+.view check:disabled:selected,
+iconview check:disabled:selected,
+treeview.check:disabled:selected,
+row:selected check:disabled,
+infobar check:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive-selected.png"), url("assets/checkbox-unchecked-insensitive-selected@2.png")); }
+
+.check:indeterminate,
+check:indeterminate,
+treeview.check:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-dark.png"), url("assets/checkbox-mixed-dark@2.png")); }
+
+.osd check:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-dark.png"), url("assets/checkbox-mixed-dark@2.png")); }
+
+menuitem check:indeterminate:hover,
+.view check:indeterminate:selected,
+iconview check:indeterminate:selected,
+treeview.check:indeterminate:selected,
+row:selected check:indeterminate,
+infobar check:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-selected.png"), url("assets/checkbox-mixed-selected@2.png")); }
+
+.check:indeterminate:disabled,
+check:indeterminate:disabled,
+treeview.check:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive-dark.png"), url("assets/checkbox-mixed-insensitive-dark@2.png")); }
+
+.osd check:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive-dark.png"), url("assets/checkbox-mixed-insensitive-dark@2.png")); }
+
+menuitem check:indeterminate:disabled:hover,
+.view check:indeterminate:disabled:selected,
+iconview check:indeterminate:disabled:selected,
+treeview.check:indeterminate:disabled:selected,
+row:selected check:indeterminate:disabled,
+infobar check:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive-selected.png"), url("assets/checkbox-mixed-insensitive-selected@2.png")); }
+
+.check:checked,
+check:checked,
+treeview.check:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-dark.png"), url("assets/checkbox-checked-dark@2.png")); }
+
+.osd check:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-dark.png"), url("assets/checkbox-checked-dark@2.png")); }
+
+menuitem check:checked:hover,
+.view check:checked:selected,
+iconview check:checked:selected,
+treeview.check:checked:selected,
+row:selected check:checked,
+infobar check:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-selected.png"), url("assets/checkbox-checked-selected@2.png")); }
+
+.check:checked:disabled,
+check:checked:disabled,
+treeview.check:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive-dark.png"), url("assets/checkbox-checked-insensitive-dark@2.png")); }
+
+.osd check:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive-dark.png"), url("assets/checkbox-checked-insensitive-dark@2.png")); }
+
+menuitem check:checked:disabled:hover,
+.view check:checked:disabled:selected,
+iconview check:checked:disabled:selected,
+treeview.check:checked:disabled:selected,
+row:selected check:checked:disabled,
+infobar check:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive-selected.png"), url("assets/checkbox-checked-insensitive-selected@2.png")); }
+
+.radio,
+radio,
+treeview.radio {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-dark.png"), url("assets/radio-unchecked-dark@2.png")); }
+
+.osd radio {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-dark.png"), url("assets/radio-unchecked-dark@2.png")); }
+
+menuitem radio:hover,
+.view radio:selected,
+iconview radio:selected,
+treeview.radio:selected,
+row:selected radio,
+infobar radio {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-selected.png"), url("assets/radio-unchecked-selected@2.png")); }
+
+.radio:disabled,
+radio:disabled,
+treeview.radio:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-insensitive-dark.png"), url("assets/radio-unchecked-insensitive-dark@2.png")); }
+
+.osd radio:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-insensitive-dark.png"), url("assets/radio-unchecked-insensitive-dark@2.png")); }
+
+menuitem radio:disabled:hover,
+.view radio:disabled:selected,
+iconview radio:disabled:selected,
+treeview.radio:disabled:selected,
+row:selected radio:disabled,
+infobar radio:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-insensitive-selected.png"), url("assets/radio-unchecked-insensitive-selected@2.png")); }
+
+.radio:indeterminate,
+radio:indeterminate,
+treeview.radio:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-dark.png"), url("assets/radio-mixed-dark@2.png")); }
+
+.osd radio:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-dark.png"), url("assets/radio-mixed-dark@2.png")); }
+
+menuitem radio:indeterminate:hover,
+.view radio:indeterminate:selected,
+iconview radio:indeterminate:selected,
+treeview.radio:indeterminate:selected,
+row:selected radio:indeterminate,
+infobar radio:indeterminate {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-selected.png"), url("assets/radio-mixed-selected@2.png")); }
+
+.radio:indeterminate:disabled,
+radio:indeterminate:disabled,
+treeview.radio:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive-dark.png"), url("assets/radio-mixed-insensitive-dark@2.png")); }
+
+.osd radio:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive-dark.png"), url("assets/radio-mixed-insensitive-dark@2.png")); }
+
+menuitem radio:indeterminate:disabled:hover,
+.view radio:indeterminate:disabled:selected,
+iconview radio:indeterminate:disabled:selected,
+treeview.radio:indeterminate:disabled:selected,
+row:selected radio:indeterminate:disabled,
+infobar radio:indeterminate:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive-selected.png"), url("assets/radio-mixed-insensitive-selected@2.png")); }
+
+.radio:checked,
+radio:checked,
+treeview.radio:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-dark.png"), url("assets/radio-checked-dark@2.png")); }
+
+.osd radio:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-dark.png"), url("assets/radio-checked-dark@2.png")); }
+
+menuitem radio:checked:hover,
+.view radio:checked:selected,
+iconview radio:checked:selected,
+treeview.radio:checked:selected,
+row:selected radio:checked,
+infobar radio:checked {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-selected.png"), url("assets/radio-checked-selected@2.png")); }
+
+.radio:checked:disabled,
+radio:checked:disabled,
+treeview.radio:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-insensitive-dark.png"), url("assets/radio-checked-insensitive-dark@2.png")); }
+
+.osd radio:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-insensitive-dark.png"), url("assets/radio-checked-insensitive-dark@2.png")); }
+
+menuitem radio:checked:disabled:hover,
+.view radio:checked:disabled:selected,
+iconview radio:checked:disabled:selected,
+treeview.radio:checked:disabled:selected,
+row:selected radio:checked:disabled,
+infobar radio:checked:disabled {
+  -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-insensitive-selected.png"), url("assets/radio-checked-insensitive-selected@2.png")); }
+
+.view.content-view.check:not(.list), iconview.content-view.check:not(.list) {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-selectionmode-dark.png"), url("assets/checkbox-selectionmode-dark@2.png"));
+  background-color: transparent; }
+
+.view.content-view.check:checked:not(.list), iconview.content-view.check:checked:not(.list) {
+  -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-selectionmode-dark.png"), url("assets/checkbox-checked-selectionmode-dark@2.png"));
+  background-color: transparent; }
+
+checkbutton.text-button, radiobutton.text-button {
+  padding: 2px 0;
+  outline-offset: 0; }
+checkbutton label:not(:only-child):first-child, radiobutton label:not(:only-child):first-child {
+  margin-left: 4px; }
+checkbutton label:not(:only-child):last-child, radiobutton label:not(:only-child):last-child {
+  margin-right: 4px; }
+
+check,
+radio {
+  min-width: 16px;
+  min-height: 16px;
+  margin: 0 2px; }
+  check:only-child, menu menuitem check,
+  radio:only-child, menu menuitem
+  radio {
+    margin: 0; }
+
+scale {
+  min-height: 15px;
+  min-width: 15px;
+  padding: 3px; }
+  scale.horizontal trough {
+    padding: 0 4px; }
+  scale.horizontal highlight, scale.horizontal fill {
+    margin: 0 -4px; }
+  scale.vertical trough {
+    padding: 4px 0; }
+  scale.vertical highlight, scale.vertical fill {
+    margin: -4px 0; }
+  scale slider {
+    min-height: 15px;
+    min-width: 15px;
+    margin: -6px; }
+  scale.fine-tune slider {
+    margin: -4px; }
+  scale.fine-tune fill,
+  scale.fine-tune highlight,
+  scale.fine-tune trough {
+    border-radius: 5px;
+    -gtk-outline-radius: 7px; }
+  scale slider {
+    background-clip: padding-box;
+    background-color: #353535;
+    border: 1px solid #242424;
+    border-radius: 50%;
+    box-shadow: none; }
+    scale slider:disabled {
+      background-color: #3c3c3c;
+      border-color: rgba(36, 36, 36, 0.8); }
+    scale slider:active {
+      background-color: #3770AA;
+      border-color: #3770AA; }
+    .osd scale slider {
+      background-color: #353535;
+      border-color: #3770AA; }
+      .osd scale slider:hover {
+        background-color: #3770AA; }
+      .osd scale slider:active {
+        background-color: #2b5783;
+        border-color: #76905b; }
+    menuitem:hover scale slider, row:selected scale slider, infobar scale slider {
+      background-color: #404040;
+      border-color: #404040; }
+      menuitem:hover scale slider:hover, row:selected scale slider:hover, infobar scale slider:hover {
+        background-color: #e1eaf2;
+        border-color: #e1eaf2; }
+      menuitem:hover scale slider:active, row:selected scale slider:active, infobar scale slider:active {
+        background-color: #9bb8d5;
+        border-color: #9bb8d5; }
+      menuitem:hover scale slider:disabled, row:selected scale slider:disabled, infobar scale slider:disabled {
+        background-color: #a5bfd9;
+        border-color: #a5bfd9; }
+  scale trough {
+    outline-offset: 2px;
+    -gtk-outline-radius: 4.5px;
+    border-radius: 2.5px;
+    background-color: #2b2b2b; }
+    scale trough:disabled {
+      background-color: rgba(207, 207, 207, 0.55); }
+    .osd scale trough {
+      background-color: #575757;
+      outline-color: rgba(195, 195, 195, 0.2); }
+      .osd scale trough highlight {
+        background-color: #3770AA; }
+    menuitem:hover scale trough
+    row:selected scale trough, infobar scale trough {
+      background-color: rgba(0, 0, 0, 0.2); }
+      menuitem:hover scale trough
+      row:selected scale trough highlight, infobar scale trough highlight {
+        background-color: #404040; }
+        menuitem:hover scale trough
+        row:selected scale trough highlight:disabled, infobar scale trough highlight:disabled {
+          background-color: #a5bfd9; }
+      menuitem:hover scale trough
+      row:selected scale trough:disabled, infobar scale trough:disabled {
+        background-color: rgba(0, 0, 0, 0.1); }
+  scale highlight {
+    border-radius: 2.5px;
+    background-color: #3770AA; }
+    scale highlight:disabled {
+      background-color: rgba(55, 112, 170, 0.55); }
+  scale fill {
+    border-radius: 2.5px;
+    background-color: rgba(55, 112, 170, 0.5); }
+    scale fill:disabled {
+      background-color: transparent; }
+  scale value {
+    color: alpha(currentColor,0.4); }
+  scale marks {
+    color: alpha(currentColor,0.4); }
+    scale marks.top {
+      margin-bottom: 1px;
+      margin-top: -4px; }
+    scale marks.bottom {
+      margin-top: 1px;
+      margin-bottom: -4px; }
+    scale marks.top {
+      margin-right: 1px;
+      margin-left: -4px; }
+    scale marks.bottom {
+      margin-left: 1px;
+      margin-right: -4px; }
+  scale.fine-tune marks.top {
+    margin-bottom: 0px;
+    margin-top: -2px; }
+  scale.fine-tune marks.bottom {
+    margin-top: 0px;
+    margin-bottom: -2px; }
+  scale.fine-tune marks.top {
+    margin-right: 0px;
+    margin-left: -2px; }
+  scale.fine-tune marks.bottom {
+    margin-left: 0px;
+    margin-right: -2px; }
+  scale.horizontal indicator {
+    min-height: 3px;
+    min-width: 1px; }
+  scale.horizontal.fine-tune indicator {
+    min-height: 2px; }
+  scale.vertical indicator {
+    min-height: 1px;
+    min-width: 3px; }
+  scale.vertical.fine-tune indicator {
+    min-width: 2px; }
+
+progressbar {
+  padding: 0;
+  font-size: smaller;
+  color: rgba(218, 218, 218, 0.7); }
+  progressbar.osd {
+    min-width: 3px;
+    min-height: 3px;
+    background-color: transparent; }
+    progressbar.osd trough {
+      border-style: none;
+      background-color: transparent;
+      box-shadow: none; }
+  progressbar progress {
+    background-color: #3770AA;
+    border-radius: 3px;
+    box-shadow: none; }
+    row:selected progressbar progress, infobar progressbar progress {
+      background-color: #404040; }
+  progressbar trough {
+    border: none;
+    border-radius: 3px;
+    background-color: #2b2b2b; }
+    row:selected progressbar trough, infobar progressbar trough {
+      background-color: rgba(0, 0, 0, 0.2); }
+
+.osd .progressbar {
+  background-color: #3770AA; }
+.osd .trough {
+  background-color: white; }
+
+levelbar block {
+  min-width: 32px;
+  min-height: 1px; }
+levelbar.vertical block {
+  min-width: 1px;
+  min-height: 32px; }
+levelbar trough {
+  border: none;
+  padding: 3px;
+  border-radius: 3px;
+  background-color: #2b2b2b; }
+levelbar.horizontal.discrete block {
+  margin: 0 1px; }
+levelbar.vertical.discrete block {
+  margin: 1px 0; }
+levelbar block:not(.empty) {
+  border: 1px solid #3770AA;
+  background-color: #3770AA;
+  border-radius: 2px; }
+levelbar block.low {
+  border-color: #f27835;
+  background-color: #f27835; }
+levelbar block.high {
+  border-color: #3770AA;
+  background-color: #3770AA; }
+levelbar block.full {
+  border-color: #73d216;
+  background-color: #73d216; }
+levelbar block.empty {
+  background-color: rgba(74, 74, 74, 0.2);
+  border-color: rgba(74, 74, 74, 0.2); }
+
+frame > border,
+.frame {
+  margin: 0;
+  padding: 0;
+  border-radius: 0;
+  border: 1px solid #292929; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
+
+scrolledwindow viewport.frame {
+  border-style: none; }
+scrolledwindow overshoot.top {
+  background-image: -gtk-gradient(radial, center top, 0, center top, 0.6, from(rgba(55, 112, 170, 0.2)), to(rgba(55, 112, 170, 0)));
+  background-size: 100% 60%;
+  background-repeat: no-repeat;
+  background-position: center top;
+  background-color: transparent;
+  border: none;
+  box-shadow: none; }
+scrolledwindow overshoot.bottom {
+  background-image: -gtk-gradient(radial, center bottom, 0, center bottom, 0.6, from(rgba(55, 112, 170, 0.2)), to(rgba(55, 112, 170, 0)));
+  background-size: 100% 60%;
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  background-color: transparent;
+  border: none;
+  box-shadow: none; }
+scrolledwindow overshoot.left {
+  background-image: -gtk-gradient(radial, left center, 0, left center, 0.6, from(rgba(55, 112, 170, 0.2)), to(rgba(55, 112, 170, 0)));
+  background-size: 60% 100%;
+  background-repeat: no-repeat;
+  background-position: left center;
+  background-color: transparent;
+  border: none;
+  box-shadow: none; }
+scrolledwindow overshoot.right {
+  background-image: -gtk-gradient(radial, right center, 0, right center, 0.6, from(rgba(55, 112, 170, 0.2)), to(rgba(55, 112, 170, 0)));
+  background-size: 60% 100%;
+  background-repeat: no-repeat;
+  background-position: right center;
+  background-color: transparent;
+  border: none;
+  box-shadow: none; }
+scrolledwindow undershoot.top {
+  background-color: transparent;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-top: 1px;
+  background-size: 10px 1px;
+  background-repeat: repeat-x;
+  background-origin: content-box;
+  background-position: center top; }
+scrolledwindow undershoot.bottom {
+  background-color: transparent;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-bottom: 1px;
+  background-size: 10px 1px;
+  background-repeat: repeat-x;
+  background-origin: content-box;
+  background-position: center bottom; }
+scrolledwindow undershoot.left {
+  background-color: transparent;
+  background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-left: 1px;
+  background-size: 1px 10px;
+  background-repeat: repeat-y;
+  background-origin: content-box;
+  background-position: left center; }
+scrolledwindow undershoot.right {
+  background-color: transparent;
+  background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-right: 1px;
+  background-size: 1px 10px;
+  background-repeat: repeat-y;
+  background-origin: content-box;
+  background-position: right center; }
+scrolledwindow junction {
+  border-color: transparent;
+  border-image: linear-gradient(to bottom, #292929 1px, transparent 1px) 0 0 0 1/0 1px stretch;
+  background-color: #3d3d3d; }
+  scrolledwindow junction:dir(rtl) {
+    border-image-slice: 0 1 0 0; }
+
+separator {
+  background-color: rgba(0, 0, 0, 0.1);
+  min-width: 1px;
+  min-height: 1px; }
+
+list {
+  background-color: #404040;
+  border-color: #292929; }
+  list row {
+    padding: 2px; }
+
+row:not(:hover) {
+  transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+row.activatable.has-open-popup, row.activatable:hover {
+  background-color: rgba(255, 255, 255, 0.03); }
+row.activatable:active {
+  color: #DADADA; }
+row.activatable:disabled {
+  color: rgba(218, 218, 218, 0.55); }
+  row.activatable:disabled image {
+    color: inherit; }
+row.activatable:selected:active {
+  color: #ffffff; }
+row.activatable:selected.has-open-popup, row.activatable:selected:hover {
+  background-color: #81976a; }
+
+.app-notification {
+  padding: 10px;
+  color: #C3C3C3;
+  background-color: #353535;
+  background-clip: border-box;
+  border-radius: 0 0 2px 2px;
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: #1c1c1c; }
+  .app-notification border {
+    border: none; }
+  .app-notification button {
+    color: #C3C3C3;
+    outline-color: rgba(195, 195, 195, 0.3);
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: rgba(109, 109, 109, 0.4); }
+    .app-notification button.flat, .app-notification button.sidebar-button {
+      border-color: rgba(55, 112, 170, 0); }
+    .app-notification button:hover {
+      color: #C3C3C3;
+      outline-color: rgba(195, 195, 195, 0.3);
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: rgba(127, 127, 127, 0.5); }
+    .app-notification button:active, .app-notification button:checked {
+      color: #ffffff;
+      outline-color: rgba(255, 255, 255, 0.3);
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: #3770AA;
+      background-clip: padding-box; }
+    .app-notification button:disabled {
+      color: #606060;
+      border-color: rgba(22, 22, 22, 0.4);
+      background-color: rgba(109, 109, 109, 0.25); }
+
+expander arrow {
+  min-width: 16px;
+  min-height: 16px;
+  -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
+  expander arrow:dir(rtl) {
+    -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl"); }
+  expander arrow:hover {
+    color: white; }
+  expander arrow:checked {
+    -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
+
+calendar {
+  color: #DADADA;
+  border: 1px solid #292929;
+  border-radius: 3px;
+  padding: 2px; }
+  calendar:selected {
+    background-color: #3770AA;
+    color: #ffffff;
+    border-radius: 1.5px; }
+  calendar.header {
+    color: #DADADA;
+    border: none;
+    border-radius: 0; }
+  calendar.button, calendar.button:focus {
+    color: rgba(218, 218, 218, 0.45);
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none; }
+    calendar.button:hover, calendar.button:focus:hover {
+      color: #DADADA; }
+    calendar.button:disabled, calendar.button:focus:disabled {
+      color: rgba(218, 218, 218, 0.55);
+      background-color: transparent;
+      background-image: none; }
+  calendar:indeterminate {
+    color: alpha(currentColor,0.55); }
+  calendar.highlight {
+    color: #DADADA; }
+
+.dialog-action-area .button.text-button {
+  padding: 6px 16px; }
+
+.message-dialog .dialog-action-area .button {
+  padding: 8px; }
+
+.message-dialog {
+  -GtkDialog-button-spacing: 0; }
+  .message-dialog .titlebar {
+    background-color: #2f2f2f;
+    border-bottom: 1px solid #1d1d1d; }
+  .message-dialog.csd.background {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border: none; }
+  .message-dialog.csd .dialog-action-area .button {
+    padding: 8px;
+    border-radius: 0; }
+  .message-dialog.csd .dialog-action-area .button, .message-dialog.csd .dialog-action-area .button:hover, .message-dialog.csd .dialog-action-area .button:active, .message-dialog.csd .dialog-action-area .button:disabled {
+    border-right-style: none;
+    border-bottom-style: none; }
+  .message-dialog.csd .dialog-action-area .button:last-child {
+    border-bottom-right-radius: 3px; }
+  .message-dialog.csd .dialog-action-area .button:first-child {
+    border-left-style: none;
+    border-bottom-left-radius: 3px; }
+
+filechooser #pathbarbox {
+  border-bottom: 1px solid rgba(217, 217, 217, 0.5); }
+
+filechooserbutton:drop(active) {
+  box-shadow: none;
+  border-color: transparent; }
+
+.sidebar {
+  border-style: none;
+  background-color: #353535; }
+  stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left, .sidebar.left:dir(rtl) {
+    border-right: 1px solid #292929;
+    border-left-style: none; }
+  stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
+    border-left: 1px solid #292929;
+    border-right-style: none; }
+  .sidebar list {
+    background-color: #404040; }
+  paned .sidebar.left, paned .sidebar.right, paned .sidebar.left:dir(rtl), paned .sidebar:dir(rtl), paned .sidebar:dir(ltr), paned .sidebar {
+    border-style: none; }
+
+stacksidebar row {
+  padding: 10px 4px; }
+  stacksidebar row > label {
+    padding-left: 6px;
+    padding-right: 6px; }
+  stacksidebar row.needs-attention > label {
+    background-size: 6px 6px, 0 0; }
+
+placessidebar > viewport.frame {
+  border-style: none; }
+placessidebar row {
+  min-height: 30px;
+  padding: 0px; }
+  placessidebar row > revealer {
+    padding: 0 10px; }
+  placessidebar row image.sidebar-icon:dir(ltr) {
+    padding-right: 8px; }
+  placessidebar row image.sidebar-icon:dir(rtl) {
+    padding-left: 8px; }
+  placessidebar row label.sidebar-label:dir(ltr) {
+    padding-right: 2px; }
+  placessidebar row label.sidebar-label:dir(rtl) {
+    padding-left: 2px; }
+  button.sidebar-button {
+    min-width: 22px;
+    min-height: 22px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    padding: 0;
+    border-radius: 100%;
+    -gtk-outline-radius: 100%; }
+    button.sidebar-button:not(:hover):not(:active) > image {
+      opacity: 0.5; }
+  placessidebar row.sidebar-placeholder-row {
+    padding: 0 8px;
+    min-height: 2px;
+    background-image: linear-gradient(to bottom, #f08437, #f08437);
+    background-clip: content-box; }
+  placessidebar row.sidebar-new-bookmark-row {
+    color: #3770AA; }
+  placessidebar row:drop(active):not(:disabled) {
+    box-shadow: inset 0 1px #f08437, inset 0 -1px #f08437; }
+    placessidebar row:drop(active):not(:disabled), placessidebar row:drop(active):not(:disabled) label, placessidebar row:drop(active):not(:disabled) image {
+      color: #f08437; }
+    placessidebar row:drop(active):not(:disabled):selected {
+      background-color: #f08437; }
+      placessidebar row:drop(active):not(:disabled):selected, placessidebar row:drop(active):not(:disabled):selected label, placessidebar row:drop(active):not(:disabled):selected image {
+        color: #ffffff; }
+
+placesview .server-list-button > image {
+  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -gtk-icon-transform: rotate(0turn); }
+placesview .server-list-button:checked > image {
+  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  -gtk-icon-transform: rotate(-0.5turn); }
+placesview > actionbar > revealer > box > label {
+  padding-left: 8px;
+  padding-right: 8px; }
+
+paned > separator {
+  min-width: 1px;
+  min-height: 1px;
+  -gtk-icon-source: none;
+  border-style: none;
+  background-color: transparent;
+  background-image: linear-gradient(to bottom, #d9d9d9, #d9d9d9);
+  background-size: 1px 1px; }
+  paned > separator:selected {
+    background-image: linear-gradient(to bottom, #3770AA, #3770AA); }
+  paned > separator.wide {
+    min-width: 5px;
+    min-height: 5px;
+    background-color: #383838;
+    background-image: linear-gradient(to bottom, #d9d9d9, #d9d9d9), linear-gradient(to bottom, #d9d9d9, #d9d9d9);
+    background-size: 1px 1px, 1px 1px; }
+paned.horizontal > separator {
+  background-repeat: repeat-y; }
+  paned.horizontal > separator:dir(ltr) {
+    margin: 0 -8px 0 0;
+    padding: 0 8px 0 0;
+    background-position: left; }
+  paned.horizontal > separator:dir(rtl) {
+    margin: 0 0 0 -8px;
+    padding: 0 0 0 8px;
+    background-position: right; }
+  paned.horizontal > separator.wide {
+    margin: 0;
+    padding: 0;
+    background-repeat: repeat-y, repeat-y;
+    background-position: left, right; }
+paned.vertical > separator {
+  margin: 0 0 -8px 0;
+  padding: 0 0 8px 0;
+  background-repeat: repeat-x;
+  background-position: top; }
+  paned.vertical > separator.wide {
+    margin: 0;
+    padding: 0;
+    background-repeat: repeat-x, repeat-x;
+    background-position: bottom, top; }
+
+infobar {
+  border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #3770AA;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #3770AA;
+      background-color: #404040; }
+    infobar.info:disabled label, infobar.info:disabled image, infobar.question:disabled label, infobar.question:disabled image, infobar.warning:disabled label, infobar.warning:disabled image, infobar.error:disabled label, infobar.error:disabled image {
+      color: rgba(255, 255, 255, 0.5); }
+  infobar.warning {
+    background-color: #f27835; }
+  infobar.error {
+    background-color: #F04A50; }
+  infobar.question {
+    background-color: #55c1ec; }
+
+.primary-toolbar toolbar.selection-mode button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover,
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0);
+  border-color: rgba(255, 255, 255, 0.5); }
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button {
+  border-color: transparent;
+  background-color: transparent;
+  background-image: none;
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0); }
+  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled,
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label,
+  .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label {
+    color: rgba(255, 255, 255, 0.4); }
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.8); }
+.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active,
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked,
+.selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .primary-toolbar toolbar.selection-mode button:hover:active, .primary-toolbar .selection-mode.inline-toolbar button:hover:active,
+.selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .primary-toolbar toolbar.selection-mode button:hover:checked, .primary-toolbar .selection-mode.inline-toolbar button:hover:checked,
+.selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+  color: #3770AA;
+  background-color: #404040;
+  border-color: #404040; }
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled {
+  background-color: rgba(255, 255, 255, 0);
+  border-color: rgba(255, 255, 255, 0.4); }
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
+  .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active,
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked,
+  .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked,
+  .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active,
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+    color: #3770AA;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-color: rgba(255, 255, 255, 0.4); }
+
+tooltip,
+.tooltip {
+  color: #DADADA;
+  border-radius: 2px;
+  border: 1px solid #d0d0d0; }
+  tooltip.background,
+  .tooltip.background {
+    background-color: #fbeaa0;
+    background-clip: padding-box; }
+    tooltip.background label,
+    .tooltip.background label {
+      padding: 4px; }
+  tooltip decoration,
+  .tooltip decoration {
+    background-color: transparent; }
+  tooltip *,
+  .tooltip * {
+    background-color: transparent;
+    color: #DADADA; }
+
+colorswatch, colorswatch:drop(active) {
+  border-style: none; }
+colorswatch.top {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px; }
+  colorswatch.top overlay {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px; }
+colorswatch.bottom {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px; }
+  colorswatch.bottom overlay {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px; }
+colorswatch.left, colorswatch:first-child:not(.top) {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px; }
+  colorswatch.left overlay, colorswatch:first-child:not(.top) overlay {
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px; }
+colorswatch.right, colorswatch:last-child:not(.bottom) {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px; }
+  colorswatch.right overlay, colorswatch:last-child:not(.bottom) overlay {
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px; }
+colorswatch.dark overlay {
+  color: rgba(255, 255, 255, 0.7); }
+  colorswatch.dark overlay:hover {
+    border-color: rgba(0, 0, 0, 0.5); }
+colorswatch.light overlay {
+  color: rgba(0, 0, 0, 0.7); }
+  colorswatch.light overlay:hover {
+    border-color: rgba(0, 0, 0, 0.3); }
+colorswatch overlay {
+  border: 1px solid rgba(0, 0, 0, 0.15); }
+  colorswatch overlay:hover {
+    background-color: rgba(255, 255, 255, 0.2); }
+colorswatch:disabled {
+  opacity: 0.5; }
+  colorswatch:disabled overlay {
+    border-color: rgba(0, 0, 0, 0.6);
+    box-shadow: none; }
+colorswatch#add-color-button {
+  border-style: solid;
+  border-width: 1px;
+  color: #DADADA;
+  outline-color: rgba(218, 218, 218, 0.3);
+  border-color: #292929;
+  background-color: #353535; }
+  colorswatch#add-color-button:hover {
+    color: #DADADA;
+    outline-color: rgba(218, 218, 218, 0.3);
+    border-color: #292929;
+    background-color: #525252; }
+  colorswatch#add-color-button overlay {
+    border-color: transparent;
+    background-color: transparent;
+    background-image: none; }
+
+button.color {
+  padding: 0; }
+  button.color colorswatch:first-child:last-child, button.color colorswatch:first-child:last-child overlay {
+    margin: 4px;
+    border-radius: 0; }
+
+colorchooser .popover.osd {
+  border-radius: 3px; }
+
+.content-view {
+  background-color: #404040; }
+  .content-view:hover {
+    -gtk-icon-effect: highlight; }
+
+.scale-popup button:hover {
+  color: #DADADA;
+  outline-color: rgba(218, 218, 218, 0.3);
+  border-color: #292929;
+  background-color: white; }
+
+.touch-selection,
+.context-menu,
+popover.touch-selection,
+.csd popover.touch-selection,
+popover.background.touch-selection,
+.csd popover.background.touch-selection {
+  font: initial; }
+
+.monospace {
+  font-family: Monospace; }
+
+button.circular,
+button.circular-button,
+.stack-switcher > button.circular {
+  min-width: 24px;
+  min-height: 24px;
+  padding: 5px;
+  border-radius: 50%;
+  -gtk-outline-radius: 50%; }
+  button.circular label,
+  button.circular-button label,
+  .stack-switcher > button.circular label {
+    padding: 0; }
+
+.keycap {
+  min-width: 16px;
+  min-height: 20px;
+  padding: 3px 6px 4px 6px;
+  color: #DADADA;
+  background-color: #404040;
+  border: 1px solid #292929;
+  border-radius: 2.5px;
+  box-shadow: inset 0px -2px 0px rgba(0, 0, 0, 0.05); }
+
+decoration {
+  border-radius: 3px 3px 0 0;
+  border-width: 0px;
+  box-shadow: 0 0 0 1px #1d1d1d, 0 8px 8px 0 rgba(0, 0, 0, 0.35);
+  margin: 10px; }
+  decoration:backdrop {
+    box-shadow: 0 0 0 1px rgba(29, 29, 29, 0.9), 0 8px 8px 0 transparent, 0 5px 5px 0 rgba(0, 0, 0, 0.2); }
+  .fullscreen decoration, .tiled decoration {
+    border-radius: 0; }
+  .popup decoration {
+    box-shadow: none;
+    border-radius: 0; }
+  .ssd decoration {
+    border-radius: 3px 3px 0 0;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.65); }
+    .ssd decoration.maximized {
+      border-radius: 0; }
+  .csd.popup decoration {
+    border-radius: 2px;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.45), 0 0 0 1px #1f1f1f; }
+  tooltip.csd decoration {
+    border-radius: 2px;
+    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.55); }
+  message-dialog.csd decoration {
+    border-radius: 3px; }
+  .solid-csd decoration {
+    border-radius: 0;
+    margin: 1px;
+    background-color: #2f2f2f;
+    box-shadow: none; }
+
+headerbar.default-decoration button.titlebutton,
+.titlebar.default-decoration button.titlebutton {
+  padding-top: 0px;
+  padding-bottom: 0px; }
+headerbar button.titlebutton,
+.titlebar button.titlebutton {
+  padding: 6px 1px;
+  border-color: transparent;
+  background-color: transparent;
+  background-image: none;
+  background-color: rgba(47, 47, 47, 0); }
+  headerbar button.titlebutton:hover,
+  .titlebar button.titlebutton:hover {
+    color: #ded6d6;
+    outline-color: rgba(222, 214, 214, 0.3);
+    border-color: rgba(16, 16, 16, 0.4);
+    background-color: rgba(103, 103, 103, 0.4); }
+  headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
+  .titlebar button.titlebutton:active,
+  .titlebar button.titlebutton:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: transparent;
+    background-color: #3770AA; }
+  headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
+  .titlebar button.titlebutton.close,
+  .titlebar button.titlebutton.maximize,
+  .titlebar button.titlebutton.minimize {
+    color: transparent;
+    background-color: transparent;
+    background-position: center;
+    background-repeat: no-repeat;
+    border-width: 0; }
+    headerbar button.titlebutton.close:backdrop, headerbar button.titlebutton.maximize:backdrop, headerbar button.titlebutton.minimize:backdrop,
+    .titlebar button.titlebutton.close:backdrop,
+    .titlebar button.titlebutton.maximize:backdrop,
+    .titlebar button.titlebutton.minimize:backdrop {
+      opacity: 1; }
+  headerbar button.titlebutton.close,
+  .titlebar button.titlebutton.close {
+    background-image: -gtk-scaled(url("assets/titlebutton-close-dark.png"), url("assets/titlebutton-close-dark@2.png")); }
+  headerbar button.titlebutton.close:backdrop,
+  .titlebar button.titlebutton.close:backdrop {
+    background-image: -gtk-scaled(url("assets/titlebutton-close-backdrop-dark.png"), url("assets/titlebutton-close-backdrop-dark@2.png")); }
+  headerbar button.titlebutton.close:hover,
+  .titlebar button.titlebutton.close:hover {
+    background-image: -gtk-scaled(url("assets/titlebutton-close-hover-dark.png"), url("assets/titlebutton-close-hover-dark@2.png")); }
+  headerbar button.titlebutton.close:active,
+  .titlebar button.titlebutton.close:active {
+    background-image: -gtk-scaled(url("assets/titlebutton-close-active-dark.png"), url("assets/titlebutton-close-active-dark@2.png")); }
+  headerbar button.titlebutton.maximize,
+  .titlebar button.titlebutton.maximize {
+    background-image: -gtk-scaled(url("assets/titlebutton-max-dark.png"), url("assets/titlebutton-max-dark@2.png")); }
+  headerbar button.titlebutton.maximize:backdrop,
+  .titlebar button.titlebutton.maximize:backdrop {
+    background-image: -gtk-scaled(url("assets/titlebutton-max-backdrop-dark.png"), url("assets/titlebutton-max-backdrop-dark@2.png")); }
+  headerbar button.titlebutton.maximize:hover,
+  .titlebar button.titlebutton.maximize:hover {
+    background-image: -gtk-scaled(url("assets/titlebutton-max-hover-dark.png"), url("assets/titlebutton-max-hover-dark@2.png")); }
+  headerbar button.titlebutton.maximize:active,
+  .titlebar button.titlebutton.maximize:active {
+    background-image: -gtk-scaled(url("assets/titlebutton-max-active-dark.png"), url("assets/titlebutton-max-active-dark@2.png")); }
+  headerbar button.titlebutton.minimize,
+  .titlebar button.titlebutton.minimize {
+    background-image: -gtk-scaled(url("assets/titlebutton-min-dark.png"), url("assets/titlebutton-min-dark@2.png")); }
+  headerbar button.titlebutton.minimize:backdrop,
+  .titlebar button.titlebutton.minimize:backdrop {
+    background-image: -gtk-scaled(url("assets/titlebutton-min-backdrop-dark.png"), url("assets/titlebutton-min-backdrop-dark@2.png")); }
+  headerbar button.titlebutton.minimize:hover,
+  .titlebar button.titlebutton.minimize:hover {
+    background-image: -gtk-scaled(url("assets/titlebutton-min-hover-dark.png"), url("assets/titlebutton-min-hover-dark@2.png")); }
+  headerbar button.titlebutton.minimize:active,
+  .titlebar button.titlebutton.minimize:active {
+    background-image: -gtk-scaled(url("assets/titlebutton-min-active-dark.png"), url("assets/titlebutton-min-active-dark@2.png")); }
+
+.view:selected, iconview:selected, .view:selected:focus, iconview:selected:focus,
+.view text:selected,
+iconview text:selected,
+textview text:selected,
+.view text:selected:focus,
+iconview text:selected:focus,
+textview text:selected:focus, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
+textview text selection:focus,
+textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+modelbutton.flat:active,
+modelbutton.flat:active arrow,
+modelbutton.flat:selected,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
+filechooser placessidebar.sidebar list row.sidebar-row:selected,
+filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
+filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected {
+  background-color: #3770AA; }
+  row:selected label, label:selected, .view:selected, iconview:selected, .view:selected:focus, iconview:selected:focus,
+  .view text:selected,
+  iconview text:selected,
+  textview text:selected,
+  .view text:selected:focus,
+  iconview text:selected:focus,
+  textview text:selected:focus, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
+  textview text selection:focus,
+  textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+  modelbutton.flat:active,
+  modelbutton.flat:active arrow,
+  modelbutton.flat:selected,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+  filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
+  filechooser placessidebar.sidebar list row.sidebar-row:selected,
+  filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
+  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected {
+    color: #ffffff; }
+    row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus,
+    .view text:disabled:selected,
+    iconview text:disabled:selected,
+    textview text:disabled:selected,
+    iconview text:disabled:selected:focus,
+    textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
+    textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    modelbutton.flat:disabled:active,
+    modelbutton.flat:active arrow:disabled,
+    modelbutton.flat:disabled:selected,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected {
+      color: #9bb8d5; }
+
+GeditNotebook.notebook tab.reorderable-page.top:active, GeditNotebook.notebook tab.reorderable-page.top.active-page, GeditNotebook.notebook tab.reorderable-page.top.active-page:hover, GeditNotebook.notebook tab.top:active, GeditNotebook.notebook tab.top.active-page, GeditNotebook.notebook tab.top.active-page:hover,
+ScratchMainWindow .notebook tab.reorderable-page.top:active,
+ScratchMainWindow .notebook tab.reorderable-page.top.active-page,
+ScratchMainWindow .notebook tab.reorderable-page.top.active-page:hover,
+ScratchMainWindow .notebook tab.top:active,
+ScratchMainWindow .notebook tab.top.active-page,
+ScratchMainWindow .notebook tab.top.active-page:hover,
+EphyNotebook.notebook tab.reorderable-page.top:active,
+EphyNotebook.notebook tab.reorderable-page.top.active-page,
+EphyNotebook.notebook tab.reorderable-page.top.active-page:hover,
+EphyNotebook.notebook tab.top:active,
+EphyNotebook.notebook tab.top.active-page,
+EphyNotebook.notebook tab.top.active-page:hover,
+MidoriNotebook .notebook tab.reorderable-page.top:active,
+MidoriNotebook .notebook tab.reorderable-page.top.active-page,
+MidoriNotebook .notebook tab.reorderable-page.top.active-page:hover,
+MidoriNotebook .notebook tab.top:active,
+MidoriNotebook .notebook tab.top.active-page,
+MidoriNotebook .notebook tab.top.active-page:hover,
+TerminalWindow .notebook tab.reorderable-page.top:active,
+TerminalWindow .notebook tab.reorderable-page.top.active-page,
+TerminalWindow .notebook tab.reorderable-page.top.active-page:hover,
+TerminalWindow .notebook tab.top:active,
+TerminalWindow .notebook tab.top.active-page,
+TerminalWindow .notebook tab.top.active-page:hover,
+PantheonTerminalPantheonTerminalWindow .notebook tab.reorderable-page.top:active,
+PantheonTerminalPantheonTerminalWindow .notebook tab.reorderable-page.top.active-page,
+PantheonTerminalPantheonTerminalWindow .notebook tab.reorderable-page.top.active-page:hover,
+PantheonTerminalPantheonTerminalWindow .notebook tab.top:active,
+PantheonTerminalPantheonTerminalWindow .notebook tab.top.active-page,
+PantheonTerminalPantheonTerminalWindow .notebook tab.top.active-page:hover {
+  box-shadow: inset 0 1px #292929, inset 0 -1px #292929, inset 1px 0 #292929, inset -1px 0 #292929; }
+
+TerminalWindow .notebook tab.reorderable-page.top, TerminalWindow .notebook tab.top,
+PantheonTerminalPantheonTerminalWindow .notebook tab.reorderable-page.top,
+PantheonTerminalPantheonTerminalWindow .notebook tab.top {
+  padding-top: 7px;
+  border-top-width: 3px; }
+TerminalWindow .notebook.header.top,
+PantheonTerminalPantheonTerminalWindow .notebook.header.top {
+  box-shadow: inset 0 1px #252525, inset 0 -1px #292929; }
+
+GtkHTML {
+  background-color: #404040;
+  color: #DADADA; }
+  GtkHTML:active {
+    color: #ffffff;
+    background-color: #3770AA; }
+
+SushiFontWidget {
+  padding: 6px 12px; }
+
+vte-terminal.terminal-screen {
+  -TerminalScreen-background-darkness: 0.9;
+  background-color: #3f3f3f;
+  color: #fff; }
+
+terminal-screen-container,
+terminal-screen-container scrollbar:not(slider) {
+  border-color: transparent;
+  background-color: transparent; }
+
+TerminalWindow .notebook tab .button {
+  color: #a1a1a1; }
+  TerminalWindow .notebook tab .button:hover {
+    color: #DADADA;
+    border-color: #292929;
+    background-color: #353535; }
+TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover {
+  color: #ff4d4d; }
+TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+  color: #3770AA; }
+
+vte-terminal {
+  -TerminalScreen-background-darkness: 0.9;
+  background-color: #3f3f3f;
+  color: #fff; }
+
+.nautilus-canvas-item {
+  border-radius: 2px; }
+
+.nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item {
+  color: #ffffff;
+  text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
+  .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active {
+    color: #DADADA; }
+  .nautilus-desktop.nautilus-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+    color: #ffffff; }
+
+.nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
+popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-canvas-item.subtitle,
+.titlebar:not(headerbar) .nautilus-canvas-item.subtitle,
+.nautilus-list-dim-label {
+  color: #898989; }
+  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, headerbar .nautilus-canvas-item.subtitle:selected,
+  .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected:focus, headerbar .nautilus-canvas-item.subtitle:selected:focus,
+  .titlebar:not(headerbar) .nautilus-canvas-item.subtitle:selected:focus,
+  .nautilus-list-dim-label:selected,
+  .nautilus-list-dim-label:selected:focus {
+    color: #e9eee4; }
+
+.nautilus-window paned > separator {
+  background-image: linear-gradient(to bottom, #454545, #454545); }
+  .nautilus-window paned > separator:dir(ltr) {
+    margin-left: -1px; }
+  .nautilus-window paned > separator:dir(rtl) {
+    margin-right: -1px; }
+
+.nautilus-window .csd.background, .nautilus-window placessidebar list,
+filechooser .csd.background,
+filechooser placessidebar list {
+  background-color: transparent; }
+.nautilus-window placessidebar.sidebar list,
+filechooser placessidebar.sidebar list {
+  background-color: #353535; }
+  .nautilus-window placessidebar.sidebar list row.sidebar-row,
+  filechooser placessidebar.sidebar list row.sidebar-row {
+    border: none;
+    color: #C3C3C3; }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row .sidebar-icon {
+      color: rgba(195, 195, 195, 0.6); }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup, .nautilus-window placessidebar.sidebar list row.sidebar-row:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup,
+    filechooser placessidebar.sidebar list row.sidebar-row:hover {
+      background-color: rgba(195, 195, 195, 0.15); }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled label, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled image,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled label,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled image {
+      color: rgba(195, 195, 195, 0.4); }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon {
+      color: inherit; }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button,
+    filechooser placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button {
+      color: #C3C3C3; }
+      .nautilus-window placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:hover,
+      filechooser placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:hover {
+        color: #C3C3C3;
+        outline-color: rgba(195, 195, 195, 0.3);
+        border-color: rgba(22, 22, 22, 0.4);
+        background-color: rgba(127, 127, 127, 0.5); }
+      .nautilus-window placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:active,
+      filechooser placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:active {
+        color: #ffffff;
+        outline-color: rgba(255, 255, 255, 0.3);
+        border-color: #292929;
+        background-color: #3770AA; }
+      .nautilus-window placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
+      filechooser placessidebar.sidebar list row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image {
+        opacity: 0.5; }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row.sidebar-new-bookmark-row,
+    filechooser placessidebar.sidebar list row.sidebar-row.sidebar-new-bookmark-row {
+      color: #3770AA; }
+      .nautilus-window placessidebar.sidebar list row.sidebar-row.sidebar-new-bookmark-row .sidebar-icon,
+      filechooser placessidebar.sidebar list row.sidebar-row.sidebar-new-bookmark-row .sidebar-icon {
+        color: inherit; }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled), .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled) label, .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled) .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled),
+    filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled) label,
+    filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled) .sidebar-icon {
+      color: #f08437; }
+    .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected {
+      background-color: #f08437; }
+      .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected label, .nautilus-window placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected .sidebar-icon,
+      filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected,
+      filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected label,
+      filechooser placessidebar.sidebar list row.sidebar-row:drop(active):not(:disabled):selected .sidebar-icon {
+        color: #ffffff; }
+  .nautilus-window placessidebar.sidebar list separator,
+  filechooser placessidebar.sidebar list separator {
+    background-color: transparent; }
+.nautilus-window.maximized placessidebar.sidebar,
+filechooser.maximized placessidebar.sidebar {
+  background-color: #353535; }
+
+NautilusQueryEditor .search-bar.toolbar {
+  padding: 5px;
+  box-shadow: none;
+  background-color: #404040; }
+
+.nautilus-circular-button.image-button.button, headerbar button.nautilus-circular-button.button.titlebutton,
+.titlebar button.nautilus-circular-button.button.titlebutton {
+  border-radius: 50%;
+  -gtk-outline-radius: 50%;
+  padding: 8px; }
+
+.disk-space-display {
+  border-style: solid;
+  border-width: 1px; }
+  .disk-space-display.unknown {
+    background-color: rgba(218, 218, 218, 0.5);
+    border-color: rgba(193, 193, 193, 0.5); }
+  .disk-space-display.used {
+    background-color: rgba(143, 168, 118, 0.8);
+    border-color: rgba(118, 144, 91, 0.8); }
+  .disk-space-display.free {
+    background-color: #484848;
+    border-color: #292929; }
+
+NautilusListView .view, NautilusListView iconview {
+  border-bottom: 1px solid #292929; }
+
+.nemo-window {
+  /* This is to keep the separator next to the sidebar dark so we don't see a gap
+     between it and the trash bar */ }
+  .nemo-window .nemo-window-pane widget.entry {
+    border: 1px solid;
+    border-radius: 3px;
+    color: #DADADA;
+    border-color: #3770AA;
+    background-color: #404040; }
+  .nemo-window .nemo-inactive-pane .view, .nemo-window .nemo-inactive-pane iconview {
+    background-color: #333333; }
+  .nemo-window .places-treeview {
+    -NemoPlacesTreeView-disk-full-bg-color: #C3C3C3;
+    -NemoPlacesTreeView-disk-full-fg-color: #76905b;
+    -GtkTreeView-vertical-separator: 7; }
+    .nemo-window .places-treeview .view.cell:hover, .nemo-window .places-treeview iconview.cell:hover {
+      background-color: rgba(195, 195, 195, 0.15); }
+  .nemo-window .nemo-places-sidebar.frame {
+    border-width: 0; }
+  .nemo-window .sidebar {
+    color: #C3C3C3;
+    background-color: #353535; }
+    .nemo-window .sidebar .frame {
+      border: none; }
+    .nemo-window .sidebar .view, .nemo-window .sidebar iconview, .nemo-window .sidebar row {
+      background-color: transparent;
+      color: #C3C3C3; }
+      .nemo-window .sidebar .view.cell:selected, .nemo-window .sidebar iconview.cell:selected, .nemo-window .sidebar row.cell:selected {
+        background-color: #3770AA;
+        color: #ffffff; }
+      .nemo-window .sidebar .view.expander, .nemo-window .sidebar iconview.expander, .nemo-window .sidebar row.expander {
+        color: #a1a1a1; }
+        .nemo-window .sidebar .view.expander:hover, .nemo-window .sidebar iconview.expander:hover, .nemo-window .sidebar row.expander:hover {
+          color: #C3C3C3; }
+  .nemo-window grid > paned > separator {
+    background-image: linear-gradient(to bottom, #454545, #454545); }
+  .nemo-window widget .toolbar .image-button, .nemo-window widget .toolbar headerbar button.titlebutton, headerbar .nemo-window widget .toolbar button.titlebutton,
+  .nemo-window widget .toolbar .titlebar button.titlebutton,
+  .titlebar .nemo-window widget .toolbar button.titlebutton {
+    padding: 0; }
+
+.caja-navigation-window .caja-side-pane .view, .caja-navigation-window .caja-side-pane iconview,
+.caja-navigation-window .caja-side-pane textview text,
+.caja-navigation-window .caja-side-pane notebook {
+  background-color: #353535;
+  color: #C3C3C3; }
+
+.gedit-headerbar-paned {
+  color: #252525; }
+
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #454545, #454545); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #d9d9d9, #d9d9d9); }
+
+.open-document-selector-treeview.view, iconview.open-document-selector-treeview {
+  padding: 3px 6px 3px 6px;
+  border-color: #404040; }
+  .open-document-selector-treeview.view:hover, iconview.open-document-selector-treeview:hover {
+    background-color: rgba(0, 0, 0, 0.05); }
+    .open-document-selector-treeview.view:hover:selected, iconview.open-document-selector-treeview:hover:selected {
+      color: #ffffff;
+      background-color: #3770AA; }
+
+.open-document-selector-name-label {
+  color: #DADADA; }
+
+.open-document-selector-path-label {
+  color: #8d8d8d;
+  font-size: smaller; }
+  .open-document-selector-path-label:selected {
+    color: rgba(255, 255, 255, 0.9); }
+
+.gedit-document-panel {
+  background-color: #353535; }
+  .gedit-document-panel row {
+    color: #C3C3C3;
+    background-color: rgba(195, 195, 195, 0); }
+    .gedit-document-panel row:hover {
+      background-color: rgba(195, 195, 195, 0.15); }
+    .gedit-document-panel row:active {
+      color: #ffffff;
+      background-color: #3770AA; }
+      .gedit-document-panel row:active button {
+        color: #ffffff; }
+    .gedit-document-panel row:selected, .gedit-document-panel row:selected:hover {
+      color: #ffffff;
+      background-color: #3770AA; }
+    .gedit-document-panel row:hover:not(:selected) button:active {
+      color: #C3C3C3; }
+  .gedit-document-panel row button {
+    min-width: 22px;
+    min-height: 22px;
+    color: transparent;
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 4px; }
+    .gedit-document-panel row button image {
+      color: inherit; }
+  .gedit-document-panel row:hover:not(:selected) button {
+    color: #a1a1a1; }
+    .gedit-document-panel row:hover:not(:selected) button:hover {
+      color: #ff4d4d; }
+    .gedit-document-panel row:hover:not(:selected) button:active {
+      color: #DADADA; }
+  .gedit-document-panel row:hover:selected button:hover {
+    color: #ff6666;
+    background: none;
+    border: none;
+    box-shadow: none; }
+    .gedit-document-panel row:hover:selected button:hover:active {
+      color: #ffffff; }
+
+.gedit-document-panel-dragged-row {
+  border: 1px solid #292929;
+  background-color: #1f1f1f;
+  color: #DADADA; }
+
+.gedit-side-panel-paned statusbar {
+  border-top: 1px solid #292929;
+  background-color: #383838; }
+
+.gedit-search-entry-occurrences-tag {
+  color: rgba(218, 218, 218, 0.6);
+  border: none;
+  margin: 2px;
+  padding: 2px; }
+
+.gedit-map-frame border {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.gedit-search-slider, .xed-window .xed-goto-line-box {
+  background-color: #353535;
+  padding: 6px;
+  border-color: #292929;
+  border-radius: 0 0 2px 2px;
+  border-width: 0 1px 1px 1px;
+  border-style: solid; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
+.gb-search-entry-occurrences-tag {
+  background: none; }
+
+workbench.csd > stack.titlebar:not(headerbar) {
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none; }
+  workbench.csd > stack.titlebar:not(headerbar) headerbar, workbench.csd > stack.titlebar:not(headerbar) headerbar:first-child, workbench.csd > stack.titlebar:not(headerbar) headerbar:last-child {
+    border-radius: 3px 3px 0 0; }
+
+editortweak .linked > entry.search:focus + .gb-linked-scroller {
+  border-top-color: #3770AA; }
+
+layouttab {
+  background-color: #404040; }
+
+layout {
+  border: 1px solid #292929;
+  -PnlDockBin-handle-size: 1; }
+
+eggsearchbar box.search-bar {
+  border-bottom: 1px solid #292929; }
+
+pillbox {
+  color: #ffffff;
+  background-color: #3770AA;
+  border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
+
+docktabstrip {
+  padding: 0 6px;
+  background-color: #383838;
+  border-bottom: 1px solid #292929; }
+  docktabstrip docktab {
+    min-height: 28px;
+    border: solid transparent;
+    border-width: 0 1px; }
+    docktabstrip docktab label {
+      opacity: 0.5; }
+    docktabstrip docktab:checked label, docktabstrip docktab:hover label {
+      opacity: 1; }
+    docktabstrip docktab:checked {
+      border-color: #292929;
+      background-color: #404040; }
+
+dockbin {
+  border: 1px solid #292929;
+  -PnlDockBin-handle-size: 1; }
+
+dockpaned {
+  border: 1px solid #292929; }
+
+dockoverlayedge {
+  background-color: #383838; }
+  dockoverlayedge docktabstrip {
+    padding: 0;
+    border: none; }
+  dockoverlayedge.left-edge tab:checked, dockoverlayedge.right-edge tab:checked {
+    border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #d9d9d9;
+  border-bottom: 1px solid #292929;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #292929; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #DADADA; }
+
+configurationview entry.flat {
+  background: none; }
+configurationview list {
+  border-width: 0; }
+
+EphyWindow .floating-bar {
+  color: #DADADA; }
+
+.xreader-window .primary-toolbar .button.the-button-in-the-combobox {
+  color: #ded6d6;
+  outline-color: rgba(222, 214, 214, 0.3);
+  border-color: rgba(16, 16, 16, 0.4);
+  background-color: rgba(103, 103, 103, 0.4); }
+  .xreader-window .primary-toolbar .button.the-button-in-the-combobox:hover {
+    background-color: rgba(141, 141, 141, 0.4); }
+  .xreader-window .primary-toolbar .button.the-button-in-the-combobox:disabled {
+    color: rgba(222, 214, 214, 0.6); }
+
+.documents-scrolledwin.frame {
+  border-width: 0; }
+
+button.documents-load-more {
+  border-width: 1px 0 0;
+  border-radius: 0; }
+
+.documents-icon-bg {
+  background-color: #3770AA;
+  color: #ffffff;
+  border-radius: 2px; }
+
+.documents-collection-icon, .photos-collection-icon {
+  background-color: rgba(218, 218, 218, 0.3);
+  border-radius: 2px; }
+
+.documents-favorite.button:active,
+.documents-favorite.button:active:hover {
+  color: #75a3d2; }
+
+.documents-entry-tag, .photos-entry-tag {
+  background-color: #3770AA;
+  color: #ffffff;
+  border-radius: 2px;
+  border-width: 0;
+  margin: 2px;
+  padding: 4px; }
+  .documents-entry-tag:hover, .photos-entry-tag:hover {
+    color: #ffffff;
+    background-color: #3c7ab9; }
+  .documents-entry-tag:active, .photos-entry-tag:active {
+    color: #ffffff;
+    background-color: #85a06a; }
+
+.photos-fade-in {
+  opacity: 1.0;
+  transition: opacity 0.2s ease-out; }
+
+.photos-fade-out {
+  opacity: 0.0;
+  transition: opacity 0.2s ease-out; }
+
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
+.content-view.document-page {
+  border-style: solid;
+  border-width: 3px 3px 6px 4px;
+  border-image: url("assets/thumbnail-frame.png") 3 3 6 4; }
+
+TotemGrilo.vertical GdMainView.frame {
+  border-width: 0; }
+
+SynapseGuiSelectionContainer *:selected,
+SynapseGuiViewVirgilio *:selected {
+  background-color: #3770AA; }
+
+.tr-workarea .undershoot,
+.tr-workarea .overshoot {
+  border-color: transparent; }
+
+.gnome-panel-menu-bar,
+.mate-panel-menu-bar {
+  color: #DADADA;
+  background-color: #292929; }
+  .gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
+  .mate-panel-menu-bar,
+  .mate-panel-menu-bar menubar {
+    background-color: #292929; }
+  .gnome-panel-menu-bar menubar,
+  .gnome-panel-menu-bar #PanelApplet label,
+  .gnome-panel-menu-bar #PanelApplet image,
+  .mate-panel-menu-bar menubar,
+  .mate-panel-menu-bar #PanelApplet label,
+  .mate-panel-menu-bar #PanelApplet image {
+    color: #DADADA; }
+  .gnome-panel-menu-bar menu > menuitem,
+  .mate-panel-menu-bar menu > menuitem {
+    color: #DADADA; }
+    .gnome-panel-menu-bar menu > menuitem:hover,
+    .mate-panel-menu-bar menu > menuitem:hover {
+      color: #ffffff; }
+  .gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
+  .gnome-panel-menu-bar #tasklist-button label,
+  .gnome-panel-menu-bar #tasklist-button image,
+  .mate-panel-menu-bar button label,
+  .mate-panel-menu-bar button image,
+  .mate-panel-menu-bar #tasklist-button label,
+  .mate-panel-menu-bar #tasklist-button image {
+    color: inherit; }
+  .gnome-panel-menu-bar #tasklist-button,
+  .mate-panel-menu-bar #tasklist-button {
+    color: #DADADA;
+    border-radius: 0;
+    border: none;
+    padding-bottom: 0;
+    padding-top: 0; }
+    .gnome-panel-menu-bar #tasklist-button:hover,
+    .mate-panel-menu-bar #tasklist-button:hover {
+      background-color: rgba(255, 255, 255, 0.05); }
+    .gnome-panel-menu-bar #tasklist-button:checked, .gnome-panel-menu-bar #tasklist-button:active,
+    .mate-panel-menu-bar #tasklist-button:checked,
+    .mate-panel-menu-bar #tasklist-button:active {
+      background-color: #3770AA; }
+      .gnome-panel-menu-bar #tasklist-button:checked label, .gnome-panel-menu-bar #tasklist-button:active label,
+      .mate-panel-menu-bar #tasklist-button:checked label,
+      .mate-panel-menu-bar #tasklist-button:active label {
+        color: white; }
+  .gnome-panel-menu-bar PanelSeparator,
+  .mate-panel-menu-bar PanelSeparator {
+    color: rgba(0, 0, 0, 0.2);
+    padding-top: 4px;
+    padding-bottom: 4px; }
+  .gnome-panel-menu-bar na-tray-applet,
+  .mate-panel-menu-bar na-tray-applet {
+    -NaTrayApplet-icon-padding: 1px; }
+
+.mintmenu:hover {
+  background-color: #363636; }
+
+.mintmenu:selected {
+  color: #ffffff;
+  background-color: #3770AA; }
+
+.wnck-pager {
+  background-color: rgba(0, 0, 0, 0.04); }
+  .wnck-pager:selected {
+    background-color: rgba(55, 112, 170, 0.6); }
+  .wnck-pager:hover {
+    background-color: rgba(55, 112, 170, 0.2); }
+
+.xfce4-panel.panel {
+  background-color: #292929;
+  color: #DADADA; }
+  .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+    color: #DADADA;
+    background-color: rgba(41, 41, 41, 0);
+    border-radius: 0;
+    border: none; }
+    .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+      border: none;
+      background-color: #434343; }
+    .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+      color: #ffffff;
+      border: none;
+      background-color: #3770AA; }
+
+.gnome-panel-menu-bar button:not(#tasklist-button),
+.mate-panel-menu-bar button:not(#tasklist-button) {
+  color: #DADADA;
+  border-radius: 0;
+  border: none;
+  background-color: rgba(41, 41, 41, 0); }
+  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
+  .mate-panel-menu-bar button:hover:not(#tasklist-button) {
+    border: none;
+    background-color: #434343; }
+  .gnome-panel-menu-bar button:active:not(#tasklist-button),
+  .mate-panel-menu-bar button:active:not(#tasklist-button), .gnome-panel-menu-bar button:checked:not(#tasklist-button),
+  .mate-panel-menu-bar button:checked:not(#tasklist-button) {
+    color: #ffffff;
+    border: none;
+    background-color: #3770AA; }
+  .gnome-panel-menu-bar button:not(#tasklist-button) label,
+  .mate-panel-menu-bar button:not(#tasklist-button) label, .gnome-panel-menu-bar button:not(#tasklist-button) image,
+  .mate-panel-menu-bar button:not(#tasklist-button) image {
+    color: inherit; }
+
+.floating-bar {
+  background-color: #3770AA;
+  color: #ffffff; }
+  .floating-bar.top {
+    border-radius: 0 0 2px 2px; }
+  .floating-bar.right {
+    border-radius: 2px 0 0 2px; }
+  .floating-bar.bottom {
+    border-radius: 2px 2px 0 0; }
+  .floating-bar.left {
+    border-radius: 0 2px 2px 0; }
+  .floating-bar .button {
+    background-color: transparent;
+    box-shadow: none;
+    border: none; }
+
+BirdieWidgetsTweetList * {
+  background-image: none;
+  background-color: transparent; }
+
+MarlinViewWindow *:selected, MarlinViewWindow *:selected:focus {
+  color: #ffffff;
+  background-color: #3770AA;
+  outline-color: transparent; }
+MarlinViewWindow GtkIconView.view:selected, MarlinViewWindow GtkIconView.view:selected:focus, MarlinViewWindow GtkIconView.view:selected:hover, MarlinViewWindow GtkIconView.view:selected:focus:hover {
+  background-color: transparent; }
+MarlinViewWindow FMListView, MarlinViewWindow FMColumnView {
+  outline-color: transparent; }
+
+.marlin-pathbar.pathbar {
+  border-radius: 3px;
+  padding-left: 4px;
+  padding-right: 4px;
+  color: #ded6d6;
+  border-color: rgba(16, 16, 16, 0.4);
+  background-color: rgba(103, 103, 103, 0.4); }
+  .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
+    color: inherit; }
+  .marlin-pathbar.pathbar:focus {
+    color: #ded6d6;
+    border-color: #3770AA;
+    background-color: rgba(103, 103, 103, 0.4); }
+  .marlin-pathbar.pathbar:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    background-color: rgba(103, 103, 103, 0.25); }
+  .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
+    color: #3770AA; }
+
+.gala-notification {
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background-color: white; }
+  .gala-notification .title, .gala-notification .label {
+    color: #5c616c; }
+
+PantheonTerminalPantheonTerminalWindow.background {
+  background-color: transparent; }
+
+SwitchboardCategoryView .view:selected, SwitchboardCategoryView iconview:selected,
+SwitchboardCategoryView .view:selected:focus,
+SwitchboardCategoryView iconview:selected:focus {
+  color: #DADADA; }
+
+.cs-header {
+  padding: 6px;
+  background-color: #ebebeb;
+  border-bottom: 1px solid #292929; }
+
+.xed-window .xed-panel.side notebook tab.top {
+  padding: 8px 12px; }
+.xed-window .xed-panel.bottom notebook.frame {
+  border: none; }
+.xed-window .small-button {
+  padding: 2px 4px; }
+.xed-window .xed-searchbar {
+  border: 0px solid #292929;
+  border-top-width: 1px; }
+.xed-window statusbar widget border {
+  border-color: transparent; }
+.xed-window statusbar button, .xed-window statusbar widget frame, .xed-window statusbar widget frame border {
+  padding: 0; }
+
+EvWindow .content-view .view:selected, EvWindow .content-view iconview:selected,
+EvWindow .content-view .view:focus:selected,
+EvWindow .content-view iconview:focus:selected {
+  background-color: #3770AA;
+  color: #ffffff; }
+
+.nautilus-window placessidebar.sidebar list scrollbar,
+filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollbar {
+  border-color: #383838; }
+  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider,
+  filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
+    background-color: #e9e9e9;
+    border: 1px solid rgba(0, 0, 0, 0.3); }
+  .nautilus-window placessidebar.sidebar list scrollbar slider,
+  filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
+    background-color: rgba(233, 233, 233, 0.7); }
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover,
+    filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
+      background-color: #f6f6f6; }
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active,
+    filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
+      background-color: #3770AA; }
+    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled,
+    filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
+      background-color: transparent; }
+  .nautilus-window placessidebar.sidebar list scrollbar trough,
+  filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
+    background-color: #383838; }
+
+#panel_window {
+  background-color: #292929;
+  color: #DADADA;
+  font-weight: bold;
+  box-shadow: inset 0 -1px #171717; }
+  #panel_window menubar,
+  #panel_window menubar > menuitem {
+    background-color: transparent;
+    color: #DADADA;
+    font-weight: bold; }
+  #panel_window menubar menuitem:disabled {
+    color: rgba(218, 218, 218, 0.5); }
+    #panel_window menubar menuitem:disabled label {
+      color: inherit; }
+  #panel_window menubar menu > menuitem {
+    font-weight: normal; }
+
+#login_window,
+#shutdown_dialog,
+#restart_dialog {
+  font-weight: normal;
+  border-style: none;
+  background-color: transparent;
+  color: #DADADA; }
+
+#content_frame {
+  padding-bottom: 14px;
+  background-color: #383838;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border: solid rgba(0, 0, 0, 0.1);
+  border-width: 1px 1px 0 1px; }
+
+#content_frame button {
+  color: #DADADA;
+  outline-color: rgba(218, 218, 218, 0.3);
+  border-color: #292929;
+  background-color: #353535; }
+  #content_frame button:hover {
+    color: #DADADA;
+    outline-color: rgba(218, 218, 218, 0.3);
+    border-color: #292929;
+    background-color: #525252; }
+  #content_frame button:active, #content_frame button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: #292929;
+    background-color: #3770AA; }
+  #content_frame button:disabled {
+    color: rgba(218, 218, 218, 0.55);
+    border-color: rgba(41, 41, 41, 0.55);
+    background-color: rgba(69, 69, 69, 0.55); }
+    #content_frame button:disabled label {
+      color: inherit; }
+
+#buttonbox_frame {
+  padding-top: 20px;
+  padding-bottom: 0px;
+  border-style: none;
+  background-color: #353535;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border: solid rgba(0, 0, 0, 0.1);
+  border-width: 0 1px 1px 1px;
+  box-shadow: inset 0 1px #252525; }
+
+#buttonbox_frame button {
+  color: #C3C3C3;
+  outline-color: rgba(195, 195, 195, 0.3);
+  border-color: rgba(22, 22, 22, 0.4);
+  background-color: rgba(109, 109, 109, 0.4); }
+  #buttonbox_frame button:hover {
+    color: #C3C3C3;
+    outline-color: rgba(195, 195, 195, 0.3);
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: rgba(127, 127, 127, 0.5); }
+  #buttonbox_frame button:active, #buttonbox_frame button:checked {
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: #3770AA; }
+  #buttonbox_frame button:disabled {
+    color: #606060;
+    border-color: rgba(22, 22, 22, 0.4);
+    background-color: rgba(109, 109, 109, 0.25); }
+
+#login_window #user_combobox {
+  color: #DADADA;
+  font-size: 13px; }
+  #login_window #user_combobox menu {
+    font-weight: normal; }
+
+#user_image {
+  padding: 3px;
+  border-radius: 2px; }
+
+#shutdown_button.button {
+  background-clip: border-box;
+  color: #ffffff;
+  outline-color: rgba(255, 255, 255, 0.3);
+  background-color: #F04A50;
+  border-color: #F04A50; }
+  #shutdown_button.button:hover {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #f4797e;
+    border-color: #f4797e; }
+  #shutdown_button.button:active, #shutdown_button.button:checked {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #ec1b22;
+    border-color: #ec1b22; }
+
+#restart_button.button {
+  background-clip: border-box;
+  color: #ffffff;
+  outline-color: rgba(255, 255, 255, 0.3);
+  background-color: #6db442;
+  border-color: #6db442; }
+  #restart_button.button:hover {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #88c663;
+    border-color: #88c663; }
+  #restart_button.button:active, #restart_button.button:checked {
+    background-clip: padding-box;
+    color: #ffffff;
+    outline-color: rgba(255, 255, 255, 0.3);
+    background-color: #568f34;
+    border-color: #568f34; }
+
+#greeter_infobar {
+  border-bottom-width: 0;
+  font-weight: bold; }
+
+window.background.lightdm menubar > menuitem {
+  padding: 0 5px 0 5px; }
+window.background.lightdm button.flat.option-button, window.background.lightdm button.option-button.sidebar-button {
+  background-color: transparent;
+  color: #dadada; }
+  window.background.lightdm button.flat.option-button:hover, window.background.lightdm button.option-button.sidebar-button:hover {
+    border-color: rgba(217, 217, 217, 0.2);
+    background-color: rgba(0, 0, 0, 0.5); }
+  window.background.lightdm button.flat.option-button:active, window.background.lightdm button.option-button.sidebar-button:active {
+    border-color: #292929;
+    background-color: #3770AA;
+    color: #ffffff; }
+window.background.lightdm button, window.background.lightdm button.toggle-button {
+  border-color: transparent;
+  background-color: transparent;
+  color: #dadada; }
+  window.background.lightdm button:hover, window.background.lightdm button.toggle-button:hover {
+    border-color: rgba(217, 217, 217, 0.2);
+    background-color: rgba(0, 0, 0, 0.5); }
+  window.background.lightdm button:active, window.background.lightdm button.selected, window.background.lightdm button.toggle-button:active, window.background.lightdm button.toggle-button.selected {
+    border-color: rgba(217, 217, 217, 0.2);
+    background-color: #3770AA;
+    color: #ffffff; }
+window.background.lightdm entry,
+window.background.lightdm .lightdm-combo entry {
+  background: rgba(0, 0, 0, 0.5);
+  color: white; }
+window.background.lightdm entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: spinner 1s linear infinite; }
+window.background.lightdm .lightdm-combo {
+  border-radius: 0;
+  background-color: transparent; }
+
+@define-color theme_fg_color #DADADA;
+@define-color theme_text_color #DADADA;
+@define-color theme_bg_color #383838;
+@define-color theme_base_color #404040;
+@define-color theme_selected_bg_color #3770AA;
+@define-color theme_selected_fg_color #ffffff;
+@define-color fg_color #DADADA;
+@define-color text_color #DADADA;
+@define-color bg_color #383838;
+@define-color base_color #404040;
+@define-color selected_bg_color #3770AA;
+@define-color selected_fg_color #ffffff;
+@define-color insensitive_bg_color #3d3d3d;
+@define-color insensitive_fg_color alpha(#dadada, 0.5);
+@define-color insensitive_base_color #404040;
+@define-color theme_unfocused_fg_color #DADADA;
+@define-color theme_unfocused_text_color #DADADA;
+@define-color theme_unfocused_bg_color #383838;
+@define-color theme_unfocused_base_color #404040;
+@define-color borders #292929;
+@define-color unfocused_borders #292929;
+@define-color warning_color #f27835;
+@define-color error_color #FC4138;
+@define-color success_color #73d216;
+@define-color placeholder_text_color #A8A8A8;
+@define-color content_view_bg #404040;
+@define-color wm_title alpha(#ded6d6, 0.8);
+@define-color wm_unfocused_title alpha(#ded6d6, 0.5);
+@define-color wm_bg #2f2f2f;
+@define-color wm_bg_unfocused #333333;
+@define-color wm_highlight #373737;
+@define-color wm_shadow alpha(black, 0.35);
+@define-color wm_button_close_bg #cc575d;
+@define-color wm_button_close_hover_bg #d7787d;
+@define-color wm_button_close_active_bg #be3841;
+@define-color wm_icon_close_bg #2f343f;
+@define-color wm_button_hover_bg #454C5C;
+@define-color wm_button_active_bg #3770AA;
+@define-color wm_button_hover_border #262932;
+@define-color wm_icon_bg #90939B;
+@define-color wm_icon_unfocused_bg #666A74;
+@define-color wm_icon_hover_bg #C4C7CC;
+@define-color wm_icon_active_bg #ffffff;


### PR DESCRIPTION
The PR adds dark theme for gtk-3.22 based on diff of dark theme for 3.0.

This fixes an issue when GTK tries to read gtk-3.0 git-dark.css theme while running gtk-3.22 related app.

The issue looks as follows (see controls and panels):
![image](https://user-images.githubusercontent.com/1551926/115005971-2e29b600-9eca-11eb-8d95-e10c260ffc19.png)
![image](https://user-images.githubusercontent.com/1551926/115006468-bc05a100-9eca-11eb-83f1-271d6e4036f2.png)

and throws a ton of errors like follows:
```console
(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3809:114: The :prelight pseudo-class is deprecated. Use :hover instead.

(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3811:78: The :insensitive pseudo-class is deprecated. Use :disabled instead.

(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3812:72: The :insensitive pseudo-class is deprecated. Use :disabled instead.

(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3812:124: The :insensitive pseudo-class is deprecated. Use :disabled instead.

(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3813:58: The :insensitive pseudo-class is deprecated. Use :disabled instead.

(pitivi:21683): Gtk-WARNING **: 15:40:50.908: Theme parsing error: gtk-dark.css:3813:113: The :insensitive pseudo-class is deprecated. Use :disabled instead.
```
with the PR update theme works OK:
![image](https://user-images.githubusercontent.com/1551926/115006735-07b84a80-9ecb-11eb-98e3-684f53983317.png)
![image](https://user-images.githubusercontent.com/1551926/115006671-fb33f200-9eca-11eb-85ce-38229b7bc627.png)

ping @i-vrnv as last accepted a PR since @voronovim is not there anymore
