### PR TITLE
Orchidea: fix expo-workspaces-name-entry being too wide

### DIFF
--- a/Orchidea/files/Orchidea/cinnamon/cinnamon.css
+++ b/Orchidea/files/Orchidea/cinnamon/cinnamon.css
@@ -1953,7 +1953,6 @@ StScrollBar StButton#vhandle:active {
   selected-color: #fff;
   caret-color: rgba(255, 255, 255, 0.85);
   caret-size: 1px;
-  width: 250px;
   height: 24px;
   text-align: center;
 }


### PR DESCRIPTION
fixes: #802

@andr35 