### PR TITLE
[Waterbody] Fix .menu-category-button-hover class for use in Cinnamenu applet.

### DIFF
--- a/waterbody/files/waterbody/cinnamon/cinnamon.css
+++ b/waterbody/files/waterbody/cinnamon/cinnamon.css
@@ -1349,8 +1349,9 @@ StScrollBar StButton#hhandle:active {
   border: 1px solid #d9d9d9;
 }
 .menu-category-button-hover {
-  background-color: red;
+  background-color: #6cabcd;
   border-radius: 2px;
+  border: 1px solid #6cabcd;
 }
 .menu-category-button-greyed {
   padding: 7px;


### PR DESCRIPTION
@tirtharajsinha This is just a suggestion, you may want to style it differently.

.menu-category-button-hover is used by Cinnamenu applet when setting "activate categories on click" is set. It's not used by any other applet at the moment.