### PR TITLE
Adapta/Adapta-Nokto: fix CSS warnings in GTK style

### DIFF
--- a/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/README.md
@@ -63,7 +63,7 @@ For Cinnamon version 4.6.x and later the Cinnamon theme's font characteristics c
 
 For users of older Cinnamon versions the theme includes an interactive bash script that allows end users to adjust the base font-size in the Cinnamon theme. This can be useful for users running Cinnamon on relatively high resolution displays with relatively small screen dimensions where the hard-coded theme default font-sizes are too small.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta-Nokto/scripts/adapta_fontsize.sh && ~/.themes/Adapta-Nokto/scripts/adapta_fontsize.sh`
 
@@ -71,11 +71,11 @@ If you are not happy with the end result simply run `~/.themes/Adapta-Nokto/scri
 
 ## Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
 
-The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1.
 
 The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta-Nokto/scripts/adapta_toggle_menufix.sh && ~/.themes/Adapta-Nokto/scripts/adapta_toggle_menufix.sh`
 
@@ -100,6 +100,7 @@ Changes in [this fork][this_adapta]:
 * Cinnamon - fix width of some text in sound applet
 * Cinnamon - support and fixes for style changes in version 6.4
 * Cinnamon - OSD color fixes for 6.4 for regular Adapta
+* Gtk - fix generated CSS to avoid :not(.class1.class2)
 
 [cornerbar]: https://github.com/linuxmint/cinnamon-spices-themes/commit/1acded2135d31218834fb0d716d45d1866878629
 [sound_padding]: https://github.com/linuxmint/cinnamon-spices-themes/commit/e160215c3a7f5e4cec78b9eaa6d129cdba7e3968

--- a/Adapta-Nokto/files/Adapta-Nokto/README.md
+++ b/Adapta-Nokto/files/Adapta-Nokto/README.md
@@ -63,7 +63,7 @@ For Cinnamon version 4.6.x and later the Cinnamon theme's font characteristics c
 
 For users of older Cinnamon versions the theme includes an interactive bash script that allows end users to adjust the base font-size in the Cinnamon theme. This can be useful for users running Cinnamon on relatively high resolution displays with relatively small screen dimensions where the hard-coded theme default font-sizes are too small.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta-Nokto/scripts/adapta_fontsize.sh && ~/.themes/Adapta-Nokto/scripts/adapta_fontsize.sh`
 
@@ -71,11 +71,11 @@ If you are not happy with the end result simply run `~/.themes/Adapta-Nokto/scri
 
 ## Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
 
-The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1.
 
 The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta-Nokto/scripts/adapta_toggle_menufix.sh && ~/.themes/Adapta-Nokto/scripts/adapta_toggle_menufix.sh`
 
@@ -100,6 +100,7 @@ Changes in [this fork][this_adapta]:
 * Cinnamon - fix width of some text in sound applet
 * Cinnamon - support and fixes for style changes in version 6.4
 * Cinnamon - OSD color fixes for 6.4 for regular Adapta
+* Gtk - fix generated CSS to avoid :not(.class1.class2)
 
 [cornerbar]: https://github.com/linuxmint/cinnamon-spices-themes/commit/1acded2135d31218834fb0d716d45d1866878629
 [sound_padding]: https://github.com/linuxmint/cinnamon-spices-themes/commit/e160215c3a7f5e4cec78b9eaa6d129cdba7e3968

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/gtk.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-3.22/gtk.css
@@ -7453,11 +7453,11 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
   background: transparent;
 }
 
-.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .caja-canvas-item.caja-desktop, .nautilus-desktop.nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .nautilus-desktop.nemo-canvas-item, .caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
   color: #FFFFFF;
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.26), 0 1px 2px rgba(0, 0, 0, 0.26), 0 2px 3px rgba(0, 0, 0, 0.32);
 }
-.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .caja-canvas-item.caja-desktop:selected, .nautilus-desktop.nemo-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .nautilus-desktop.nemo-canvas-item:selected, .caja-desktop.caja-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
   text-shadow: none;
 }
 
@@ -7467,11 +7467,16 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
 .background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook {
   box-shadow: inset 0 1px rgb(40.55, 53.15, 59.45);
 }
-.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop):not(.caja-desktop.caja-canvas-item):not(.nemo-desktop.nemo-canvas-item) {
+.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop) {
   background-image: none;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
+  border-radius: 2px;
+  outline-width: 0;
+}
+
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
   outline-width: 0;
 }
