### PR TITLE
Cinnamox update 211221

### DIFF
--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #671559;
   background-gradient-end: #3e0d35; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #b53c12;
   background-gradient-end: #ef825c; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #E95420;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(233, 84, 32, 0.2);
+  border-radius: 10px;
+  color: #f2d9f0; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #e9dd00; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(82, 17, 71, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2d9f0;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #E95420; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #6c165d;
   background-gradient-end: #410d38; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #b53c12;
   background-gradient-end: #ef825c; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #E95420;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(233, 84, 32, 0.2);
+  border-radius: 10px;
+  color: #f2d9f0; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #e9dd00; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(82, 17, 71, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2d9f0;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #E95420; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
+++ b/Cinnamox-Aubergine/files/Cinnamox-Aubergine/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #5E2750;
   color: #f2d9f0; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #834122;
   background-gradient-end: #4f2714; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #ac3900;
   background-gradient-end: #ff6a1f; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #e54c00;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(229, 76, 0, 0.2);
+  border-radius: 10px;
+  color: #f2e2da; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #e5e500; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(105, 52, 27, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2e2da;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #e54c00; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #8a4423;
   background-gradient-end: #532915; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #ac3900;
   background-gradient-end: #ff6a1f; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #e54c00;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(229, 76, 0, 0.2);
+  border-radius: 10px;
+  color: #f2e2da; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #e5e500; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(105, 52, 27, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2e2da;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #e54c00; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
+++ b/Cinnamox-Gold-Spice/files/Cinnamox-Gold-Spice/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #663d2b;
   color: #f2e2da; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #cddbe4;
   background-gradient-end: #5d89a8; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #2a5069;
   background-gradient-end: #4686af; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #386b8c;
   border-radius: 10px;
   color: #ffffff; }
