### PR TITLE
[Orchidea] Remove side padding so that corners are click zones

### DIFF
--- a/Orchidea/files/Orchidea/cinnamon/cinnamon.css
+++ b/Orchidea/files/Orchidea/cinnamon/cinnamon.css
@@ -415,22 +415,18 @@ StScrollBar StButton#vhandle:active {
 }
 
 .panel-top {
-  padding: 0 12px;
   border-radius: 0 0 12px 12px;
 }
 
 .panel-bottom {
-  padding: 0 12px;
   border-radius: 12px 12px 0 0;
 }
 
 .panel-left {
-  padding: 12px 0;
   border-radius: 0 12px 12px 0;
 }
 
 .panel-right {
-  padding: 12px 0;
   border-radius: 12px 0 0 12px;
 }
 


### PR DESCRIPTION
Removing side padding so that applets on the ends of the panels can be clicked on when the mouse is in the corner. Currently if you send your mouse cursor to a corner with vigor and click, nothing happens because the side padding puts buttons on the ends of panels slightly away from the end.

Pinging @Andr35 for approval.