### PR TITLE
Update cinnamon.css

### DIFF
--- a/Vivaldi/files/Vivaldi/cinnamon/cinnamon.css
+++ b/Vivaldi/files/Vivaldi/cinnamon/cinnamon.css
@@ -273,7 +273,7 @@ background-color: none;
     background-color: rgba(23,23,23,1);
     outline: 2px rgba(200,56,56,0.9);
     font-size: 0.9em;
-    font-weight: normal;
+    font-weight: bold;
     height: 40px;
 }
 


### PR DESCRIPTION
When hovering the cursor over the date and clock at the panel (default is in the right bottom corner), the font turns to normal (default is bold) which results in shifting the icons right. To fix it the value "normal" of the property "font-weight" of the "panel.js/ -> #panel" section has been changed to "bold".