### PR TITLE
Pragmatic-Darker-Blue: fixed missing coloring for GTK file chooser

### DIFF
--- a/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk.css
+++ b/Pragmatic-Darker-Blue/files/Pragmatic-Darker-Blue/gtk-3.22/gtk.css
@@ -2446,6 +2446,15 @@ calendar {
 filechooser #pathbarbox {
   border-bottom: 1px solid rgba(217, 217, 217, 0.5); }
 
+filechooser box.search-bar {
+  color: #ded6d6;
+  background-color: #2f2f2f;
+  box-shadow: none;
+  border-width: 0 0 1px 0;
+  border-style: solid;
+  border-image: linear-gradient(to bottom, #2f2f2f, #1d1d1d) 1 0 1 0;
+}
+
 filechooserbutton:drop(active) {
   box-shadow: none;
   border-color: transparent; }


### PR DESCRIPTION
This PR fixes missing coloring for GTK file chooser file name input in GTK-3.22 for Pragmatic-Darker-Blue

before:
![image](https://user-images.githubusercontent.com/1551926/207245016-c8678497-4b52-481a-9ee5-6f813e2b97c5.png)

after:
![image](https://user-images.githubusercontent.com/1551926/207245133-6303c0ab-377a-439f-bca7-eecb13d14b9a.png)
