### PR TITLE
Carta: Highlight active apps in the grouped window bar

### DIFF
--- a/Carta/files/Carta/cinnamon/cinnamon.css
+++ b/Carta/files/Carta/cinnamon/cinnamon.css
@@ -1631,10 +1631,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 .grouped-window-list-item-box:active, .grouped-window-list-item-box:checked {
     color: rgb(207, 216, 220); 
+    border-color: rgba(255, 255, 255, 0.25);
 }
 .grouped-window-list-item-box:focus {
     color: rgb(207, 216, 220); 
-    border-color: rgb(207, 216, 220);
+    border-color: rgb(33, 150, 243);
 } 
 .grouped-window-list-item-box:hover {
     color: rgb(97, 108, 113); 


### PR DESCRIPTION
Thanks for this beautiful theme @andr35 !
This is a proposition for a minor improvement on the theme's usability: it was a bit annoying not being able to distinguish active apps from the others in the window bar (e.g. find which windows are open). Only the currently focused window was highlighted. 

This PR changes the theme to highlight the currently focused window in blue (reusing a color from the theme, like in slider bars), and other open windows in grey.

![image](https://user-images.githubusercontent.com/17616580/225443588-16d4e66b-0a81-4744-9751-1984998334c5.png)
