### PR TITLE
Mint-XP: Fix theme name being too long

### DIFF
--- a/Mint-XP/info.json
+++ b/Mint-XP/info.json
@@ -1,5 +1,5 @@
 {
     "author": "fmcgorenc",
-    "name": "Mint-XP (GTK3, GTK2 and metacity included)",
-    "description": "A theme for XP fans"
+    "name": "Mint-XP",
+    "description": "A theme for XP fans. (GTK3, GTK2 and metacity included)"
 }


### PR DESCRIPTION
Makes the cinnamon settings themes dialog unnecessarily wide when you click on the download tab.