### PR TITLE
[Orchidea] Fix hard to read tooltip

### DIFF
--- a/Orchidea/files/Orchidea/cinnamon/cinnamon.css
+++ b/Orchidea/files/Orchidea/cinnamon/cinnamon.css
@@ -89,7 +89,8 @@ StScrollBar StButton#vhandle:active {
 
 #Tooltip {
   padding: 2px 12px;
-  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 20px;
+  background-color: #3c3c3c;
   color: rgba(255, 255, 255, 0.5);
   font-weight: normal;
   text-align: center;


### PR DESCRIPTION
Change
![Screenshot from 2021-07-30 11-44-26](https://user-images.githubusercontent.com/58893963/127643211-16a316af-d732-4777-9900-8c5009b72915.png)
to
![Screenshot from 2021-07-30 11-46-54](https://user-images.githubusercontent.com/58893963/127643227-2e4d0dc6-c860-47a1-b05d-7023e11712f9.png)

This is just a suggestion, you may want to style it differently.