@@ -7561,7 +7566,7 @@ dialog.background.csd > box.dialog-vbox > grid.horizontal > scrolledwindow.frame
   margin: -1px;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
 }
 .nautilus-canvas-item.dim-label, .dim-label.caja-canvas-item, .dim-label.nemo-canvas-item {

--- a/Adapta-Nokto/files/Adapta-Nokto/gtk-4.0/gtk.css
+++ b/Adapta-Nokto/files/Adapta-Nokto/gtk-4.0/gtk.css
@@ -7458,11 +7458,11 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
   background: transparent;
 }
 
-.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .caja-canvas-item.caja-desktop, .nautilus-desktop.nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .nautilus-desktop.nemo-canvas-item, .caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
   color: #FFFFFF;
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.26), 0 1px 2px rgba(0, 0, 0, 0.26), 0 2px 3px rgba(0, 0, 0, 0.32);
 }
-.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .caja-canvas-item.caja-desktop:selected, .nautilus-desktop.nemo-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .nautilus-desktop.nemo-canvas-item:selected, .caja-desktop.caja-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
   text-shadow: none;
 }
 
@@ -7472,7 +7472,7 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
 .background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook {
   box-shadow: inset 0 1px rgb(40.55, 53.15, 59.45);
 }
-.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > box > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop):not(.caja-desktop.caja-canvas-item):not(.nemo-desktop.nemo-canvas-item) {
+.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > box > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop) {
   background-image: none;
 }
 
@@ -7569,7 +7569,11 @@ dialog.background.csd > box.dialog-vbox > grid.horizontal > scrolledwindow.frame
   margin: -1px;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
