### PR TITLE
Change destructive action button color and clean up comment

### DIFF
--- a/Mint-X-Dark/files/Mint-X-Dark/cinnamon/cinnamon.css
+++ b/Mint-X-Dark/files/Mint-X-Dark/cinnamon/cinnamon.css
@@ -1118,7 +1118,7 @@ StScrollView.hfade {
 }
 
 .dialog-button:destructive-action {
-    color: #c21616;
+    color: #fc1818;
 }
 
 .dialog-list .dialog-list-title {
@@ -2383,7 +2383,7 @@ StScrollView.hfade {
 
 
 /* ==================================================================================================
- * Cinnamon 6.4 adjustments (Not commited yet, see https://github.com/linuxmint/mint-themes/pull/487)
+ * Cinnamon 6.4 adjustments
  * ==================================================================================================*/
  
  .menu.menu-top {
@@ -2438,7 +2438,7 @@ StScrollView.hfade {
 }
 
 .dialog-button:destructive-action {
-    color: #c21616;
+    color: #fc1818;
 }
 
 .dialog-list .dialog-list-title {


### PR DESCRIPTION
Updated destructive action button color for better visibility and removed outdated comment about Cinnamon 6.4 adjustments.