### PR TITLE
Add cornerbar styles to Adapta and Adapta-Nokto themes

### DIFF
--- a/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
@@ -1019,3 +1019,11 @@ StBin.popup-menu StBoxLayout.switcher-list .item-box > StButton:rtl, StBin.menu 
 
 StBin.popup-menu StBoxLayout.switcher-list .item-box > StBin.thumbnail, StBin.menu StBoxLayout.switcher-list .item-box > StBin.thumbnail { margin: 6px; }
 .menu-selected-app-box {}
+
+.applet-cornerbar { width: 8px; background-color: #00bdd5; }
+
+.applet-cornerbar.vertical { height: 8px; }
+
+.applet-cornerbar-box { padding: 3px 3px; }
+
+.applet-cornerbar-box:hover { background-color: #10cdff; }

--- a/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/cinnamon/cinnamon.css
@@ -1026,4 +1026,4 @@ StBin.popup-menu StBoxLayout.switcher-list .item-box > StBin.thumbnail, StBin.me
 
 .applet-cornerbar-box { padding: 3px 3px; }
 
-.applet-cornerbar-box:hover { background-color: #10cdff; }
+.applet-cornerbar-box:hover { background-color: #008d9f; }

--- a/Adapta/files/Adapta/cinnamon/cinnamon.css
+++ b/Adapta/files/Adapta/cinnamon/cinnamon.css
@@ -1019,3 +1019,11 @@ StBin.popup-menu StBoxLayout.switcher-list .item-box > StButton:rtl, StBin.menu 
 
 StBin.popup-menu StBoxLayout.switcher-list .item-box > StBin.thumbnail, StBin.menu StBoxLayout.switcher-list .item-box > StBin.thumbnail { margin: 6px; }
 .menu-selected-app-box {}
+
+.applet-cornerbar { width: 8px; background-color: #00bdd5; }
+
+.applet-cornerbar.vertical { height: 8px; }
+
+.applet-cornerbar-box { padding: 3px 3px; }
+
+.applet-cornerbar-box:hover { background-color: #008d9f; }


### PR DESCRIPTION
On Linux Mint 21.3 with Cinnamon, when the [cornerbar@cinnamon.org](https://github.com/linuxmint/cinnamon/tree/master/files/usr/share/cinnamon/applets/cornerbar%40cinnamon.org) applet is added the cornerbar is not getting displayed.

This is because the [CSS rules required for the cornerbar applet](https://github.com/linuxmint/cinnamon/blob/ca8df1fc82b8d068d72bc2b974cc1168952e4122/data/theme/cinnamon.css#L1882-L1898) are missing from the styles.

After adding the proposed styles the cornerbar looks like this:
> ![cornerbar](https://github.com/linuxmint/cinnamon-spices-themes/assets/87750369/99f1b19c-b734-48ce-881c-3957188f5898)
