### PR TITLE
[Pragmatic-Darker-Blue] fixed GTK-3.22 tooltip font color for dark theme

### DIFF
--- a/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk-dark.css
+++ b/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk-dark.css
@@ -2626,7 +2626,7 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
 
 tooltip,
 .tooltip {
-  color: #DADADA;
+  color: #4a4a4a;
   border-radius: 2px;
   border: 1px solid #d0d0d0; }
   tooltip.background,
@@ -2642,7 +2642,7 @@ tooltip,
   tooltip *,
   .tooltip * {
     background-color: transparent;
-    color: #DADADA; }
+    color: #4a4a4a; }
 
 colorswatch, colorswatch:drop(active) {
   border-style: none; }


### PR DESCRIPTION
This PR fixes unreadable tooltips in GTK-3.22 dark theme for Pragmatic-Darker-Blue