### PR TITLE
Orchidea: better tooltips

### DIFF
--- a/Orchidea/files/Orchidea/cinnamon/cinnamon.css
+++ b/Orchidea/files/Orchidea/cinnamon/cinnamon.css
@@ -88,11 +88,13 @@ StScrollBar StButton#vhandle:active {
 }
 
 #Tooltip {
-  padding: 2px 12px;
-  background-color: rgba(255, 255, 255, 0.5);
-  color: rgba(255, 255, 255, 0.5);
+  margin: 2px;
+  padding: 4px 12px;
+  background-color: rgba(0, 0, 0, 0.85);
+  color: rgba(255, 255, 255, 0.85);
   font-weight: normal;
   text-align: center;
+  border-radius: 12px;
 }
 
 /* ===================================================================

--- a/Orchidea/src/sass/_common.scss
+++ b/Orchidea/src/sass/_common.scss
@@ -81,11 +81,13 @@ StScrollBar StButton#vhandle:active {
     -barlevel-border-width: 0;  
 }
 #Tooltip {
-    padding: 2px 12px;
-    background-color: $hint_fg_color;
-    color: $inverse_hint_fg_color;
+    margin: 2px;
+    padding: 4px 12px;
+    background-color: rgba(black, 0.85);
+    color: $inverse_fg_color;
     font-weight: normal;
     text-align: center;
+    border-radius: 12px;
 }
 /* ===================================================================
  * Shared button properties
@@ -390,19 +392,15 @@ StScrollBar StButton#vhandle:active {
 .panelRight.vertical:dnd {
 }
 .panel-top {
-    padding: 0 12px;
     border-radius: 0 0 $buttons_radius $buttons_radius;
 }
 .panel-bottom {
-    padding: 0 12px;
     border-radius: $buttons_radius $buttons_radius 0 0;
 }
 .panel-left {
-    padding: 12px 0;
     border-radius: 0 $buttons_radius $buttons_radius 0;
 }
 .panel-right {
-    padding: 12px 0 ;
     border-radius: $buttons_radius 0 0 $buttons_radius;
 }
 .panel-status-button {


### PR DESCRIPTION
Fix some tooltip readability issues as pointed out by @fredcw 

New tooltip colors are:

![screenshot-2021-07-31 20-29-47](https://user-images.githubusercontent.com/9112303/127749884-2963a983-19e8-499e-801d-0213fa2fa2cb.png)
![screenshot-2021-07-31 20-30-10](https://user-images.githubusercontent.com/9112303/127749885-a9e39e90-9b9a-40fb-a104-081772935c3e.png)




 