### PR TITLE
[Orchidea] Fix grid button in cinnamenu

### DIFF
--- a/Orchidea/files/Orchidea/cinnamon/cinnamon.css
+++ b/Orchidea/files/Orchidea/cinnamon/cinnamon.css
@@ -1309,7 +1309,7 @@ StScrollBar StButton#vhandle:active {
   background-color: rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.9);
   transition-duration: 150ms;
-  border-radius: 100px;
+  border-radius: 20px;
 }
 
 .menu-application-button-selected:highlighted {


### PR DESCRIPTION
Reducing the border-radius of .menu-application-button-selected {} to 20px still keeps the list buttons in the default menu applet fully rounded but fixes a problem in cinnamenu's grid view where the button label goes outside the highlighted area.