+
+.menu-category-button-hover {
+  background-color: rgba(56, 107, 140, 0.2);
+  border-radius: 10px;
+  color: #0c1419; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #b2b059; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(149, 178, 198, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #0c1419;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #386b8c; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #dce5ec;
   background-gradient-end: #658fac; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #2a5069;
   background-gradient-end: #4686af; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #386b8c;
   border-radius: 10px;
   color: #ffffff; }
+
+.menu-category-button-hover {
+  background-color: rgba(56, 107, 140, 0.2);
+  border-radius: 10px;
+  color: #0c1419; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #b2b059; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(149, 178, 198, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #0c1419;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #386b8c; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
+++ b/Cinnamox-Heather/files/Cinnamox-Heather/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #99b0bf;
   color: #0c1419; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #506a77;
   background-gradient-end: #304047; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #1a8674;
   background-gradient-end: #33d7bb; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #23b29a;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(35, 178, 154, 0.2);
+  border-radius: 10px;
+  color: #daeaf2; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #a1a144; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(64, 85, 95, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #daeaf2;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #23b29a; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #54707d;
   background-gradient-end: #32434b; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #1a8674;
   background-gradient-end: #33d7bb; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #23b29a;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(35, 178, 154, 0.2);
+  border-radius: 10px;
+  color: #daeaf2; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #a1a144; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(64, 85, 95, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #daeaf2;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #23b29a; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
+++ b/Cinnamox-Kashmir-Blue/files/Cinnamox-Kashmir-Blue/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #29404c;
   color: #daeaf2; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #3c4650;
   background-gradient-end: #242a30; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #29609d;
   background-gradient-end: #71a2da; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #3d80cc;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(61, 128, 204, 0.2);
+  border-radius: 10px;
+  color: #d8e5f2; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #d8d84e; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(48, 56, 64, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #d8e5f2;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #3d80cc; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #3f4a54;
   background-gradient-end: #262c32; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #29609d;
   background-gradient-end: #71a2da; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #3d80cc;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(61, 128, 204, 0.2);
+  border-radius: 10px;
+  color: #d8e5f2; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #d8d84e; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(48, 56, 64, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #d8e5f2;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #3d80cc; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
+++ b/Cinnamox-Rhino/files/Cinnamox-Rhino/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #3b444c;
   color: #d8e5f2; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #af0000;
   background-gradient-end: #690000; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #994d00;
   background-gradient-end: #ff8000; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #CC6600;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(204, 102, 0, 0.2);
+  border-radius: 10px;
+  color: #f2dada; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #cccc00; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(140, 0, 0, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2dada;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #CC6600; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #b80000;
   background-gradient-end: #6e0000; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #994d00;
   background-gradient-end: #ff8000; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #CC6600;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(204, 102, 0, 0.2);
+  border-radius: 10px;
+  color: #f2dada; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #cccc00; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(140, 0, 0, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #f2dada;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #CC6600; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
+++ b/Cinnamox-Rosso-Cursa/files/Cinnamox-Rosso-Cursa/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #800000;
   color: #f2dada; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon.css
@@ -32,7 +32,7 @@
   background-gradient-start: #718062;
   background-gradient-end: #444d3b; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #509d29;
   background-gradient-end: #94da71; }
@@ -127,7 +127,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -353,6 +353,11 @@ StScrollView StScrollBar {
   background-color: #6ccc3d;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(108, 204, 61, 0.2);
+  border-radius: 10px;
+  color: #e6f2da; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -951,12 +956,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #aaaa3a; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -981,14 +980,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(90, 102, 78, 0.5); }
@@ -1117,6 +1116,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #e6f2da;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #6ccc3d; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/cinnamon/cinnamon_old.css
@@ -42,7 +42,7 @@
   background-gradient-start: #768666;
   background-gradient-end: #47503d; }
 
-.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
+.expo-workspaces-name-entry#selected, .window-caption:focus, .window-caption#selected, .switcher-list .item-box:selected, .calendar-not-today:selected:hover, .calendar-not-today:selected, .calendar-today:hover, .calendar-today, .workspace-graph .workspace:active, .workspace-button:outlined, .workspace-button:outlined:shaded, .panel-bottom .window-list-item-box:active, .panel-bottom .window-list-item-box:checked, .panel-bottom .window-list-item-box:focus, .panel-bottom .window-list-item-box:running, .modal-dialog-button:pressed, .modal-dialog-button:active, .notification-icon-button:active, .notification-button:active, .keyboard-key:active, .sound-player StButton:active {
   background-gradient-direction: vertical;
   background-gradient-start: #509d29;
   background-gradient-end: #94da71; }
@@ -182,7 +182,7 @@
 .menu-category-button-label:rtl, .menu-application-button-label:rtl {
   padding-right: 4px; }
 
-.menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
+.menu-category-button-hover, .menu-category-button-selected, .menu-category-button-greyed, .menu-category-button, .menu-application-button-selected, .menu-application-button, .menu-favorites-button, .popup-combobox-item, .popup-menu-item {
   padding: 5px; }
 
 .mount-question-dialog-subject, .show-processes-dialog-subject {
@@ -420,6 +420,11 @@ StScrollView StScrollBar {
   background-color: #6ccc3d;
   border-radius: 10px;
   color: #000000; }
+
+.menu-category-button-hover {
+  background-color: rgba(108, 204, 61, 0.2);
+  border-radius: 10px;
+  color: #e6f2da; }
 
 .menu-selected-app-box {
   padding: 0 4px;
@@ -993,12 +998,6 @@ StScrollView StScrollBar {
   margin-bottom: .6em;
   color: #aaaa3a; }
 
-.calendar-event-button:hover {
-  font-weight: bold; }
-
-.calendar-event-button:hover .calendar-event-countdown {
-  font-weight: bold; }
-
 .calendar-event-color-strip {
   width: 1px; }
 
@@ -1023,14 +1022,14 @@ StScrollView StScrollBar {
   padding: 5px; }
 
 .calendar-day-event-dot-box {
-  margin-top: 1.7em;
+  margin: 1.7em 0 0.5em;
   max-rows: 1; }
 
 .calendar-day-event-dot {
   margin: 1px;
-  border-radius: 99px;
-  width: 4px;
-  height: 4px; }
+  border-radius: 256px;
+  width: 2px;
+  height: 2px; }
 
 #keyboard {
   background-color: rgba(90, 102, 78, 0.5); }
@@ -1159,6 +1158,13 @@ StScrollView StScrollBar {
 .run-dialog {
   border-radius: 10px;
   padding: 16px 20px 8px; }
+
+.run-dialog-description {
+  color: #e6f2da;
+  padding-top: 16px; }
+
+.run-dialog-description.error {
+  color: #6ccc3d; }
 
 .cinnamon-mount-operation-icon {
   icon-size: 4.8em; }

--- a/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
+++ b/Cinnamox-Willow-Grove/files/Cinnamox-Willow-Grove/gtk-3.20/gtk.css
@@ -2703,6 +2703,12 @@ calendar {
   background-color: #4f5947;
   color: #e6f2da; }
 
+calendar-view event.color-light label {
+  color: black; }
+
+calendar-view event.color-dark label {
+  color: white; }
+
 /***************
  ! Color chooser
 ****************/


### PR DESCRIPTION
* Cinnamon - improved support for calendar with events applet in 5.2
* Cinnamon - added support for new run dialog selectors in 5.2
* Cinnamon - added menu-category-button-hover selector for improved cinnamenu compatibility
* GTK3.20 - improved contrast for Events in Gnome Calendar