+  border-radius: 2px;
+}
+
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
 }
 .nautilus-canvas-item.dim-label, .dim-label.caja-canvas-item, .dim-label.nemo-canvas-item {

--- a/Adapta/README.md
+++ b/Adapta/README.md
@@ -63,7 +63,7 @@ For Cinnamon version 4.6.x and later the Cinnamon theme's font characteristics c
 
 For users of older Cinnamon versions the theme includes an interactive bash script that allows end users to adjust the base font-size in the Cinnamon theme. This can be useful for users running Cinnamon on relatively high resolution displays with relatively small screen dimensions where the hard-coded theme default font-sizes are too small.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta/scripts/adapta_fontsize.sh && ~/.themes/Adapta/scripts/adapta_fontsize.sh`
 
@@ -71,11 +71,11 @@ If you are not happy with the end result simply run `~/.themes/Adapta/scripts/ad
 
 ## Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
 
-The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1.
 
 The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta/scripts/adapta_toggle_menufix.sh && ~/.themes/Adapta/scripts/adapta_toggle_menufix.sh`
 
@@ -100,6 +100,7 @@ Changes in [this fork][this_adapta]:
 * Cinnamon - fix width of some text in sound applet
 * Cinnamon - support and fixes for style changes in version 6.4
 * Cinnamon - OSD color fixes for 6.4 for regular Adapta
+* Gtk - fix generated CSS to avoid :not(.class1.class2)
 
 [cornerbar]: https://github.com/linuxmint/cinnamon-spices-themes/commit/1acded2135d31218834fb0d716d45d1866878629
 [sound_padding]: https://github.com/linuxmint/cinnamon-spices-themes/commit/e160215c3a7f5e4cec78b9eaa6d129cdba7e3968

--- a/Adapta/files/Adapta/README.md
+++ b/Adapta/files/Adapta/README.md
@@ -63,7 +63,7 @@ For Cinnamon version 4.6.x and later the Cinnamon theme's font characteristics c
 
 For users of older Cinnamon versions the theme includes an interactive bash script that allows end users to adjust the base font-size in the Cinnamon theme. This can be useful for users running Cinnamon on relatively high resolution displays with relatively small screen dimensions where the hard-coded theme default font-sizes are too small.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta/scripts/adapta_fontsize.sh && ~/.themes/Adapta/scripts/adapta_fontsize.sh`
 
@@ -71,11 +71,11 @@ If you are not happy with the end result simply run `~/.themes/Adapta/scripts/ad
 
 ## Cinnamon Stock Menu applet in Cinnamon 4.4.x and older
 
-The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1. 
+The app description area at the bottom of the stock cinnamon menu applet may not expand appropriately to fit the content in Cinnamon 4.4.x and older when text scaling factor is set > 1.
 
 The theme includes an interactive bash script that allows end users toggle an adjustment of the cinnamon.css to mitigate this behaviour.
 
-To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it. 
+To access the tool open a terminal window (Ctrl-Alt-T) and use the following command to make the script executable and launch it.
 
 `chmod +x ~/.themes/Adapta/scripts/adapta_toggle_menufix.sh && ~/.themes/Adapta/scripts/adapta_toggle_menufix.sh`
 
@@ -100,6 +100,7 @@ Changes in [this fork][this_adapta]:
 * Cinnamon - fix width of some text in sound applet
 * Cinnamon - support and fixes for style changes in version 6.4
 * Cinnamon - OSD color fixes for 6.4 for regular Adapta
+* Gtk - fix generated CSS to avoid :not(.class1.class2)
 
 [cornerbar]: https://github.com/linuxmint/cinnamon-spices-themes/commit/1acded2135d31218834fb0d716d45d1866878629
 [sound_padding]: https://github.com/linuxmint/cinnamon-spices-themes/commit/e160215c3a7f5e4cec78b9eaa6d129cdba7e3968

--- a/Adapta/files/Adapta/gtk-3.22/gtk.css
+++ b/Adapta/files/Adapta/gtk-3.22/gtk.css
@@ -7453,11 +7453,11 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
   background: transparent;
 }
 
-.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .caja-canvas-item.caja-desktop, .nautilus-desktop.nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .nautilus-desktop.nemo-canvas-item, .caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
   color: #FFFFFF;
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.26), 0 1px 2px rgba(0, 0, 0, 0.26), 0 2px 3px rgba(0, 0, 0, 0.32);
 }
-.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .caja-canvas-item.caja-desktop:selected, .nautilus-desktop.nemo-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .nautilus-desktop.nemo-canvas-item:selected, .caja-desktop.caja-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
   text-shadow: none;
 }
 
@@ -7467,11 +7467,16 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
 .background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook {
   box-shadow: inset 0 1px #FFFFFF;
 }
-.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop):not(.caja-desktop.caja-canvas-item):not(.nemo-desktop.nemo-canvas-item) {
+.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop) {
   background-image: none;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
+  border-radius: 2px;
+  outline-width: 0;
+}
+
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
   outline-width: 0;
 }
@@ -7561,7 +7566,7 @@ dialog.background.csd > box.dialog-vbox > grid.horizontal > scrolledwindow.frame
   margin: -1px;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
 }
 .nautilus-canvas-item.dim-label, .dim-label.caja-canvas-item, .dim-label.nemo-canvas-item {

--- a/Adapta/files/Adapta/gtk-4.0/gtk.css
+++ b/Adapta/files/Adapta/gtk-4.0/gtk.css
@@ -7458,11 +7458,11 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
   background: transparent;
 }
 
-.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .caja-canvas-item.caja-desktop, .nautilus-desktop.nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nautilus-desktop.nautilus-canvas-item, .nautilus-desktop.caja-canvas-item, .nautilus-desktop.nemo-canvas-item, .caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
   color: #FFFFFF;
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.26), 0 1px 2px rgba(0, 0, 0, 0.26), 0 2px 3px rgba(0, 0, 0, 0.32);
 }
-.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .caja-canvas-item.caja-desktop:selected, .nautilus-desktop.nemo-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+.nautilus-desktop.nautilus-canvas-item:selected, .nautilus-desktop.caja-canvas-item:selected, .nautilus-desktop.nemo-canvas-item:selected, .caja-desktop.caja-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
   text-shadow: none;
 }
 
@@ -7472,7 +7472,7 @@ dialog.background.csd > box.dialog-vbox.vertical > searchbar + scrolledwindow > 
 .background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook {
   box-shadow: inset 0 1px #FFFFFF;
 }
-.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > box > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop):not(.caja-desktop.caja-canvas-item):not(.nemo-desktop.nemo-canvas-item) {
+.background.nautilus-window:not(.nautilus-desktop-window):not(nautilus-desktop-window) > grid > paned > overlay > notebook > box > stack > box.vertical > grid > overlay > scrolledwindow > .view:not(.nautilus-desktop) {
   background-image: none;
 }
 
@@ -7569,7 +7569,11 @@ dialog.background.csd > box.dialog-vbox > grid.horizontal > scrolledwindow.frame
   margin: -1px;
 }
 
-.nautilus-canvas-item, .caja-desktop.caja-canvas-item, .caja-canvas-item, .nemo-canvas-item, .nemo-desktop.nemo-canvas-item {
+.caja-desktop.caja-canvas-item, .nemo-desktop.nemo-canvas-item {
+  border-radius: 2px;
+}
+
+.nautilus-canvas-item, .caja-canvas-item, .nemo-canvas-item {
   border-radius: 2px;
 }
 .nautilus-canvas-item.dim-label, .dim-label.caja-canvas-item, .dim-label.nemo-canvas-item {


### PR DESCRIPTION
Fixes #872 

Some SCSS `@extend` generated code like this: `:not(.nemo-desktop.nemo-canvas-item)` which gtk doesn't know to how to parse. Avoid it in the generated CSS.

`Theme parsing error: gtk.css:7470:228: Missing closing bracket for :not()`